### PR TITLE
feat: per-run ledger with workflow name / run ID separation

### DIFF
--- a/.changeset/workflow-runs.md
+++ b/.changeset/workflow-runs.md
@@ -1,0 +1,20 @@
+---
+"drej": minor
+---
+
+Introduce per-run ledger with workflow name / run ID separation.
+
+Each workflow execution now has a stable **workflow name** (user-defined) and an auto-generated **run ID** (UUID). Ledger files are stored at `ledgers/<name>/<runId>.ndjson` so all runs of a workflow are grouped together.
+
+API changes:
+- `POST /v1/workflows/:name/runs` — starts a run; first SSE event is `run_started` carrying the run ID
+- `POST /v1/workflows/:name/runs/:runId/resume` — resumes a specific run
+- `GET /v1/workflows/:name/runs` — lists all run IDs for a workflow
+- `GET /v1/workflows/:name/runs/:runId/ledger` — fetches ledger for a specific run
+
+SDK changes:
+- `client.run(w)` is now `async` and returns `Promise<WorkflowRun>`; `run.id` gives the run ID, `run.name` the workflow name, and it is async-iterable for events
+- `client.resumeRun(name, runId, w)` resumes a run
+- `client.listWorkflowRuns(name)` lists runs
+- `client.getWorkflowLedger(name, runId)` fetches the ledger
+- `WorkflowEvent` fields renamed: `workflowId` → `workflowName` + `runId`

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -192,7 +192,7 @@ function buildStep(def: StepDef): WorkflowStep {
           for await (const ev of exec.executeCode({ code: def.code, context: def.context })) {
             await ctx.emit({
               ts: Date.now(),
-              workflowId: ctx.workflowId,
+              workflowName: ctx.workflowName, runId: ctx.runId,
               stepIndex: ctx.stepIndex,
               event: LedgerEvent.ExecEvent,
               payload: ev,
@@ -219,7 +219,7 @@ function buildStep(def: StepDef): WorkflowStep {
           for await (const ev of exec.executeCommand({ command, cwd: def.cwd, envs: def.envs })) {
             await ctx.emit({
               ts: Date.now(),
-              workflowId: ctx.workflowId,
+              workflowName: ctx.workflowName, runId: ctx.runId,
               stepIndex: ctx.stepIndex,
               event: LedgerEvent.ExecEvent,
               payload: ev,
@@ -271,7 +271,7 @@ function buildStep(def: StepDef): WorkflowStep {
                 const base = def.delayMs ?? 500;
                 const delay = def.backoff === "exponential" ? base * Math.pow(2, attempt) : base;
                 await ctx.emit({
-                  ts: Date.now(), workflowId: ctx.workflowId, stepIndex: ctx.stepIndex,
+                  ts: Date.now(), workflowName: ctx.workflowName, runId: ctx.runId, stepIndex: ctx.stepIndex,
                   event: LedgerEvent.ExecEvent,
                   payload: { type: "retry_attempt", attempt: attempt + 1, maxAttempts: def.maxAttempts, error: String(err) },
                 });
@@ -408,7 +408,8 @@ function sseResponse(gen: AsyncGenerator<SSEEvent>): Response {
 // Tee ledger: persists to NdjsonLedger AND streams each entry to the SSE client.
 // exec_event entries flow through here in real-time as code/commands execute.
 function workflowSseResponse(
-  workflowId: string,
+  workflowName: string,
+  runId: string,
   steps: WorkflowStep[],
   deps: WorkflowDeps,
   resumeMode: boolean,
@@ -424,11 +425,15 @@ function workflowSseResponse(
             await deps.ledger.append(entry);
             emit(entry);
           },
-          readAll: (wfId) => deps.ledger.readAll(wfId),
-          lastCheckpoint: (wfId) => deps.ledger.lastCheckpoint(wfId),
+          readAll: (name, id) => deps.ledger.readAll(name, id),
+          lastCheckpoint: (name, id) => deps.ledger.lastCheckpoint(name, id),
+          listRuns: (name) => deps.ledger.listRuns(name),
         };
 
         const teeDeps: WorkflowDeps = { ...deps, ledger: teeLedger };
+
+        // First event tells the client the auto-generated run ID
+        emit({ event: LedgerEvent.RunStarted, workflowName, runId, stepIndex: -1, ts: Date.now(), payload: { workflowName, runId } });
 
         let workflow: Workflow | undefined;
         try {
@@ -437,21 +442,21 @@ function workflowSseResponse(
 
           if (resumeMode) {
             ({ workflow, nextStep, lastOutput } = await Workflow.resumeFromLedger(
-              workflowId,
+              workflowName,
+              runId,
               steps,
               teeDeps,
             ));
           } else {
-            workflow = new Workflow(workflowId, steps, teeDeps);
+            workflow = new Workflow(workflowName, runId, steps, teeDeps);
             nextStep = 0;
             lastOutput = {};
           }
 
           await workflow.run(lastOutput, nextStep);
         } catch (err) {
-          // Saga rollback: clean up any completed steps (e.g. delete sandbox on failure)
           try { await workflow?.rollback(); } catch { /* ignore rollback errors */ }
-          emit({ event: "workflow_failed", workflowId, error: String(err), ts: Date.now(), stepIndex: -1 });
+          emit({ event: "workflow_failed", workflowName, runId, error: String(err), ts: Date.now(), stepIndex: -1 });
         } finally {
           ctrl.close();
         }
@@ -827,23 +832,23 @@ const app = new Elysia()
   // ── Workflows (microkernel engine) ─────────────────────────────────────────
 
   .post(
-    "/v1/workflows",
-    ({ body }) => {
+    "/v1/workflows/:name/runs",
+    ({ params, body }) => {
+      const runId = crypto.randomUUID();
       const steps = (body.steps as unknown as StepDef[]).map(buildStep);
-      return workflowSseResponse(body.id, steps, workflowDeps, false);
+      return workflowSseResponse(params.name, runId, steps, workflowDeps, false);
     },
     {
       body: t.Object({
-        id: t.String(),
         steps: t.Array(StepSchema),
       }),
     },
   )
   .post(
-    "/v1/workflows/:id/resume",
+    "/v1/workflows/:name/runs/:runId/resume",
     ({ params, body }) => {
       const steps = (body.steps as unknown as StepDef[]).map(buildStep);
-      return workflowSseResponse(params.id, steps, workflowDeps, true);
+      return workflowSseResponse(params.name, params.runId, steps, workflowDeps, true);
     },
     {
       body: t.Object({
@@ -851,8 +856,11 @@ const app = new Elysia()
       }),
     },
   )
-  .get("/v1/workflows/:id/ledger", ({ params }) =>
-    workflowDeps.ledger.readAll(params.id),
+  .get("/v1/workflows/:name/runs", ({ params }) =>
+    workflowDeps.ledger.listRuns(params.name).then((runs) => ({ runs })),
+  )
+  .get("/v1/workflows/:name/runs/:runId/ledger", ({ params }) =>
+    workflowDeps.ledger.readAll(params.name, params.runId),
   )
 
   .listen(PORT);

--- a/examples/control-flow.ts
+++ b/examples/control-flow.ts
@@ -2,15 +2,16 @@
  * Demonstrates all control-flow builder methods:
  *   retry    — retries a flaky command with exponential backoff
  *   when     — branches on workflow state
- *   forEach  — iterates a list; item is a real template variable
+ *   forEach  — iterates a list; item resolves via template literal
  *   parallel — runs branches concurrently inside the same sandbox
  */
 import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
 
 const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
 
-const w = workflow(`control-flow-${Date.now()}`)
-  .sandbox({ image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } }, (s) =>
+const w = workflow("control-flow").sandbox(
+  { image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } },
+  (s) =>
     s
       // retry: coin flip, fails ~50% of the time
       .retry(
@@ -31,7 +32,7 @@ const w = workflow(`control-flow-${Date.now()}`)
         (s) => s.exec('echo "[when] else-branch: no sandbox"'),
       )
 
-      // forEach: item is a LoopVar — use it in a template literal directly
+      // forEach: item is a LoopVar — use directly in a template literal
       .forEach(["alpha.txt", "beta.txt", "gamma.txt"], { as: "filename" }, (s, filename) =>
         s.exec(`echo "[loop] writing /tmp/${filename}" && echo "hello" > /tmp/${filename}`),
       )
@@ -45,11 +46,12 @@ const w = workflow(`control-flow-${Date.now()}`)
 
       // verify loop files survived
       .exec("ls /tmp/*.txt && echo '[verify] all files present'"),
-  );
+);
 
-console.log(`Running workflow ${w.build().id}...\n`);
+const run = await client.run(w);
+console.log(`Run ID: ${run.id} (workflow: ${run.name})\n`);
 
-for await (const ev of client.run(w)) {
+for await (const ev of run) {
   if (ev.event === "exec_event") {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);

--- a/examples/hello-world.ts
+++ b/examples/hello-world.ts
@@ -2,14 +2,15 @@ import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
 
 const client = new DrejClient({ baseUrl: process.env.DREJ_API_URL ?? "http://localhost:6000" });
 
-const w = workflow(`hello-world-${Date.now()}`)
-  .sandbox({ image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } }, (s) =>
-    s.exec('echo "hello world"'),
-  );
+const w = workflow("hello-world").sandbox(
+  { image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } },
+  (s) => s.exec('echo "hello world"'),
+);
 
-console.log(`Running workflow ${w.build().id}...`);
+const run = await client.run(w);
+console.log(`Run ID: ${run.id} (workflow: ${run.name})`);
 
-for await (const ev of client.run(w)) {
+for await (const ev of run) {
   if (ev.event === "exec_event") {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);

--- a/examples/run-bash-script.ts
+++ b/examples/run-bash-script.ts
@@ -22,14 +22,15 @@ echo ""
 echo "=== done ==="
 `.trim();
 
-const w = workflow(`bash-script-${Date.now()}`)
-  .sandbox({ image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } }, (s) =>
-    s.exec(script),
-  );
+const w = workflow("bash-script").sandbox(
+  { image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } },
+  (s) => s.exec(script),
+);
 
-console.log(`Running workflow ${w.build().id}...`);
+const run = await client.run(w);
+console.log(`Run ID: ${run.id} (workflow: ${run.name})`);
 
-for await (const ev of client.run(w)) {
+for await (const ev of run) {
   if (ev.event === "exec_event") {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1,4 +1,6 @@
+
 export enum LedgerEvent {
+  RunStarted = "run_started",
   StepStart = "step_start",
   StepComplete = "step_complete",
   StepFailed = "step_failed",
@@ -11,9 +13,10 @@ export enum LedgerEvent {
 
 export interface LedgerEntry {
   ts: number;
-  workflowId: string;
+  workflowName: string;
+  runId: string;
   stepIndex: number;
-  branch?: number; // set by parallel steps to identify which concurrent branch emitted this entry
+  branch?: number;
   event: LedgerEvent;
   payload?: unknown;
   error?: string;
@@ -21,8 +24,9 @@ export interface LedgerEntry {
 
 export interface ILedger {
   append(entry: LedgerEntry): Promise<void>;
-  readAll(workflowId: string): Promise<LedgerEntry[]>;
-  lastCheckpoint(workflowId: string): Promise<LedgerEntry | null>;
+  readAll(workflowName: string, runId: string): Promise<LedgerEntry[]>;
+  lastCheckpoint(workflowName: string, runId: string): Promise<LedgerEntry | null>;
+  listRuns(workflowName: string): Promise<string[]>;
 }
 
 export class MemoryLedger implements ILedger {
@@ -32,37 +36,45 @@ export class MemoryLedger implements ILedger {
     this.entries.push(entry);
   }
 
-  async readAll(workflowId: string): Promise<LedgerEntry[]> {
-    return this.entries.filter((e) => e.workflowId === workflowId);
+  async readAll(workflowName: string, runId: string): Promise<LedgerEntry[]> {
+    return this.entries.filter((e) => e.workflowName === workflowName && e.runId === runId);
   }
 
-  async lastCheckpoint(workflowId: string): Promise<LedgerEntry | null> {
-    const all = await this.readAll(workflowId);
+  async lastCheckpoint(workflowName: string, runId: string): Promise<LedgerEntry | null> {
+    const all = await this.readAll(workflowName, runId);
     for (let i = all.length - 1; i >= 0; i--) {
       if (all[i].event === LedgerEvent.Checkpoint) return all[i];
     }
     return null;
   }
+
+  async listRuns(workflowName: string): Promise<string[]> {
+    const seen = new Set<string>();
+    for (const e of this.entries) {
+      if (e.workflowName === workflowName) seen.add(e.runId);
+    }
+    return [...seen];
+  }
 }
 
-// Each workflow gets its own <dir>/<workflowId>.ndjson file.
+// Each run gets its own <dir>/<workflowName>/<runId>.ndjson file.
 // Bun.write creates parent directories automatically on first write.
 export class NdjsonLedger implements ILedger {
   constructor(private readonly dir: string) {}
 
-  private filePath(workflowId: string): string {
-    return `${this.dir}/${workflowId}.ndjson`;
+  private filePath(workflowName: string, runId: string): string {
+    return `${this.dir}/${workflowName}/${runId}.ndjson`;
   }
 
   async append(entry: LedgerEntry): Promise<void> {
-    const path = this.filePath(entry.workflowId);
+    const path = this.filePath(entry.workflowName, entry.runId);
     const existing = await Bun.file(path).text().catch(() => "");
     await Bun.write(path, existing + JSON.stringify(entry) + "\n");
   }
 
-  async readAll(workflowId: string): Promise<LedgerEntry[]> {
+  async readAll(workflowName: string, runId: string): Promise<LedgerEntry[]> {
     try {
-      const text = await Bun.file(this.filePath(workflowId)).text();
+      const text = await Bun.file(this.filePath(workflowName, runId)).text();
       return text
         .split("\n")
         .filter((line) => line.length > 0)
@@ -72,11 +84,24 @@ export class NdjsonLedger implements ILedger {
     }
   }
 
-  async lastCheckpoint(workflowId: string): Promise<LedgerEntry | null> {
-    const all = await this.readAll(workflowId);
+  async lastCheckpoint(workflowName: string, runId: string): Promise<LedgerEntry | null> {
+    const all = await this.readAll(workflowName, runId);
     for (let i = all.length - 1; i >= 0; i--) {
       if (all[i].event === LedgerEvent.Checkpoint) return all[i];
     }
     return null;
+  }
+
+  async listRuns(workflowName: string): Promise<string[]> {
+    try {
+      const glob = new Bun.Glob("*.ndjson");
+      const files: string[] = [];
+      for await (const f of glob.scan({ cwd: `${this.dir}/${workflowName}`, onlyFiles: true })) {
+        files.push(f.slice(0, -7)); // strip .ndjson
+      }
+      return files;
+    } catch {
+      return [];
+    }
   }
 }

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -5,7 +5,8 @@ import type { ILogger } from "./logger";
 import { noopLogger } from "./logger";
 
 export interface WorkflowRunContext {
-  readonly workflowId: string;
+  readonly workflowName: string;
+  readonly runId: string;
   readonly stepIndex: number;
   readonly control: ISandboxControl;
   readonly execFactory: IExecClientFactory;
@@ -19,7 +20,8 @@ export interface WorkflowStep {
 }
 
 export interface WorkflowCheckpoint {
-  workflowId: string;
+  workflowName: string;
+  runId: string;
   stepIndex: number;
   completedSteps: Record<number, { output: unknown; completedAt: number }>;
   timestamp: number;
@@ -35,7 +37,8 @@ export interface WorkflowDeps {
 }
 
 export class Workflow {
-  readonly id: string;
+  readonly name: string;
+  readonly runId: string;
   private _status: WorkflowStatus = "idle";
   private readonly completedSteps = new Map<number, { output: unknown; completedAt: number }>();
   private readonly log: ILogger;
@@ -45,17 +48,19 @@ export class Workflow {
   }
 
   constructor(
-    id: string,
+    name: string,
+    runId: string,
     private readonly steps: WorkflowStep[],
     private readonly deps: WorkflowDeps,
   ) {
-    this.id = id;
+    this.name = name;
+    this.runId = runId;
     this.log = deps.logger ?? noopLogger;
   }
 
   async run(input: unknown, startFromStep = 0): Promise<unknown> {
     this._status = "running";
-    this.log.info("workflow started", { workflowId: this.id, startFromStep, totalSteps: this.steps.length });
+    this.log.info("workflow started", { workflowName: this.name, runId: this.runId, startFromStep, totalSteps: this.steps.length });
 
     let current: unknown =
       startFromStep > 0 ? (this.completedSteps.get(startFromStep - 1)?.output ?? input) : input;
@@ -64,37 +69,39 @@ export class Workflow {
       const step = this.steps[i];
       const ctx = this.makeContext(i);
 
-      this.log.debug("step starting", { workflowId: this.id, stepIndex: i, stepId: step.id });
-      await ctx.emit({ ts: Date.now(), workflowId: this.id, stepIndex: i, event: LedgerEvent.StepStart });
+      this.log.debug("step starting", { workflowName: this.name, runId: this.runId, stepIndex: i, stepId: step.id });
+      await ctx.emit({ ts: Date.now(), workflowName: this.name, runId: this.runId, stepIndex: i, event: LedgerEvent.StepStart });
 
       try {
         const output = await step.run(current, ctx);
         this.completedSteps.set(i, { output, completedAt: Date.now() });
         current = output;
 
-        this.log.debug("step complete", { workflowId: this.id, stepIndex: i, stepId: step.id });
+        this.log.debug("step complete", { workflowName: this.name, runId: this.runId, stepIndex: i, stepId: step.id });
         await ctx.emit({
           ts: Date.now(),
-          workflowId: this.id,
+          workflowName: this.name,
+          runId: this.runId,
           stepIndex: i,
           event: LedgerEvent.StepComplete,
           payload: output,
         });
 
-        // Checkpoint written after every completed step for resumption
         await this.deps.ledger.append({
           ts: Date.now(),
-          workflowId: this.id,
+          workflowName: this.name,
+          runId: this.runId,
           stepIndex: i + 1,
           event: LedgerEvent.Checkpoint,
           payload: this.snapshot(),
         });
       } catch (err) {
         this._status = "failed";
-        this.log.error("step failed", { workflowId: this.id, stepIndex: i, stepId: step.id, error: String(err) });
+        this.log.error("step failed", { workflowName: this.name, runId: this.runId, stepIndex: i, stepId: step.id, error: String(err) });
         await ctx.emit({
           ts: Date.now(),
-          workflowId: this.id,
+          workflowName: this.name,
+          runId: this.runId,
           stepIndex: i,
           event: LedgerEvent.StepFailed,
           error: String(err),
@@ -104,19 +111,19 @@ export class Workflow {
     }
 
     this._status = "completed";
-    this.log.info("workflow complete", { workflowId: this.id });
+    this.log.info("workflow complete", { workflowName: this.name, runId: this.runId });
     await this.deps.ledger.append({
       ts: Date.now(),
-      workflowId: this.id,
+      workflowName: this.name,
+      runId: this.runId,
       stepIndex: -1,
       event: LedgerEvent.WorkflowComplete,
     });
     return current;
   }
 
-  // Saga-style rollback: undoes completed steps in reverse order
   async rollback(toStep = 0): Promise<void> {
-    this.log.info("rolling back workflow", { workflowId: this.id });
+    this.log.info("rolling back workflow", { workflowName: this.name, runId: this.runId });
     const stepsToUndo = [...this.completedSteps.entries()]
       .filter(([i]) => i >= toStep)
       .sort(([a], [b]) => b - a);
@@ -125,11 +132,12 @@ export class Workflow {
       const step = this.steps[i];
       if (step.rollback) {
         const ctx = this.makeContext(i);
-        this.log.debug("rolling back step", { workflowId: this.id, stepIndex: i, stepId: step.id });
+        this.log.debug("rolling back step", { workflowName: this.name, runId: this.runId, stepIndex: i, stepId: step.id });
         await step.rollback(result.output, ctx);
         await ctx.emit({
           ts: Date.now(),
-          workflowId: this.id,
+          workflowName: this.name,
+          runId: this.runId,
           stepIndex: i,
           event: LedgerEvent.StepRolledBack,
         });
@@ -138,10 +146,11 @@ export class Workflow {
     }
 
     this._status = "rolled_back";
-    this.log.info("workflow rolled back", { workflowId: this.id });
+    this.log.info("workflow rolled back", { workflowName: this.name, runId: this.runId });
     await this.deps.ledger.append({
       ts: Date.now(),
-      workflowId: this.id,
+      workflowName: this.name,
+      runId: this.runId,
       stepIndex: -1,
       event: LedgerEvent.WorkflowFailed,
       error: "rolled_back",
@@ -150,21 +159,22 @@ export class Workflow {
 
   snapshot(): WorkflowCheckpoint {
     return {
-      workflowId: this.id,
+      workflowName: this.name,
+      runId: this.runId,
       stepIndex: this.completedSteps.size,
       completedSteps: Object.fromEntries(this.completedSteps),
       timestamp: Date.now(),
     };
   }
 
-  // Time-travel resumption: reconstructs workflow state from the last ledger checkpoint
   static async resumeFromLedger(
-    workflowId: string,
+    workflowName: string,
+    runId: string,
     steps: WorkflowStep[],
     deps: WorkflowDeps,
   ): Promise<{ workflow: Workflow; nextStep: number; lastOutput: unknown }> {
-    const wf = new Workflow(workflowId, steps, deps);
-    const entry = await deps.ledger.lastCheckpoint(workflowId);
+    const wf = new Workflow(workflowName, runId, steps, deps);
+    const entry = await deps.ledger.lastCheckpoint(workflowName, runId);
 
     if (entry?.payload) {
       const cp = entry.payload as WorkflowCheckpoint;
@@ -172,7 +182,7 @@ export class Workflow {
         wf.completedSteps.set(Number(idx), result as { output: unknown; completedAt: number });
       }
       const lastOutput = cp.completedSteps[cp.stepIndex - 1]?.output ?? {};
-      deps.logger?.info("resuming workflow from checkpoint", { workflowId, nextStep: cp.stepIndex });
+      deps.logger?.info("resuming workflow from checkpoint", { workflowName, runId, nextStep: cp.stepIndex });
       return { workflow: wf, nextStep: cp.stepIndex, lastOutput };
     }
 
@@ -181,7 +191,8 @@ export class Workflow {
 
   private makeContext(stepIndex: number): WorkflowRunContext {
     return {
-      workflowId: this.id,
+      workflowName: this.name,
+      runId: this.runId,
       stepIndex,
       control: this.deps.control,
       execFactory: this.deps.execFactory,

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -185,6 +185,7 @@ export interface DrejClientOptions {
 // ── Workflow types ─────────────────────────────────────────────────────────
 
 export type WorkflowEventKind =
+  | "run_started"
   | "step_start"
   | "step_complete"
   | "step_failed"
@@ -196,13 +197,26 @@ export type WorkflowEventKind =
 
 export interface WorkflowEvent {
   ts: number;
-  workflowId: string;
+  workflowName: string;
+  runId: string;
   stepIndex: number;
-  branch?: number; // set on events emitted from parallel branches
+  branch?: number;
   event: WorkflowEventKind;
   payload?: unknown;
   error?: string;
   result?: unknown;
+}
+
+export class WorkflowRun implements AsyncIterable<WorkflowEvent> {
+  constructor(
+    public readonly name: string,
+    public readonly id: string,
+    private readonly _events: AsyncGenerator<WorkflowEvent>,
+  ) {}
+
+  [Symbol.asyncIterator](): AsyncIterator<WorkflowEvent> {
+    return this._events;
+  }
 }
 
 export type Predicate =
@@ -561,34 +575,65 @@ export class DrejClient {
 
   // ── Workflows ────────────────────────────────────────────────────────────
 
-  async *run(w: { build(): { id: string; steps: StepDef[] } }): AsyncGenerator<WorkflowEvent> {
-    const { id, steps } = w.build();
-    yield* this.runWorkflow(id, steps);
+  async run(w: { build(): { name: string; steps: StepDef[] } }): Promise<WorkflowRun> {
+    const { name, steps } = w.build();
+    return this._startRun(name, steps);
   }
 
-  async *runWorkflow(id: string, steps: StepDef[]): AsyncGenerator<WorkflowEvent> {
-    const res = await fetch(`${this.baseUrl}/v1/workflows`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id, steps }),
-    });
+  async resumeRun(
+    name: string,
+    runId: string,
+    w: { build(): { name: string; steps: StepDef[] } } | StepDef[],
+  ): Promise<WorkflowRun> {
+    const steps = Array.isArray(w) ? w : w.build().steps;
+    const res = await fetch(
+      `${this.baseUrl}/v1/workflows/${encodeURIComponent(name)}/runs/${encodeURIComponent(runId)}/resume`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ steps }),
+      },
+    );
     if (!res.ok) throw new DrejError("drej API error", res.status);
-    if (!res.body) return;
-    yield* parseWorkflowSSE(res.body);
+    if (!res.body) throw new DrejError("empty response body", 500);
+    return this._consumeRunStarted(name, res.body);
   }
 
-  async *resumeWorkflow(id: string, steps: StepDef[]): AsyncGenerator<WorkflowEvent> {
-    const res = await fetch(`${this.baseUrl}/v1/workflows/${id}/resume`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ steps }),
-    });
+  listWorkflowRuns(name: string): Promise<{ runs: string[] }> {
+    return this.request("GET", `/v1/workflows/${encodeURIComponent(name)}/runs`);
+  }
+
+  getWorkflowLedger(name: string, runId: string): Promise<WorkflowEvent[]> {
+    return this.request(
+      "GET",
+      `/v1/workflows/${encodeURIComponent(name)}/runs/${encodeURIComponent(runId)}/ledger`,
+    );
+  }
+
+  private async _startRun(name: string, steps: StepDef[]): Promise<WorkflowRun> {
+    const res = await fetch(
+      `${this.baseUrl}/v1/workflows/${encodeURIComponent(name)}/runs`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ steps }),
+      },
+    );
     if (!res.ok) throw new DrejError("drej API error", res.status);
-    if (!res.body) return;
-    yield* parseWorkflowSSE(res.body);
+    if (!res.body) throw new DrejError("empty response body", 500);
+    return this._consumeRunStarted(name, res.body);
   }
 
-  getWorkflowLedger(id: string): Promise<WorkflowEvent[]> {
-    return this.request("GET", `/v1/workflows/${id}/ledger`);
+  private async _consumeRunStarted(
+    name: string,
+    body: ReadableStream<Uint8Array>,
+  ): Promise<WorkflowRun> {
+    const stream = parseWorkflowSSE(body);
+    const first = await stream.next();
+    if (first.done || first.value.event !== "run_started") {
+      throw new DrejError("expected run_started as first SSE event", 500);
+    }
+    const { runId } = first.value.payload as { runId: string };
+    return new WorkflowRun(name, runId, stream);
   }
 }

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -1,4 +1,4 @@
-export { DrejClient, DrejError } from "./client";
+export { DrejClient, DrejError, WorkflowRun } from "./client";
 export type {
   DrejClientOptions,
   Resources,

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -184,7 +184,7 @@ class WorkflowParallelBuilder {
 export class WorkflowBuilder {
   private _steps: StepDef[] = [];
 
-  constructor(private _id: string) {}
+  constructor(private _name: string) {}
 
   sandbox(opts: SandboxOpts, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
     const sb = new SandboxStepBuilder();
@@ -204,11 +204,11 @@ export class WorkflowBuilder {
     return this;
   }
 
-  build(): { id: string; steps: StepDef[] } {
-    return { id: this._id, steps: this._steps };
+  build(): { name: string; steps: StepDef[] } {
+    return { name: this._name, steps: this._steps };
   }
 }
 
-export function workflow(id: string): WorkflowBuilder {
-  return new WorkflowBuilder(id);
+export function workflow(name: string): WorkflowBuilder {
+  return new WorkflowBuilder(name);
 }


### PR DESCRIPTION
Each execution is now identified by a stable workflow name plus an auto-generated UUID run ID. Ledger files land at
ledgers/<name>/<runId>.ndjson. Server emits run_started as the first SSE event so the client can surface run.id before iteration begins.

Adds GET /v1/workflows/:name/runs for listing all runs of a workflow.