### PR TITLE
feat(sdk): fluent workflow builder API

### DIFF
--- a/.changeset/sdk-workflow-builder.md
+++ b/.changeset/sdk-workflow-builder.md
@@ -1,0 +1,9 @@
+---
+"drej": minor
+---
+
+Add fluent workflow builder API to TypeScript SDK.
+
+`workflow(id)` returns a `WorkflowBuilder` with chainable `.sandbox()` and `.parallel()` methods. Inside a sandbox scope, `SandboxStepBuilder` provides `.exec()`, `.writeFile()`, `.retry()`, `.forEach()`, `.when()`, and `.parallel()`. The `forEach` callback receives `(s, item)` where `item` serialises to `{{name}}` in template literals, enabling natural JS interpolation. Top-level `.parallel()` supports multiple concurrent sandbox sessions via `WorkflowParallelBuilder`. `DrejClient.run(w)` accepts a built workflow directly. The `sandbox()` helper defaults the entrypoint to `["tail", "-f", "/dev/null"]`.
+
+Adds a server-side `sequence` step type that runs child steps sequentially, used internally by the builder to represent multi-step parallel branches.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -81,6 +81,7 @@ enum StepType {
   Conditional = "conditional",
   Loop = "loop",
   Parallel = "parallel",
+  Sequence = "sequence",
 }
 
 type Predicate =
@@ -107,7 +108,8 @@ type StepDef =
   | { type: StepType.Retry; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: StepType.Conditional; condition: Predicate; then: StepDef[]; else?: StepDef[] }
   | { type: StepType.Loop; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
-  | { type: StepType.Parallel; steps: StepDef[] };
+  | { type: StepType.Parallel; steps: StepDef[] }
+  | { type: StepType.Sequence; steps: StepDef[] };
 
 type WorkflowState = Record<string, unknown> & { sandboxId?: string };
 
@@ -351,6 +353,25 @@ function buildStep(def: StepDef): WorkflowStep {
         },
       };
     }
+
+    case StepType.Sequence: {
+      const childSteps = def.steps.map(buildStep);
+      return {
+        id: StepType.Sequence,
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          let current = input;
+          for (const step of childSteps) {
+            current = await step.run(current, ctx);
+          }
+          return current;
+        },
+        async rollback(input: unknown, ctx: WorkflowRunContext): Promise<void> {
+          for (const step of [...childSteps].reverse()) {
+            if (step.rollback) await step.rollback(input, ctx);
+          }
+        },
+      };
+    }
   }
 }
 
@@ -480,6 +501,7 @@ const StepSchema = t.Recursive((Self) =>
       t.Literal(StepType.Conditional),
       t.Literal(StepType.Loop),
       t.Literal(StepType.Parallel),
+      t.Literal(StepType.Sequence),
     ]),
     // create_sandbox
     image: t.Optional(ImageSpecSchema),

--- a/examples/control-flow.ts
+++ b/examples/control-flow.ts
@@ -1,90 +1,55 @@
 /**
- * Demonstrates all four control-flow step types:
- *   retry       — retries a flaky command up to N times with exponential backoff
- *   conditional — branches based on a state value (sandboxId present or not)
- *   loop        — writes one file per item; uses {{filename}} interpolation
- *   parallel    — runs two independent commands concurrently
+ * Demonstrates all control-flow builder methods:
+ *   retry    — retries a flaky command with exponential backoff
+ *   when     — branches on workflow state
+ *   forEach  — iterates a list; item is a real template variable
+ *   parallel — runs branches concurrently inside the same sandbox
  */
-import { DrejClient } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
 
 const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
-const workflowId = `control-flow-${Date.now()}`;
 
