### PR TITLE
feat(core): enums, per-workflow ledger files, and logging system

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,9 @@ import type { SSEEvent } from "@drej/opensandbox";
 import {
   Workflow,
   NdjsonLedger,
+  LedgerEvent,
+  ConsoleLogger,
+  LogLevel,
   type WorkflowDeps,
   type WorkflowStep,
   type WorkflowRunContext,
@@ -15,10 +18,19 @@ import {
 const BASE_URL = process.env.OPEN_SANDBOX_BASE_URL ?? "http://localhost:8080";
 const API_KEY = process.env.OPEN_SANDBOX_API_KEY!;
 const PORT = Number(process.env.PORT ?? 6000);
+const LEDGER_DIR = process.env.LEDGER_DIR ?? "./ledgers";
 
-console.log(`[config] OPEN_SANDBOX_BASE_URL=${BASE_URL}`);
-console.log(`[config] OPEN_SANDBOX_API_KEY=${API_KEY ? "(set)" : "(empty)"}`);
-console.log(`[config] PORT=${PORT}`);
+function parseLogLevel(s?: string): LogLevel {
+  switch (s?.toLowerCase()) {
+    case "debug": return LogLevel.Debug;
+    case "warn": return LogLevel.Warn;
+    case "error": return LogLevel.Error;
+    case "silent": return LogLevel.Silent;
+    default: return LogLevel.Info;
+  }
+}
+
+const logger = new ConsoleLogger(parseLogLevel(process.env.LOG_LEVEL));
 
 const control = new ControlClient({ baseUrl: BASE_URL, apiKey: API_KEY });
 
@@ -53,14 +65,22 @@ const workflowDeps: WorkflowDeps = {
       return exec as unknown as ISandboxExec;
     },
   },
-  ledger: new NdjsonLedger(process.env.LEDGER_PATH ?? "./drej.ndjson"),
+  ledger: new NdjsonLedger(LEDGER_DIR),
+  logger,
 };
 
 // ── Workflow step definitions ──────────────────────────────────────────────
 
+enum StepType {
+  CreateSandbox = "create_sandbox",
+  ExecCode = "exec_code",
+  ExecCommand = "exec_command",
+  DeleteSandbox = "delete_sandbox",
+}
+
 type StepDef =
   | {
-      type: "create_sandbox";
+      type: StepType.CreateSandbox;
       image?: { uri: string; auth?: { username: string; password: string } };
       snapshotId?: string;
       timeout?: number;
@@ -69,17 +89,17 @@ type StepDef =
       metadata?: Record<string, string>;
       resourceLimits?: { cpu?: string; memory?: string; gpu?: string };
     }
