### PR TITLE
feat(core): retry, conditional, loop, parallel step types + multiline…

### DIFF
--- a/.changeset/workflow-control-flow.md
+++ b/.changeset/workflow-control-flow.md
@@ -1,0 +1,13 @@
+---
+"drej": minor
+---
+
+Add retry, conditional, loop, and parallel step types to the workflow engine.
+
+- `retry` — retries a child step up to N times with fixed or exponential backoff
+- `conditional` — branches on a structured predicate (`eq`, `neq`, `gt`, `lt`, `exists`, `and`, `or`) evaluated against workflow state
+- `loop` — iterates over a static `items` array or a dot-path `over` pointing to an array in state; supports `concurrently` flag for parallel iterations
+- `parallel` — fans out multiple steps with `Promise.all`; emits events with a `branch` index for demuxing
+- `{{key}}` interpolation in `exec_command` so loop items and other state values can be referenced in command strings
+- `branch` field added to `WorkflowEvent` to identify parallel branch origin
+- `Predicate` type exported from the SDK for use with `conditional` steps

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 *.local
 *.ndjson
+plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,12 @@ mode = "direct"
 mode = "dns"
 ```
 
+## SDK focus
+
+We are currently focused exclusively on making the **TypeScript SDK** (`packages/sdks/typescript`) full-featured and production-ready. Python SDK is maintained but not the priority. Do not add new features to the Python SDK unless explicitly asked.
+
 ## Releases
 
 The TypeScript SDK (`packages/sdks/typescript`) is published to npm via changesets. Every PR that changes publishable packages needs a changeset (`bunx changeset`). CI enforces this. Releases are cut automatically via `changesets/action` on merge to `main`.
+
+> **Changeset must be committed** before CI will pass — `bunx changeset status --since origin/main` reads from git history, not disk.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -76,7 +76,17 @@ enum StepType {
   ExecCode = "exec_code",
   ExecCommand = "exec_command",
   DeleteSandbox = "delete_sandbox",
+  Retry = "retry",
+  Conditional = "conditional",
+  Loop = "loop",
+  Parallel = "parallel",
 }
+
+type Predicate =
+  | { op: "eq" | "neq"; field: string; value: unknown }
+  | { op: "gt" | "lt" | "gte" | "lte"; field: string; value: number }
+  | { op: "exists" | "not_exists"; field: string }
+  | { op: "and" | "or"; predicates: Predicate[] };
 
 type StepDef =
   | {
@@ -91,9 +101,45 @@ type StepDef =
     }
   | { type: StepType.ExecCode; code: string; context?: { id: string; language: string } }
   | { type: StepType.ExecCommand; command: string; cwd?: string; envs?: Record<string, string> }
-  | { type: StepType.DeleteSandbox };
+  | { type: StepType.DeleteSandbox }
+  | { type: StepType.Retry; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
+  | { type: StepType.Conditional; condition: Predicate; then: StepDef[]; else?: StepDef[] }
+  | { type: StepType.Loop; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
+  | { type: StepType.Parallel; steps: StepDef[] };
 
 type WorkflowState = Record<string, unknown> & { sandboxId?: string };
+
+// Resolves a dot-path into a plain object, e.g. "status.exitCode" → obj.status.exitCode
+function getPath(obj: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((cur, key) => {
+    if (cur === null || cur === undefined || typeof cur !== "object") return undefined;
+    return (cur as Record<string, unknown>)[key];
+  }, obj);
+}
+
+// Replaces {{key}} placeholders in a string with values from WorkflowState.
+// Enables loop items and other state values to be referenced in exec_command strings.
+function interpolate(template: string, state: WorkflowState): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+    const val = state[key as keyof WorkflowState];
+    return val !== undefined ? String(val) : `{{${key}}}`;
+  });
+}
+
+function evaluate(predicate: Predicate, state: unknown): boolean {
+  switch (predicate.op) {
+    case "eq":  return getPath(state, predicate.field) === predicate.value;
+    case "neq": return getPath(state, predicate.field) !== predicate.value;
+    case "gt":  return Number(getPath(state, predicate.field)) > predicate.value;
+    case "lt":  return Number(getPath(state, predicate.field)) < predicate.value;
+    case "gte": return Number(getPath(state, predicate.field)) >= predicate.value;
+    case "lte": return Number(getPath(state, predicate.field)) <= predicate.value;
+    case "exists":     return getPath(state, predicate.field) !== undefined;
+    case "not_exists": return getPath(state, predicate.field) === undefined;
+    case "and": return predicate.predicates.every((p) => evaluate(p, state));
+    case "or":  return predicate.predicates.some((p) => evaluate(p, state));
+  }
+}
 
 function buildStep(def: StepDef): WorkflowStep {
   switch (def.type) {
@@ -160,8 +206,15 @@ function buildStep(def: StepDef): WorkflowStep {
           const state = (input ?? {}) as WorkflowState;
           if (!state.sandboxId) throw new Error("exec_command requires sandboxId in workflow state");
           const exec = await ctx.execFactory.forSandbox(state.sandboxId);
+          // Interpolate {{key}} placeholders from state (useful inside loop iterations).
+          const raw = interpolate(def.command, state);
+          // Multiline commands lose their newlines through the JSON serialization boundary.
+          // Base64-encode them so the container receives the script verbatim.
+          const command = raw.includes("\n")
+            ? `echo ${Buffer.from(raw).toString("base64")} | base64 -d | bash`
+            : raw;
           const events: SSEEvent[] = [];
-          for await (const ev of exec.executeCommand({ command: def.command, cwd: def.cwd, envs: def.envs })) {
+          for await (const ev of exec.executeCommand({ command, cwd: def.cwd, envs: def.envs })) {
             await ctx.emit({
               ts: Date.now(),
               workflowId: ctx.workflowId,
@@ -184,6 +237,105 @@ function buildStep(def: StepDef): WorkflowStep {
           return { ...state, sandboxId: undefined };
         },
       };
+
+    case StepType.Retry: {
+      const child = buildStep(def.step);
+      return {
+        id: StepType.Retry,
+        rollback: child.rollback,
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          let lastErr: unknown;
+          for (let attempt = 0; attempt < def.maxAttempts; attempt++) {
+            try {
+              return await child.run(input, ctx);
+            } catch (err) {
+              lastErr = err;
+              if (attempt < def.maxAttempts - 1) {
+                const base = def.delayMs ?? 500;
+                const delay = def.backoff === "exponential" ? base * Math.pow(2, attempt) : base;
+                await ctx.emit({
+                  ts: Date.now(), workflowId: ctx.workflowId, stepIndex: ctx.stepIndex,
+                  event: LedgerEvent.ExecEvent,
+                  payload: { type: "retry_attempt", attempt: attempt + 1, maxAttempts: def.maxAttempts, error: String(err) },
+                });
+                await new Promise<void>((r) => setTimeout(r, delay));
+              }
+            }
+          }
+          throw lastErr;
+        },
+      };
+    }
+
+    case StepType.Conditional: {
+      const thenSteps = def.then.map(buildStep);
+      const elseSteps = (def.else ?? []).map(buildStep);
+      return {
+        id: StepType.Conditional,
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          const branch = evaluate(def.condition, input) ? thenSteps : elseSteps;
+          let current = input;
+          for (const step of branch) {
+            current = await step.run(current, ctx);
+          }
+          return current;
+        },
+      };
+    }
+
+    case StepType.Loop: {
+      return {
+        id: StepType.Loop,
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          const arr = def.items ?? (def.over ? getPath(input, def.over) : undefined);
+          if (!Array.isArray(arr)) throw new Error(`loop: must provide either "items" or "over" pointing to an array in workflow state`);
+
+          const runIteration = async (item: unknown, index: number): Promise<unknown> => {
+            const iterState = { ...(input as WorkflowState), [def.as]: item, loopIndex: index };
+            let current: unknown = iterState;
+            for (const step of def.steps.map(buildStep)) {
+              current = await step.run(current, ctx);
+            }
+            return current;
+          };
+
+          const loopResults = def.concurrently
+            ? await Promise.all(arr.map((item, i) => runIteration(item, i)))
+            : await arr.reduce<Promise<unknown[]>>(async (accP, item, i) => {
+                const acc = await accP;
+                acc.push(await runIteration(item, i));
+                return acc;
+              }, Promise.resolve([]));
+
+          return { ...(input as WorkflowState), loopResults };
+        },
+      };
+    }
+
+    case StepType.Parallel: {
+      return {
+        id: StepType.Parallel,
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          const results = await Promise.all(
+            def.steps.map((stepDef, branchIndex) => {
+              const branchCtx: WorkflowRunContext = {
+                ...ctx,
+                stepIndex: ctx.stepIndex * 1000 + branchIndex,
+                emit: (entry) => ctx.emit({ ...entry, branch: branchIndex }),
+              };
+              return buildStep(stepDef).run(input, branchCtx);
+            }),
+          );
+
+          const merged = results.reduce<WorkflowState>(
+            (acc, result) => ({ ...acc, ...(result as WorkflowState) }),
+            input as WorkflowState,
+          );
+
+          return { ...merged, parallelResults: results };
+        },
+      };
+    }
   }
 }
 
@@ -292,30 +444,60 @@ const ResourcesSchema = t.Object({
   gpu: t.Optional(t.String()),
 });
 
-const StepSchema = t.Object({
-  type: t.Union([
-    t.Literal(StepType.CreateSandbox),
-    t.Literal(StepType.ExecCode),
-    t.Literal(StepType.ExecCommand),
-    t.Literal(StepType.DeleteSandbox),
+const PredicateSchema = t.Recursive((Self) =>
+  t.Union([
+    t.Object({ op: t.Union([t.Literal("eq"), t.Literal("neq")]), field: t.String(), value: t.Any() }),
+    t.Object({ op: t.Union([t.Literal("gt"), t.Literal("lt"), t.Literal("gte"), t.Literal("lte")]), field: t.String(), value: t.Number() }),
+    t.Object({ op: t.Union([t.Literal("exists"), t.Literal("not_exists")]), field: t.String() }),
+    t.Object({ op: t.Union([t.Literal("and"), t.Literal("or")]), predicates: t.Array(Self) }),
   ]),
-  // create_sandbox
-  image: t.Optional(ImageSpecSchema),
-  snapshotId: t.Optional(t.String()),
-  timeout: t.Optional(t.Number()),
-  entrypoint: t.Optional(t.Array(t.String())),
-  env: t.Optional(t.Record(t.String(), t.String())),
-  metadata: t.Optional(t.Record(t.String(), t.String())),
-  // exec_code
-  code: t.Optional(t.String()),
-  context: t.Optional(t.Object({ id: t.String(), language: t.String() })),
-  // exec_command
-  command: t.Optional(t.String()),
-  cwd: t.Optional(t.String()),
-  envs: t.Optional(t.Record(t.String(), t.String())),
-  // create_sandbox resource limits
-  resourceLimits: t.Optional(ResourcesSchema),
-});
+);
+
+const StepSchema = t.Recursive((Self) =>
+  t.Object({
+    type: t.Union([
+      t.Literal(StepType.CreateSandbox),
+      t.Literal(StepType.ExecCode),
+      t.Literal(StepType.ExecCommand),
+      t.Literal(StepType.DeleteSandbox),
+      t.Literal(StepType.Retry),
+      t.Literal(StepType.Conditional),
+      t.Literal(StepType.Loop),
+      t.Literal(StepType.Parallel),
+    ]),
+    // create_sandbox
+    image: t.Optional(ImageSpecSchema),
+    snapshotId: t.Optional(t.String()),
+    timeout: t.Optional(t.Number()),
+    entrypoint: t.Optional(t.Array(t.String())),
+    env: t.Optional(t.Record(t.String(), t.String())),
+    metadata: t.Optional(t.Record(t.String(), t.String())),
+    resourceLimits: t.Optional(ResourcesSchema),
+    // exec_code
+    code: t.Optional(t.String()),
+    context: t.Optional(t.Object({ id: t.String(), language: t.String() })),
+    // exec_command
+    command: t.Optional(t.String()),
+    cwd: t.Optional(t.String()),
+    envs: t.Optional(t.Record(t.String(), t.String())),
+    // retry
+    step: t.Optional(Self),
+    maxAttempts: t.Optional(t.Number()),
+    delayMs: t.Optional(t.Number()),
+    backoff: t.Optional(t.Union([t.Literal("fixed"), t.Literal("exponential")])),
+    // conditional
+    condition: t.Optional(PredicateSchema),
+    then: t.Optional(t.Array(Self)),
+    else: t.Optional(t.Array(Self)),
+    // loop
+    over: t.Optional(t.String()),
+    items: t.Optional(t.Array(t.Any())),
+    as: t.Optional(t.String()),
+    steps: t.Optional(t.Array(Self)),
+    concurrently: t.Optional(t.Boolean()),
+    // parallel reuses steps above
+  }),
+);
 
 // ── App ────────────────────────────────────────────────────────────────────
 

--- a/examples/control-flow.ts
+++ b/examples/control-flow.ts
@@ -1,0 +1,96 @@
+/**
+ * Demonstrates all four control-flow step types:
+ *   retry       — retries a flaky command up to N times with exponential backoff
+ *   conditional — branches based on a state value (sandboxId present or not)
+ *   loop        — writes one file per item; uses {{filename}} interpolation
+ *   parallel    — runs two independent commands concurrently
+ */
+import { DrejClient } from "../packages/sdks/typescript/src/index";
+
+const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
+const workflowId = `control-flow-${Date.now()}`;
+
+console.log(`Running workflow ${workflowId}...\n`);
+
+for await (const ev of client.runWorkflow(workflowId, [
+  // ── 1. Boot sandbox ────────────────────────────────────────────────────
+  {
+    type: "create_sandbox",
+    image: { uri: "ubuntu:22.04" },
+    entrypoint: ["tail", "-f", "/dev/null"],
+    resourceLimits: { cpu: "500m", memory: "512Mi" },
+  },
+
+  // ── 2. retry ───────────────────────────────────────────────────────────
+  // Coin flip: fails ~50% of the time. Retry handles it.
+  {
+    type: "retry",
+    maxAttempts: 5,
+    delayMs: 200,
+    backoff: "exponential",
+    step: {
+      type: "exec_command",
+      command: `
+        R=$((RANDOM % 2))
+        if [ $R -eq 0 ]; then
+          echo "[retry] tails — failing"
+          exit 1
+        fi
+        echo "[retry] heads — success after attempt"
+      `,
+    },
+  },
+
+  // ── 3. conditional ─────────────────────────────────────────────────────
+  // sandboxId is in state after create_sandbox, so the "then" branch runs.
+  {
+    type: "conditional",
+    condition: { op: "exists", field: "sandboxId" },
+    then: [
+      { type: "exec_command", command: 'echo "[conditional] then-branch: sandbox is alive"' },
+    ],
+    else: [
+      { type: "exec_command", command: 'echo "[conditional] else-branch: no sandbox"' },
+    ],
+  },
+
+  // ── 4. loop ────────────────────────────────────────────────────────────
+  // Iterates over a static list. {{filename}} and {{loopIndex}} are injected
+  // into each iteration's state and interpolated into the command string.
+  {
+    type: "loop",
+    items: ["alpha.txt", "beta.txt", "gamma.txt"],
+    as: "filename",
+    steps: [
+      {
+        type: "exec_command",
+        command: 'echo "[loop {{loopIndex}}] writing /tmp/{{filename}}" && echo "hello" > /tmp/{{filename}}',
+      },
+    ],
+  },
+
+  // ── 5. parallel ────────────────────────────────────────────────────────
+  // Both branches sleep 1s and run concurrently — total wall time ~1s, not 2s.
+  {
+    type: "parallel",
+    steps: [
+      { type: "exec_command", command: 'sleep 1 && echo "[parallel 0] done"' },
+      { type: "exec_command", command: 'sleep 1 && echo "[parallel 1] done"' },
+    ],
+  },
+
+  // ── 6. verify loop results ─────────────────────────────────────────────
+  { type: "exec_command", command: "ls /tmp/*.txt && echo '[verify] all files present'" },
+
+  // ── 7. cleanup ─────────────────────────────────────────────────────────
+  { type: "delete_sandbox" },
+])) {
+  if (ev.event === "exec_event") {
+    const e = ev.payload as { type: string; text?: string };
+    if (e.text) process.stdout.write(e.text);
+  } else {
+    const branch = ev.branch !== undefined ? ` branch=${ev.branch}` : "";
+    const extra = ev.error ? ` error=${ev.error}` : "";
+    console.log(`[${ev.event}] step=${ev.stepIndex}${branch}${extra}`);
+  }
+}

--- a/examples/run-bash-script.ts
+++ b/examples/run-bash-script.ts
@@ -1,0 +1,50 @@
+import { DrejClient } from "../packages/sdks/typescript/src/index";
+
+const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
+
+const workflowId = `bash-script-${Date.now()}`;
+
+const script = `
+#!/bin/bash
+set -euo pipefail
+
+echo "=== system info ==="
+uname -a
+echo ""
+
+echo "=== disk usage ==="
+df -h /
+echo ""
+
+echo "=== writing a file and reading it back ==="
+echo "hello from drej" > /tmp/drej-test.txt
+cat /tmp/drej-test.txt
+echo ""
+
+echo "=== done ==="
+`.trim();
+
+console.log(`Running workflow ${workflowId}...`);
+
+for await (const ev of client.runWorkflow(workflowId, [
+  {
+    type: "create_sandbox",
+    image: { uri: "ubuntu:22.04" },
+    entrypoint: ["tail", "-f", "/dev/null"],
+    resourceLimits: { cpu: "500m", memory: "512Mi" },
+  },
+  { type: "exec_command", command: script },
+  { type: "delete_sandbox" },
+])) {
+  if (ev.event === "exec_event") {
+    const e = ev.payload as { type: string; text?: string };
+    if (e.text) process.stdout.write(e.text);
+  } else {
+    const extra = ev.error
+      ? ` error=${ev.error}`
+      : ev.payload
+        ? ` payload=${JSON.stringify(ev.payload)}`
+        : "";
+    console.log(`[${ev.event}] step=${ev.stepIndex}${extra}`);
+  }
+}

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -13,6 +13,7 @@ export interface LedgerEntry {
   ts: number;
   workflowId: string;
   stepIndex: number;
+  branch?: number; // set by parallel steps to identify which concurrent branch emitted this entry
   event: LedgerEvent;
   payload?: unknown;
   error?: string;

--- a/packages/sdks/python/drej/client.py
+++ b/packages/sdks/python/drej/client.py
@@ -14,7 +14,7 @@ class DrejError(Exception):
 
 
 class DrejClient:
-    def __init__(self, base_url: str = "http://localhost:3000") -> None:
+    def __init__(self, base_url: str = "http://localhost:6000") -> None:
         self.base_url = base_url.rstrip("/")
 
     def _request(self, method: str, path: str, body: dict | None = None) -> Any:
@@ -366,3 +366,14 @@ class DrejClient:
 
     def watch_metrics(self, sandbox_id: str) -> Generator[dict, None, None]:
         return self._stream("GET", f"/v1/sandboxes/{sandbox_id}/metrics/watch")
+
+    # ── Workflows ─────────────────────────────────────────────────────────
+
+    def run_workflow(self, id: str, steps: list[dict]) -> Generator[dict, None, None]:
+        return self._stream("POST", "/v1/workflows", {"id": id, "steps": steps})
+
+    def resume_workflow(self, id: str, steps: list[dict]) -> Generator[dict, None, None]:
+        return self._stream("POST", f"/v1/workflows/{id}/resume", {"steps": steps})
+
+    def get_workflow_ledger(self, id: str) -> list[dict]:
+        return self._request("GET", f"/v1/workflows/{id}/ledger")

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -198,11 +198,18 @@ export interface WorkflowEvent {
   ts: number;
   workflowId: string;
   stepIndex: number;
+  branch?: number; // set on events emitted from parallel branches
   event: WorkflowEventKind;
   payload?: unknown;
   error?: string;
   result?: unknown;
 }
+
+export type Predicate =
+  | { op: "eq" | "neq"; field: string; value: unknown }
+  | { op: "gt" | "lt" | "gte" | "lte"; field: string; value: number }
+  | { op: "exists" | "not_exists"; field: string }
+  | { op: "and" | "or"; predicates: Predicate[] };
 
 export type StepDef =
   | {
@@ -217,7 +224,11 @@ export type StepDef =
     }
   | { type: "exec_code"; code: string; context?: { id: string; language: string } }
   | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string> }
-  | { type: "delete_sandbox" };
+  | { type: "delete_sandbox" }
+  | { type: "retry"; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
+  | { type: "conditional"; condition: Predicate; then: StepDef[]; else?: StepDef[] }
+  | { type: "loop"; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
+  | { type: "parallel"; steps: StepDef[] };
 
 // ── SSE parsers ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
… command fix

- Add retry, conditional, loop, parallel step types to the workflow engine
- Predicate DSL for conditional branching (eq/neq/gt/lt/exists/and/or)
- {{key}} interpolation in exec_command for referencing state in loop iterations
- loop step supports static `items` array or dynamic `over` dot-path into state
- parallel step fans out branches with Promise.all; branch index on LedgerEntry
- multiline exec_command auto-encodes via base64 so newlines survive serialization
- Fix Python SDK default port (3000 → 6000) and add workflow methods
- Add plans/ to .gitignore