-console.log(`Running workflow ${workflowId}...\n`);
+const w = workflow(`control-flow-${Date.now()}`)
+  .sandbox({ image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } }, (s) =>
+    s
+      // retry: coin flip, fails ~50% of the time
+      .retry(
+        5,
+        (s) =>
+          s.exec(`
+            R=$((RANDOM % 2))
+            if [ $R -eq 0 ]; then echo "[retry] tails — failing"; exit 1; fi
+            echo "[retry] heads — success"
+          `),
+        { delayMs: 200, backoff: "exponential" },
+      )
 
-for await (const ev of client.runWorkflow(workflowId, [
-  // ── 1. Boot sandbox ────────────────────────────────────────────────────
-  {
-    type: "create_sandbox",
-    image: { uri: "ubuntu:22.04" },
-    entrypoint: ["tail", "-f", "/dev/null"],
-    resourceLimits: { cpu: "500m", memory: "512Mi" },
-  },
+      // when: sandboxId is in state after sandbox boots, so then-branch runs
+      .when(
+        { op: "exists", field: "sandboxId" },
+        (s) => s.exec('echo "[when] then-branch: sandbox is alive"'),
+        (s) => s.exec('echo "[when] else-branch: no sandbox"'),
+      )
 
-  // ── 2. retry ───────────────────────────────────────────────────────────
-  // Coin flip: fails ~50% of the time. Retry handles it.
-  {
-    type: "retry",
-    maxAttempts: 5,
-    delayMs: 200,
-    backoff: "exponential",
-    step: {
-      type: "exec_command",
-      command: `
-        R=$((RANDOM % 2))
-        if [ $R -eq 0 ]; then
-          echo "[retry] tails — failing"
-          exit 1
-        fi
-        echo "[retry] heads — success after attempt"
-      `,
-    },
-  },
+      // forEach: item is a LoopVar — use it in a template literal directly
+      .forEach(["alpha.txt", "beta.txt", "gamma.txt"], { as: "filename" }, (s, filename) =>
+        s.exec(`echo "[loop] writing /tmp/${filename}" && echo "hello" > /tmp/${filename}`),
+      )
 
-  // ── 3. conditional ─────────────────────────────────────────────────────
-  // sandboxId is in state after create_sandbox, so the "then" branch runs.
-  {
-    type: "conditional",
-    condition: { op: "exists", field: "sandboxId" },
-    then: [
-      { type: "exec_command", command: 'echo "[conditional] then-branch: sandbox is alive"' },
-    ],
-    else: [
-      { type: "exec_command", command: 'echo "[conditional] else-branch: no sandbox"' },
-    ],
-  },
+      // parallel: both branches sleep 1s concurrently — wall time ~1s not 2s
+      .parallel((p) =>
+        p
+          .branch((s) => s.exec('sleep 1 && echo "[parallel 0] done"'))
+          .branch((s) => s.exec('sleep 1 && echo "[parallel 1] done"')),
+      )
 
-  // ── 4. loop ────────────────────────────────────────────────────────────
-  // Iterates over a static list. {{filename}} and {{loopIndex}} are injected
-  // into each iteration's state and interpolated into the command string.
-  {
-    type: "loop",
-    items: ["alpha.txt", "beta.txt", "gamma.txt"],
-    as: "filename",
-    steps: [
-      {
-        type: "exec_command",
-        command: 'echo "[loop {{loopIndex}}] writing /tmp/{{filename}}" && echo "hello" > /tmp/{{filename}}',
-      },
-    ],
-  },
+      // verify loop files survived
+      .exec("ls /tmp/*.txt && echo '[verify] all files present'"),
+  );
 
-  // ── 5. parallel ────────────────────────────────────────────────────────
-  // Both branches sleep 1s and run concurrently — total wall time ~1s, not 2s.
-  {
-    type: "parallel",
-    steps: [
-      { type: "exec_command", command: 'sleep 1 && echo "[parallel 0] done"' },
-      { type: "exec_command", command: 'sleep 1 && echo "[parallel 1] done"' },
-    ],
-  },
+console.log(`Running workflow ${w.build().id}...\n`);
 
-  // ── 6. verify loop results ─────────────────────────────────────────────
-  { type: "exec_command", command: "ls /tmp/*.txt && echo '[verify] all files present'" },
-
-  // ── 7. cleanup ─────────────────────────────────────────────────────────
-  { type: "delete_sandbox" },
-])) {
+for await (const ev of client.run(w)) {
   if (ev.event === "exec_event") {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);

--- a/examples/hello-world.ts
+++ b/examples/hello-world.ts
@@ -1,21 +1,15 @@
-import { DrejClient } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
 
 const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
 
-const workflowId = `hello-world-${Date.now()}`;
+const w = workflow(`hello-world-${Date.now()}`)
+  .sandbox({ image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } }, (s) =>
+    s.exec('echo "hello world"'),
+  );
 
-console.log(`Running workflow ${workflowId}...`);
+console.log(`Running workflow ${w.build().id}...`);
 
-for await (const ev of client.runWorkflow(workflowId, [
-  {
-    type: "create_sandbox",
-    image: { uri: "ubuntu:22.04" },
-    entrypoint: ["tail", "-f", "/dev/null"],
-    resourceLimits: { cpu: "500m", memory: "512Mi" },
-  },
-  { type: "exec_command", command: 'echo "hello world"' },
-  { type: "delete_sandbox" },
-])) {
+for await (const ev of client.run(w)) {
   if (ev.event === "exec_event") {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);

--- a/examples/run-bash-script.ts
+++ b/examples/run-bash-script.ts
@@ -1,8 +1,6 @@
-import { DrejClient } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
 
 const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
-
-const workflowId = `bash-script-${Date.now()}`;
 
 const script = `
 #!/bin/bash
@@ -24,27 +22,19 @@ echo ""
 echo "=== done ==="
 `.trim();
 
-console.log(`Running workflow ${workflowId}...`);
+const w = workflow(`bash-script-${Date.now()}`)
+  .sandbox({ image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } }, (s) =>
+    s.exec(script),
+  );
 
-for await (const ev of client.runWorkflow(workflowId, [
-  {
-    type: "create_sandbox",
-    image: { uri: "ubuntu:22.04" },
-    entrypoint: ["tail", "-f", "/dev/null"],
-    resourceLimits: { cpu: "500m", memory: "512Mi" },
-  },
-  { type: "exec_command", command: script },
-  { type: "delete_sandbox" },
-])) {
+console.log(`Running workflow ${w.build().id}...`);
+
+for await (const ev of client.run(w)) {
   if (ev.event === "exec_event") {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);
   } else {
-    const extra = ev.error
-      ? ` error=${ev.error}`
-      : ev.payload
-        ? ` payload=${JSON.stringify(ev.payload)}`
-        : "";
+    const extra = ev.error ? ` error=${ev.error}` : ev.payload ? ` payload=${JSON.stringify(ev.payload)}` : "";
     console.log(`[${ev.event}] step=${ev.stepIndex}${extra}`);
   }
 }

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -229,7 +229,8 @@ export type StepDef =
   | { type: "retry"; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: "conditional"; condition: Predicate; then: StepDef[]; else?: StepDef[] }
   | { type: "loop"; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
-  | { type: "parallel"; steps: StepDef[] };
+  | { type: "parallel"; steps: StepDef[] }
+  | { type: "sequence"; steps: StepDef[] };
 
 // ── SSE parsers ────────────────────────────────────────────────────────────
 
@@ -559,6 +560,11 @@ export class DrejClient {
   }
 
   // ── Workflows ────────────────────────────────────────────────────────────
+
+  async *run(w: { build(): { id: string; steps: StepDef[] } }): AsyncGenerator<WorkflowEvent> {
+    const { id, steps } = w.build();
+    yield* this.runWorkflow(id, steps);
+  }
 
   async *runWorkflow(id: string, steps: StepDef[]): AsyncGenerator<WorkflowEvent> {
     const res = await fetch(`${this.baseUrl}/v1/workflows`, {

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -28,3 +28,6 @@ export type {
   WorkflowEventKind,
   StepDef,
 } from "./client";
+
+export { workflow, WorkflowBuilder, SandboxStepBuilder } from "./workflow";
+export type { SandboxOpts, LoopItem } from "./workflow";

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -1,0 +1,214 @@
+import type { StepDef, ImageSpec, Resources, Predicate } from "./client";
+
+// Placeholder that serialises to {{name}} inside template literals.
+// Used as the `item` parameter in forEach callbacks so users write
+// `s.exec(`upload ${item}`)` instead of `s.exec("upload {{item}}")`.
+class LoopVar {
+  constructor(private name: string) {}
+  toString() {
+    return `{{${this.name}}}`;
+  }
+}
+
+export type LoopItem = { toString(): string };
+
+export type SandboxOpts = {
+  image?: ImageSpec;
+  snapshotId?: string;
+  timeout?: number;
+  entrypoint?: string[];
+  env?: Record<string, string>;
+  metadata?: Record<string, string>;
+  resourceLimits?: Resources;
+};
+
+type ForEachOpts = {
+  concurrency?: number;
+  as?: string;
+};
+
+type ForEachSource = unknown[] | { from: string };
+type ForEachCallback = (s: SandboxStepBuilder, item: LoopItem) => SandboxStepBuilder | string;
+
+function wrapSteps(steps: StepDef[]): StepDef {
+  return steps.length === 1 ? steps[0] : { type: "sequence", steps };
+}
+
+// ── SandboxStepBuilder ────────────────────────────────────────────────────────
+
+export class SandboxStepBuilder {
+  protected _steps: StepDef[] = [];
+
+  exec(command: string, opts?: { cwd?: string; envs?: Record<string, string> }): this {
+    this._steps.push({ type: "exec_command", command, ...opts });
+    return this;
+  }
+
+  writeFile(path: string, content: string, encoding?: "utf8" | "base64"): this {
+    this._steps.push({ type: "write_file", path, content, ...(encoding ? { encoding } : {}) });
+    return this;
+  }
+
+  retry(
+    maxAttempts: number,
+    fn: (s: SandboxStepBuilder) => SandboxStepBuilder,
+    opts?: { delayMs?: number; backoff?: "fixed" | "exponential" },
+  ): this {
+    const inner = new SandboxStepBuilder();
+    fn(inner);
+    this._steps.push({ type: "retry", step: wrapSteps(inner.build()), maxAttempts, ...opts });
+    return this;
+  }
+
+  forEach(source: ForEachSource, fn: ForEachCallback): this;
+  forEach(source: ForEachSource, opts: ForEachOpts, fn: ForEachCallback): this;
+  forEach(
+    source: ForEachSource,
+    optsOrFn: ForEachOpts | ForEachCallback,
+    fn?: ForEachCallback,
+  ): this {
+    const opts: ForEachOpts = typeof optsOrFn === "function" ? {} : optsOrFn;
+    const callback: ForEachCallback = typeof optsOrFn === "function" ? optsOrFn : fn!;
+
+    const varName = opts.as ?? "item";
+    const loopVar = new LoopVar(varName);
+    const inner = new SandboxStepBuilder();
+    const result = callback(inner, loopVar);
+
+    const steps: StepDef[] =
+      typeof result === "string"
+        ? [{ type: "exec_command", command: result }]
+        : result.build();
+
+    this._steps.push({
+      type: "loop",
+      as: varName,
+      steps,
+      ...(Array.isArray(source) ? { items: source } : { over: source.from }),
+      ...(opts.concurrency !== undefined && opts.concurrency > 1 ? { concurrently: true } : {}),
+    });
+
+    return this;
+  }
+
+  when(
+    condition: Predicate,
+    thenFn: (s: SandboxStepBuilder) => SandboxStepBuilder,
+    elseFn?: (s: SandboxStepBuilder) => SandboxStepBuilder,
+  ): this {
+    const thenBuilder = new SandboxStepBuilder();
+    thenFn(thenBuilder);
+
+    const elseSteps = elseFn
+      ? (() => {
+          const b = new SandboxStepBuilder();
+          elseFn(b);
+          return b.build();
+        })()
+      : undefined;
+
+    this._steps.push({
+      type: "conditional",
+      condition,
+      then: thenBuilder.build(),
+      ...(elseSteps ? { else: elseSteps } : {}),
+    });
+
+    return this;
+  }
+
+  parallel(fn: (p: SandboxParallelBuilder) => SandboxParallelBuilder): this {
+    const pb = new SandboxParallelBuilder();
+    fn(pb);
+    this._steps.push({ type: "parallel", steps: pb.build() });
+    return this;
+  }
+
+  build(): StepDef[] {
+    return [...this._steps];
+  }
+}
+
+// ── SandboxParallelBuilder ────────────────────────────────────────────────────
+// Used inside a sandbox scope — branches share the same sandbox, no new ones.
+
+class SandboxParallelBuilder {
+  private _branches: StepDef[] = [];
+
+  branch(fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
+    const sb = new SandboxStepBuilder();
+    fn(sb);
+    this._branches.push(wrapSteps(sb.build()));
+    return this;
+  }
+
+  build(): StepDef[] {
+    return this._branches;
+  }
+}
+
+// ── WorkflowParallelBuilder ───────────────────────────────────────────────────
+// Used at the top-level workflow scope — each branch can own its own sandbox.
+
+class WorkflowParallelBuilder {
+  private _branches: StepDef[] = [];
+
+  sandbox(opts: SandboxOpts, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
+    const sb = new SandboxStepBuilder();
+    fn(sb);
+    this._branches.push({
+      type: "sequence",
+      steps: [
+        { type: "create_sandbox", entrypoint: ["tail", "-f", "/dev/null"], ...opts },
+        ...sb.build(),
+        { type: "delete_sandbox" },
+      ],
+    });
+    return this;
+  }
+
+  branch(fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
+    const sb = new SandboxStepBuilder();
+    fn(sb);
+    this._branches.push(wrapSteps(sb.build()));
+    return this;
+  }
+
+  build(): StepDef[] {
+    return this._branches;
+  }
+}
+
+// ── WorkflowBuilder ───────────────────────────────────────────────────────────
+
+export class WorkflowBuilder {
+  private _steps: StepDef[] = [];
+
+  constructor(private _id: string) {}
+
+  sandbox(opts: SandboxOpts, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
+    const sb = new SandboxStepBuilder();
+    fn(sb);
+    this._steps.push(
+      { type: "create_sandbox", entrypoint: ["tail", "-f", "/dev/null"], ...opts },
+      ...sb.build(),
+      { type: "delete_sandbox" },
+    );
+    return this;
+  }
+
+  parallel(fn: (p: WorkflowParallelBuilder) => WorkflowParallelBuilder): this {
+    const pb = new WorkflowParallelBuilder();
+    fn(pb);
+    this._steps.push({ type: "parallel", steps: pb.build() });
+    return this;
+  }
+
+  build(): { id: string; steps: StepDef[] } {
+    return { id: this._id, steps: this._steps };
+  }
+}
+
+export function workflow(id: string): WorkflowBuilder {
+  return new WorkflowBuilder(id);
+}


### PR DESCRIPTION
Adds workflow(id).sandbox(...).parallel(...) builder that composes StepDef arrays without raw JSON. forEach(items, (s, item) => ...) uses a LoopVar placeholder so template literals resolve to {{name}} at runtime. Parallel branches at the workflow level can each own a sandbox session. DrejClient.run(w) accepts the builder directly.

Adds a sequence step type server-side to enable multi-step parallel branches.