### PR TITLE
feat: restructure examples as standalone packages

### DIFF
--- a/examples/control-flow/README.md
+++ b/examples/control-flow/README.md
@@ -1,0 +1,19 @@
+# control-flow
+
+Demonstrates all of drej's built-in control-flow primitives in a single workflow.
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it shows
+
+| Primitive | Description |
+|-----------|-------------|
+| `retry`   | Retries a flaky command up to 5 times with exponential backoff |
+| `when`    | Branches conditionally on workflow state |
+| `forEach` | Iterates over a list with a loop variable |
+| `parallel`| Runs two branches concurrently inside the same sandbox |

--- a/examples/control-flow/index.ts
+++ b/examples/control-flow/index.ts
@@ -5,7 +5,7 @@
  *   forEach  — iterates a list; item resolves via template literal
  *   parallel — runs branches concurrently inside the same sandbox
  */
-import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "drej";
 
 const client = new DrejClient({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
@@ -59,7 +59,7 @@ for await (const ev of run) {
     const e = ev.payload as { type: string; text?: string };
     if (e.text) process.stdout.write(e.text);
   } else {
-    const branch = ev.branch !== undefined ? ` branch=${ev.branch}` : "";
+    const branch = (ev as { branch?: number }).branch !== undefined ? ` branch=${(ev as { branch?: number }).branch}` : "";
     const extra = ev.error ? ` error=${ev.error}` : "";
     console.log(`[${ev.event}] step=${ev.stepIndex}${branch}${extra}`);
   }

--- a/examples/control-flow/package.json
+++ b/examples/control-flow/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "drej-example-control-flow",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0"
+  }
+}

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,17 @@
+# hello-world
+
+The simplest drej workflow: spin up an Ubuntu sandbox, run `echo "hello world"`, and stream the output.
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates an Ubuntu 22.04 sandbox
+2. Executes `echo "hello world"` inside it
+3. Streams every workflow event to stdout, printing exec output as it arrives
+4. Deletes the sandbox on completion

--- a/examples/hello-world/bun.lock
+++ b/examples/hello-world/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "drej-example-hello-world",
+      "dependencies": {
+        "drej": "^0.4.0",
+      },
+    },
+  },
+  "packages": {
+    "drej": ["drej@0.4.0", "", {}, "sha512-YuX61TshYZGdQqrJI9KSKCfSct3FvkRwuFFsGTrhoDM709xWpFG75jd4QFezmctTnQT3W6j4Lf4IYN9IE7b+hQ=="],
+  }
+}

--- a/examples/hello-world/index.ts
+++ b/examples/hello-world/index.ts
@@ -1,33 +1,13 @@
-import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "drej";
 
 const client = new DrejClient({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
 });
 
-const script = `
-#!/bin/bash
-set -euo pipefail
-
-echo "=== system info ==="
-uname -a
-echo ""
-
-echo "=== disk usage ==="
-df -h /
-echo ""
-
-echo "=== writing a file and reading it back ==="
-echo "hello from drej" > /tmp/drej-test.txt
-cat /tmp/drej-test.txt
-echo ""
-
-echo "=== done ==="
-`.trim();
-
-const w = workflow("bash-script").sandbox(
+const w = workflow("hello-world").sandbox(
   { image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } },
-  (s) => s.exec(script),
+  (s) => s.exec('echo "hello world"'),
 );
 
 const run = await client.run(w);

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "drej-example-hello-world",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0"
+  }
+}

--- a/examples/run-bash-script/README.md
+++ b/examples/run-bash-script/README.md
@@ -1,0 +1,17 @@
+# run-bash-script
+
+Run a multi-line bash script inside an isolated sandbox and stream its output.
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates an Ubuntu 22.04 sandbox
+2. Uploads and runs a bash script that prints system info, disk usage, and writes/reads a file
+3. Streams output to stdout as it arrives
+4. Deletes the sandbox on completion

--- a/examples/run-bash-script/index.ts
+++ b/examples/run-bash-script/index.ts
@@ -1,13 +1,33 @@
-import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "drej";
 
 const client = new DrejClient({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
 });
 
-const w = workflow("hello-world").sandbox(
+const script = `
+#!/bin/bash
+set -euo pipefail
+
+echo "=== system info ==="
+uname -a
+echo ""
+
+echo "=== disk usage ==="
+df -h /
+echo ""
+
+echo "=== writing a file and reading it back ==="
+echo "hello from drej" > /tmp/drej-test.txt
+cat /tmp/drej-test.txt
+echo ""
+
+echo "=== done ==="
+`.trim();
+
+const w = workflow("bash-script").sandbox(
   { image: { uri: "ubuntu:22.04" }, resourceLimits: { cpu: "500m", memory: "512Mi" } },
-  (s) => s.exec('echo "hello world"'),
+  (s) => s.exec(script),
 );
 
 const run = await client.run(w);

--- a/examples/run-bash-script/package.json
+++ b/examples/run-bash-script/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "drej-example-run-bash-script",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0"
+  }
+}

--- a/examples/snapshot-replay/README.md
+++ b/examples/snapshot-replay/README.md
@@ -1,0 +1,22 @@
+# snapshot-replay
+
+Demonstrates drej's snapshot and replay feature: run a workflow once to install dependencies and capture a snapshot, then replay from that snapshot — skipping the install — to run updated code against the same environment.
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+**Initial run**
+1. Creates a Python 3.11 sandbox
+2. Installs `requests` via pip
+3. Captures a snapshot after the install step
+4. Runs a script against httpbin
+
+**Replay**
+1. Boots a new sandbox from the snapshot (pip install already done)
+2. Runs an updated script that fetches a different endpoint

--- a/examples/snapshot-replay/index.ts
+++ b/examples/snapshot-replay/index.ts
@@ -4,12 +4,13 @@
  * An initial run installs dependencies and captures a snapshot. A replay run
  * boots from that snapshot directly — skipping the install — and runs an
  * updated script against the same environment.
- *
- * Usage: bun run examples/snapshot-replay.ts
  */
-import { DrejClient, workflow } from "../packages/sdks/typescript/src/index";
+import { DrejClient, workflow } from "drej";
 
-const client = new DrejClient({\n  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",\n  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",\n});
+const client = new DrejClient({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+});
 
 const WORKFLOW = "snapshot-replay-demo";
 const sandbox = { image: { uri: "python:3.11-slim" }, resourceLimits: { cpu: "1", memory: "512Mi" } };
@@ -42,18 +43,15 @@ const run1 = await client.run(
 
 console.log(`run: ${run1.id}`);
 
-let snapshotId: string | undefined;
 for await (const ev of run1) {
   if (ev.event === "exec_event") {
     const { text } = ev.payload as { text?: string };
     if (text) process.stdout.write(text);
   } else if (ev.event === "snapshot") {
-    snapshotId = (ev.payload as { snapshotId: string }).snapshotId;
+    const { snapshotId } = ev.payload as { snapshotId: string };
     console.log(`snapshot: ${snapshotId}`);
   }
 }
-
-if (!snapshotId) throw new Error("no snapshot captured");
 
 // ── Replay ────────────────────────────────────────────────────────────────────
 // Boots from the snapshot (deps already present), skips the install step.

--- a/examples/snapshot-replay/package.json
+++ b/examples/snapshot-replay/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "drej-example-snapshot-replay",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0"
+  }
+}


### PR DESCRIPTION
Each example now lives in its own directory with a package.json that installs drej from npm (^0.5.0) and a README explaining what it does.