### PR TITLE
feat(core): write_file step type and always base64-encode exec_command

### DIFF
--- a/.changeset/write-file-step.md
+++ b/.changeset/write-file-step.md
@@ -1,0 +1,8 @@
+---
+"drej": minor
+---
+
+Add `write_file` workflow step type and always base64-encode `exec_command` strings.
+
+- `write_file` step writes text or binary content to a path inside the sandbox; accepts `encoding: "utf8"` (default) or `"base64"` for binary files
+- `exec_command` now unconditionally base64-encodes the command string before sending to the container, eliminating all quoting and special-character edge cases

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -76,6 +76,7 @@ enum StepType {
   ExecCode = "exec_code",
   ExecCommand = "exec_command",
   DeleteSandbox = "delete_sandbox",
+  WriteFile = "write_file",
   Retry = "retry",
   Conditional = "conditional",
   Loop = "loop",
@@ -102,6 +103,7 @@ type StepDef =
   | { type: StepType.ExecCode; code: string; context?: { id: string; language: string } }
   | { type: StepType.ExecCommand; command: string; cwd?: string; envs?: Record<string, string> }
   | { type: StepType.DeleteSandbox }
+  | { type: StepType.WriteFile; path: string; content: string; encoding?: "utf8" | "base64" }
   | { type: StepType.Retry; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: StepType.Conditional; condition: Predicate; then: StepDef[]; else?: StepDef[] }
   | { type: StepType.Loop; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
@@ -208,11 +210,9 @@ function buildStep(def: StepDef): WorkflowStep {
           const exec = await ctx.execFactory.forSandbox(state.sandboxId);
           // Interpolate {{key}} placeholders from state (useful inside loop iterations).
           const raw = interpolate(def.command, state);
-          // Multiline commands lose their newlines through the JSON serialization boundary.
-          // Base64-encode them so the container receives the script verbatim.
-          const command = raw.includes("\n")
-            ? `echo ${Buffer.from(raw).toString("base64")} | base64 -d | bash`
-            : raw;
+          // Always base64-encode so any content (newlines, quotes, special chars)
+          // survives the JSON serialization boundary without quoting issues.
+          const command = `echo ${Buffer.from(raw).toString("base64")} | base64 -d | bash`;
           const events: SSEEvent[] = [];
           for await (const ev of exec.executeCommand({ command, cwd: def.cwd, envs: def.envs })) {
             await ctx.emit({
@@ -235,6 +235,21 @@ function buildStep(def: StepDef): WorkflowStep {
           const state = (input ?? {}) as WorkflowState;
           if (state.sandboxId) await ctx.control.deleteSandbox(state.sandboxId);
           return { ...state, sandboxId: undefined };
+        },
+      };
+
+    case StepType.WriteFile:
+      return {
+        id: StepType.WriteFile,
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          const state = (input ?? {}) as WorkflowState;
+          if (!state.sandboxId) throw new Error("write_file requires sandboxId in workflow state");
+          const exec = await ctx.execFactory.forSandbox(state.sandboxId);
+          const content: string | Uint8Array = def.encoding === "base64"
+            ? new Uint8Array(Buffer.from(def.content, "base64"))
+            : def.content;
+          await exec.uploadFile(def.path, content);
+          return state;
         },
       };
 
@@ -460,6 +475,7 @@ const StepSchema = t.Recursive((Self) =>
       t.Literal(StepType.ExecCode),
       t.Literal(StepType.ExecCommand),
       t.Literal(StepType.DeleteSandbox),
+      t.Literal(StepType.WriteFile),
       t.Literal(StepType.Retry),
       t.Literal(StepType.Conditional),
       t.Literal(StepType.Loop),
@@ -480,6 +496,10 @@ const StepSchema = t.Recursive((Self) =>
     command: t.Optional(t.String()),
     cwd: t.Optional(t.String()),
     envs: t.Optional(t.Record(t.String(), t.String())),
+    // write_file
+    path: t.Optional(t.String()),
+    content: t.Optional(t.String()),
+    encoding: t.Optional(t.Union([t.Literal("utf8"), t.Literal("base64")])),
     // retry
     step: t.Optional(Self),
     maxAttempts: t.Optional(t.Number()),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -72,6 +72,7 @@ export interface ISandboxControl {
 export interface ISandboxExec {
   executeCode(options: ExecuteCodeInput): AsyncGenerator<SSEEvent>;
   executeCommand(options: ExecuteCommandInput): AsyncGenerator<SSEEvent>;
+  uploadFile(path: string, content: string | Uint8Array): Promise<void>;
 }
 
 export interface IExecClientFactory {

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -225,6 +225,7 @@ export type StepDef =
   | { type: "exec_code"; code: string; context?: { id: string; language: string } }
   | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string> }
   | { type: "delete_sandbox" }
+  | { type: "write_file"; path: string; content: string; encoding?: "utf8" | "base64" }
   | { type: "retry"; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: "conditional"; condition: Predicate; then: StepDef[]; else?: StepDef[] }
   | { type: "loop"; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }


### PR DESCRIPTION
- Add write_file step: writes utf8 or base64-encoded content to a path in the sandbox
- Extend ISandboxExec with uploadFile so write_file can use the core port
- Always base64-encode exec_command strings; removes the newline special case so any command content safely crosses the JSON serialization boundary