-  | { type: "exec_code"; code: string; context?: { id: string; language: string } }
-  | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string> }
-  | { type: "delete_sandbox" };
+  | { type: StepType.ExecCode; code: string; context?: { id: string; language: string } }
+  | { type: StepType.ExecCommand; command: string; cwd?: string; envs?: Record<string, string> }
+  | { type: StepType.DeleteSandbox };
 
 type WorkflowState = Record<string, unknown> & { sandboxId?: string };
 
 function buildStep(def: StepDef): WorkflowStep {
   switch (def.type) {
-    case "create_sandbox":
+    case StepType.CreateSandbox:
       return {
-        id: "create_sandbox",
+        id: StepType.CreateSandbox,
         async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
           const state = (input ?? {}) as WorkflowState;
           const sb = await ctx.control.createSandbox({
@@ -111,9 +131,9 @@ function buildStep(def: StepDef): WorkflowStep {
         },
       };
 
-    case "exec_code":
+    case StepType.ExecCode:
       return {
-        id: "exec_code",
+        id: StepType.ExecCode,
         async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
           const state = (input ?? {}) as WorkflowState;
           if (!state.sandboxId) throw new Error("exec_code requires sandboxId in workflow state");
@@ -124,7 +144,7 @@ function buildStep(def: StepDef): WorkflowStep {
               ts: Date.now(),
               workflowId: ctx.workflowId,
               stepIndex: ctx.stepIndex,
-              event: "exec_event",
+              event: LedgerEvent.ExecEvent,
               payload: ev,
             });
             events.push(ev as unknown as SSEEvent);
@@ -133,9 +153,9 @@ function buildStep(def: StepDef): WorkflowStep {
         },
       };
 
-    case "exec_command":
+    case StepType.ExecCommand:
       return {
-        id: "exec_command",
+        id: StepType.ExecCommand,
         async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
           const state = (input ?? {}) as WorkflowState;
           if (!state.sandboxId) throw new Error("exec_command requires sandboxId in workflow state");
@@ -146,7 +166,7 @@ function buildStep(def: StepDef): WorkflowStep {
               ts: Date.now(),
               workflowId: ctx.workflowId,
               stepIndex: ctx.stepIndex,
-              event: "exec_event",
+              event: LedgerEvent.ExecEvent,
               payload: ev,
             });
             events.push(ev as unknown as SSEEvent);
@@ -155,9 +175,9 @@ function buildStep(def: StepDef): WorkflowStep {
         },
       };
 
-    case "delete_sandbox":
+    case StepType.DeleteSandbox:
       return {
-        id: "delete_sandbox",
+        id: StepType.DeleteSandbox,
         async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
           const state = (input ?? {}) as WorkflowState;
           if (state.sandboxId) await ctx.control.deleteSandbox(state.sandboxId);
@@ -274,10 +294,10 @@ const ResourcesSchema = t.Object({
 
 const StepSchema = t.Object({
   type: t.Union([
-    t.Literal("create_sandbox"),
-    t.Literal("exec_code"),
-    t.Literal("exec_command"),
-    t.Literal("delete_sandbox"),
+    t.Literal(StepType.CreateSandbox),
+    t.Literal(StepType.ExecCode),
+    t.Literal(StepType.ExecCommand),
+    t.Literal(StepType.DeleteSandbox),
   ]),
   // create_sandbox
   image: t.Optional(ImageSpecSchema),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,8 +11,12 @@ export type {
   IExecClientFactory,
 } from "./types";
 
+export { LedgerEvent } from "./ledger";
 export type { LedgerEntry, ILedger } from "./ledger";
 export { MemoryLedger, NdjsonLedger } from "./ledger";
+
+export { LogLevel, ConsoleLogger, noopLogger } from "./logger";
+export type { ILogger } from "./logger";
 
 export type {
   WorkflowRunContext,

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1,16 +1,19 @@
+export enum LedgerEvent {
+  StepStart = "step_start",
+  StepComplete = "step_complete",
+  StepFailed = "step_failed",
+  StepRolledBack = "step_rolled_back",
+  WorkflowComplete = "workflow_complete",
+  WorkflowFailed = "workflow_failed",
+  Checkpoint = "checkpoint",
+  ExecEvent = "exec_event",
+}
+
 export interface LedgerEntry {
   ts: number;
   workflowId: string;
   stepIndex: number;
-  event:
-    | "step_start"
-    | "step_complete"
-    | "step_failed"
-    | "step_rolled_back"
-    | "workflow_complete"
-    | "workflow_failed"
-    | "checkpoint"
-    | "exec_event";
+  event: LedgerEvent;
   payload?: unknown;
   error?: string;
 }
@@ -35,42 +38,44 @@ export class MemoryLedger implements ILedger {
   async lastCheckpoint(workflowId: string): Promise<LedgerEntry | null> {
     const all = await this.readAll(workflowId);
     for (let i = all.length - 1; i >= 0; i--) {
-      if (all[i].event === "checkpoint") return all[i];
+      if (all[i].event === LedgerEvent.Checkpoint) return all[i];
     }
     return null;
   }
 }
 
+// Each workflow gets its own <dir>/<workflowId>.ndjson file.
+// Bun.write creates parent directories automatically on first write.
 export class NdjsonLedger implements ILedger {
-  constructor(private readonly filePath: string) {}
+  constructor(private readonly dir: string) {}
+
+  private filePath(workflowId: string): string {
+    return `${this.dir}/${workflowId}.ndjson`;
+  }
 
   async append(entry: LedgerEntry): Promise<void> {
-    const line = JSON.stringify(entry) + "\n";
-    const existing = await Bun.file(this.filePath).text().catch(() => "");
-    await Bun.write(this.filePath, existing + line);
+    const path = this.filePath(entry.workflowId);
+    const existing = await Bun.file(path).text().catch(() => "");
+    await Bun.write(path, existing + JSON.stringify(entry) + "\n");
   }
 
   async readAll(workflowId: string): Promise<LedgerEntry[]> {
-    return (await this.parseAll()).filter((e) => e.workflowId === workflowId);
+    try {
+      const text = await Bun.file(this.filePath(workflowId)).text();
+      return text
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as LedgerEntry);
+    } catch {
+      return [];
+    }
   }
 
   async lastCheckpoint(workflowId: string): Promise<LedgerEntry | null> {
     const all = await this.readAll(workflowId);
     for (let i = all.length - 1; i >= 0; i--) {
-      if (all[i].event === "checkpoint") return all[i];
+      if (all[i].event === LedgerEvent.Checkpoint) return all[i];
     }
     return null;
-  }
-
-  private async parseAll(): Promise<LedgerEntry[]> {
-    try {
-      const text = await Bun.file(this.filePath).text();
-      return text
-        .split("\n")
-        .filter((line: string) => line.length > 0)
-        .map((line: string) => JSON.parse(line) as LedgerEntry);
-    } catch {
-      return [];
-    }
   }
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,37 @@
+export enum LogLevel {
+  Debug = 0,
+  Info = 1,
+  Warn = 2,
+  Error = 3,
+  Silent = 4,
+}
+
+export interface ILogger {
+  debug(msg: string, meta?: Record<string, unknown>): void;
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export class ConsoleLogger implements ILogger {
+  constructor(private readonly minLevel: LogLevel = LogLevel.Info) {}
+
+  private log(level: LogLevel, prefix: string, msg: string, meta?: Record<string, unknown>): void {
+    if (level < this.minLevel) return;
+    const out = meta ? `${prefix} ${msg} ${JSON.stringify(meta)}` : `${prefix} ${msg}`;
+    if (level >= LogLevel.Error) console.error(out);
+    else console.log(out);
+  }
+
+  debug(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Debug, "[DEBUG]", msg, meta); }
+  info(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Info, "[INFO]", msg, meta); }
+  warn(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Warn, "[WARN]", msg, meta); }
+  error(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Error, "[ERROR]", msg, meta); }
+}
+
+export const noopLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -1,5 +1,8 @@
 import type { ILedger, LedgerEntry } from "./ledger";
+import { LedgerEvent } from "./ledger";
 import type { ISandboxControl, IExecClientFactory } from "./types";
+import type { ILogger } from "./logger";
+import { noopLogger } from "./logger";
 
 export interface WorkflowRunContext {
   readonly workflowId: string;
@@ -28,12 +31,14 @@ export interface WorkflowDeps {
   control: ISandboxControl;
   execFactory: IExecClientFactory;
   ledger: ILedger;
+  logger?: ILogger;
 }
 
 export class Workflow {
   readonly id: string;
   private _status: WorkflowStatus = "idle";
   private readonly completedSteps = new Map<number, { output: unknown; completedAt: number }>();
+  private readonly log: ILogger;
 
   get status(): WorkflowStatus {
     return this._status;
@@ -45,10 +50,13 @@ export class Workflow {
     private readonly deps: WorkflowDeps,
   ) {
     this.id = id;
+    this.log = deps.logger ?? noopLogger;
   }
 
   async run(input: unknown, startFromStep = 0): Promise<unknown> {
     this._status = "running";
+    this.log.info("workflow started", { workflowId: this.id, startFromStep, totalSteps: this.steps.length });
+
     let current: unknown =
       startFromStep > 0 ? (this.completedSteps.get(startFromStep - 1)?.output ?? input) : input;
 
@@ -56,36 +64,39 @@ export class Workflow {
       const step = this.steps[i];
       const ctx = this.makeContext(i);
 
-      await ctx.emit({ ts: Date.now(), workflowId: this.id, stepIndex: i, event: "step_start" });
+      this.log.debug("step starting", { workflowId: this.id, stepIndex: i, stepId: step.id });
+      await ctx.emit({ ts: Date.now(), workflowId: this.id, stepIndex: i, event: LedgerEvent.StepStart });
 
       try {
         const output = await step.run(current, ctx);
         this.completedSteps.set(i, { output, completedAt: Date.now() });
         current = output;
 
+        this.log.debug("step complete", { workflowId: this.id, stepIndex: i, stepId: step.id });
         await ctx.emit({
           ts: Date.now(),
           workflowId: this.id,
           stepIndex: i,
-          event: "step_complete",
+          event: LedgerEvent.StepComplete,
           payload: output,
         });
 
-        // Checkpoint written to ledger after every completed step for time-travel resumption
+        // Checkpoint written after every completed step for resumption
         await this.deps.ledger.append({
           ts: Date.now(),
           workflowId: this.id,
           stepIndex: i + 1,
-          event: "checkpoint",
+          event: LedgerEvent.Checkpoint,
           payload: this.snapshot(),
         });
       } catch (err) {
         this._status = "failed";
+        this.log.error("step failed", { workflowId: this.id, stepIndex: i, stepId: step.id, error: String(err) });
         await ctx.emit({
           ts: Date.now(),
           workflowId: this.id,
           stepIndex: i,
-          event: "step_failed",
+          event: LedgerEvent.StepFailed,
           error: String(err),
         });
         throw err;
@@ -93,17 +104,19 @@ export class Workflow {
     }
 
     this._status = "completed";
+    this.log.info("workflow complete", { workflowId: this.id });
     await this.deps.ledger.append({
       ts: Date.now(),
       workflowId: this.id,
       stepIndex: -1,
-      event: "workflow_complete",
+      event: LedgerEvent.WorkflowComplete,
     });
     return current;
   }
 
   // Saga-style rollback: undoes completed steps in reverse order
   async rollback(toStep = 0): Promise<void> {
+    this.log.info("rolling back workflow", { workflowId: this.id });
     const stepsToUndo = [...this.completedSteps.entries()]
       .filter(([i]) => i >= toStep)
       .sort(([a], [b]) => b - a);
@@ -112,23 +125,25 @@ export class Workflow {
       const step = this.steps[i];
       if (step.rollback) {
         const ctx = this.makeContext(i);
+        this.log.debug("rolling back step", { workflowId: this.id, stepIndex: i, stepId: step.id });
         await step.rollback(result.output, ctx);
         await ctx.emit({
           ts: Date.now(),
           workflowId: this.id,
           stepIndex: i,
-          event: "step_rolled_back",
+          event: LedgerEvent.StepRolledBack,
         });
         this.completedSteps.delete(i);
       }
     }
 
     this._status = "rolled_back";
+    this.log.info("workflow rolled back", { workflowId: this.id });
     await this.deps.ledger.append({
       ts: Date.now(),
       workflowId: this.id,
       stepIndex: -1,
-      event: "workflow_failed",
+      event: LedgerEvent.WorkflowFailed,
       error: "rolled_back",
     });
   }
@@ -157,6 +172,7 @@ export class Workflow {
         wf.completedSteps.set(Number(idx), result as { output: unknown; completedAt: number });
       }
       const lastOutput = cp.completedSteps[cp.stepIndex - 1]?.output ?? {};
+      deps.logger?.info("resuming workflow from checkpoint", { workflowId, nextStep: cp.stepIndex });
       return { workflow: wf, nextStep: cp.stepIndex, lastOutput };
     }
 


### PR DESCRIPTION
- Add LedgerEvent enum replacing string literals in LedgerEntry.event
- Add StepType enum in apps/api replacing create_sandbox/exec_code/etc strings
- Add LogLevel enum, ILogger interface, ConsoleLogger, and noopLogger in packages/core
- Thread logger through WorkflowDeps; Workflow emits structured logs at debug/info/error
- NdjsonLedger now writes per-workflow files (<dir>/<workflowId>.ndjson) instead of a single shared file; eliminates workflowId-filter scans on read
- API reads LOG_LEVEL env var (debug/info/warn/error/silent, default: info) and LEDGER_DIR (default: ./ledgers)