### PR TITLE
feat: introduce pluggable storage adapter system

### DIFF
--- a/.changeset/pluggable-storage-adapter.md
+++ b/.changeset/pluggable-storage-adapter.md
@@ -1,0 +1,13 @@
+---
+"@drej/core": minor
+"drej": minor
+"@drej/adapter-postgres": minor
+---
+
+Introduce pluggable storage adapter system.
+
+- `ILedger` renamed to `IStorageAdapter` with optional `connect()` and `close()` lifecycle methods
+- Built-in implementations renamed: `MemoryLedger` → `MemoryAdapter`, `NdjsonLedger` → `NdjsonAdapter`
+- `DrejClientOptions` gains an `adapter` field accepting any `IStorageAdapter` implementation
+- `DrejClient` gains `connect()` and `close()` methods for adapter lifecycle management
+- New `@drej/adapter-postgres` package: `PostgresAdapter` backed by a user-supplied Postgres connection string; owns its schema and runs migrations on `connect()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ bun run typecheck
 bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json
 bunx tsc --noEmit --strict --project packages/core/tsconfig.json
 bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json
+bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json
 
 # Changesets (required on every PR touching publishable packages)
 bunx changeset        # add a changeset
@@ -46,7 +47,7 @@ bunx changeset status # verify one exists
 ```
 packages/core/              — Workflow engine (no runtime deps outside opensandbox)
   types.ts / steps.ts       — StepDef union and buildStep() factory
-  ledger.ts                 — ILedger, MemoryLedger, NdjsonLedger, LedgerEvent
+  ledger.ts                 — IStorageAdapter, MemoryAdapter, NdjsonAdapter, LedgerEvent
   workflow.ts               — Workflow class (run, rollback, resumeFromLedger), WorkflowHooks
 
 packages/opensandbox/       — OpenSandbox HTTP clients
@@ -57,6 +58,10 @@ packages/opensandbox/       — OpenSandbox HTTP clients
 packages/sdks/typescript/   — Public TypeScript SDK (published to npm as "drej")
   client.ts                 — DrejClient: runs workflows in-process, exposes sandbox/snapshot mgmt
   workflow.ts               — WorkflowBuilder, SandboxStepBuilder (fluent builder API)
+
+packages/adapters/postgres/ — Postgres storage adapter (published as "@drej/adapter-postgres")
+  src/adapter.ts            — PostgresAdapter implementing IStorageAdapter
+  src/migrations.ts         — Idempotent CREATE TABLE IF NOT EXISTS schema
 ```
 
 ### Key design points
@@ -67,7 +72,7 @@ packages/sdks/typescript/   — Public TypeScript SDK (published to npm as "drej
 
 **Async event stream**: `client.run()` returns a `WorkflowRun` which is an `AsyncIterable<WorkflowEvent>`. Callers `for await` over events in real-time as steps execute. Every event is also persisted to the ledger simultaneously (tee pattern inside `DrejClient._makeStream`).
 
-**Ledger**: `DrejClientOptions.ledgerDir` enables a durable NDJSON ledger on disk. Omit it for an in-memory ledger. The ledger backs `resumeRun()` and `replayFromSnapshot()`.
+**Storage adapter**: `DrejClientOptions.adapter` accepts any `IStorageAdapter` implementation — pass `new PostgresAdapter(connectionString)` for production. `ledgerDir` is shorthand for an `NdjsonAdapter`. Omit both for an in-memory `MemoryAdapter`. Call `await client.connect()` before first use when using a DB-backed adapter; `await client.close()` on shutdown. The adapter backs `resumeRun()`, `replayFromSnapshot()`, `listRuns()`, and `getRunLedger()`.
 
 **Hooks**: `WorkflowHooks` (defined in `packages/core/workflow.ts`) provides lifecycle callbacks: `onStepStart`, `onStepComplete`, `onStepFailed`, `onStepRolledBack`, `onWorkflowComplete`, `onWorkflowFailed`. Pass via `WorkflowDeps.hooks`.
 
@@ -87,7 +92,8 @@ packages/sdks/typescript/   — Public TypeScript SDK (published to npm as "drej
 |---|---|
 | `baseUrl` | OpenSandbox server URL (e.g. `http://localhost:8080`) |
 | `apiKey` | OpenSandbox API key (empty string for local dev) |
-| `ledgerDir` | Directory for durable NDJSON ledger (omit for in-memory) |
+| `adapter` | Custom `IStorageAdapter` (e.g. `new PostgresAdapter(url)`) |
+| `ledgerDir` | Shorthand for `new NdjsonAdapter(dir)` — durable NDJSON on disk |
 
 ## Local OpenSandbox setup
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,18 @@
         "@changesets/cli": "^2.31.0",
       },
     },
+    "packages/adapters/postgres": {
+      "name": "@drej/adapter-postgres",
+      "version": "0.0.1",
+      "dependencies": {
+        "@drej/core": "workspace:*",
+        "postgres": "^3.4.5",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+        "typescript": "latest",
+      },
+    },
     "packages/core": {
       "name": "@drej/core",
       "version": "0.0.0",
@@ -76,6 +88,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@drej/adapter-postgres": ["@drej/adapter-postgres@workspace:packages/adapters/postgres"],
 
     "@drej/core": ["@drej/core@workspace:packages/core"],
 
@@ -198,6 +212,8 @@
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "workspaces": [
     "packages/core",
     "packages/opensandbox",
-    "packages/sdks/typescript"
+    "packages/sdks/typescript",
+    "packages/adapters/postgres"
   ],
   "scripts": {
-    "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json"
+    "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0"

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@drej/adapter-postgres",
+  "version": "0.0.1",
+  "private": false,
+  "main": "./src/index.ts",
+  "dependencies": {
+    "postgres": "^3.4.5",
+    "@drej/core": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "latest",
+    "typescript": "latest"
+  }
+}

--- a/packages/adapters/postgres/src/adapter.ts
+++ b/packages/adapters/postgres/src/adapter.ts
@@ -1,0 +1,87 @@
+import postgres from "postgres";
+import type { IStorageAdapter, LedgerEntry, LedgerEvent } from "@drej/core";
+import { MIGRATION_SQL } from "./migrations";
+
+type Row = {
+  run_id: string;
+  wf_name: string;
+  step_idx: number;
+  branch: number | null;
+  event: string;
+  payload: unknown;
+  error: string | null;
+  ts: string;
+};
+
+function rowToEntry(row: Row): LedgerEntry {
+  return {
+    runId: row.run_id,
+    workflowName: row.wf_name,
+    stepIndex: row.step_idx,
+    branch: row.branch ?? undefined,
+    event: row.event as LedgerEvent,
+    payload: row.payload ?? undefined,
+    error: row.error ?? undefined,
+    ts: Number(row.ts),
+  };
+}
+
+export class PostgresAdapter implements IStorageAdapter {
+  private readonly sql: ReturnType<typeof postgres>;
+
+  constructor(connectionString: string) {
+    this.sql = postgres(connectionString);
+  }
+
+  async connect(): Promise<void> {
+    await this.sql.unsafe(MIGRATION_SQL);
+  }
+
+  async close(): Promise<void> {
+    await this.sql.end();
+  }
+
+  async append(entry: LedgerEntry): Promise<void> {
+    await this.sql`
+      INSERT INTO drej_events (run_id, wf_name, step_idx, branch, event, payload, error, ts)
+      VALUES (
+        ${entry.runId},
+        ${entry.workflowName},
+        ${entry.stepIndex},
+        ${entry.branch ?? null},
+        ${entry.event},
+        ${entry.payload !== undefined ? JSON.stringify(entry.payload) : null},
+        ${entry.error ?? null},
+        ${entry.ts}
+      )
+    `;
+  }
+
+  async readAll(workflowName: string, runId: string): Promise<LedgerEntry[]> {
+    const rows = await this.sql<Row[]>`
+      SELECT run_id, wf_name, step_idx, branch, event, payload, error, ts
+      FROM drej_events
+      WHERE wf_name = ${workflowName} AND run_id = ${runId}
+      ORDER BY ts ASC
+    `;
+    return rows.map(rowToEntry);
+  }
+
+  async lastCheckpoint(workflowName: string, runId: string): Promise<LedgerEntry | null> {
+    const rows = await this.sql<Row[]>`
+      SELECT run_id, wf_name, step_idx, branch, event, payload, error, ts
+      FROM drej_events
+      WHERE wf_name = ${workflowName} AND run_id = ${runId} AND event = 'checkpoint'
+      ORDER BY ts DESC
+      LIMIT 1
+    `;
+    return rows.length ? rowToEntry(rows[0]) : null;
+  }
+
+  async listRuns(workflowName: string): Promise<string[]> {
+    const rows = await this.sql<{ run_id: string }[]>`
+      SELECT DISTINCT run_id FROM drej_events WHERE wf_name = ${workflowName}
+    `;
+    return rows.map((r) => r.run_id);
+  }
+}

--- a/packages/adapters/postgres/src/index.ts
+++ b/packages/adapters/postgres/src/index.ts
@@ -1,0 +1,1 @@
+export { PostgresAdapter } from "./adapter";

--- a/packages/adapters/postgres/src/migrations.ts
+++ b/packages/adapters/postgres/src/migrations.ts
@@ -1,0 +1,16 @@
+export const MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS drej_events (
+  id        BIGSERIAL   PRIMARY KEY,
+  run_id    TEXT        NOT NULL,
+  wf_name   TEXT        NOT NULL,
+  step_idx  INTEGER     NOT NULL,
+  branch    INTEGER,
+  event     TEXT        NOT NULL,
+  payload   JSONB,
+  error     TEXT,
+  ts        BIGINT      NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS drej_events_run_id ON drej_events(run_id);
+CREATE INDEX IF NOT EXISTS drej_events_wf_name ON drej_events(wf_name);
+`;

--- a/packages/adapters/postgres/tsconfig.json
+++ b/packages/adapters/postgres/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { LedgerEvent } from "./ledger";
-export type { LedgerEntry, ILedger } from "./ledger";
-export { MemoryLedger, NdjsonLedger } from "./ledger";
+export type { LedgerEntry, IStorageAdapter } from "./ledger";
+export { MemoryAdapter, NdjsonAdapter } from "./ledger";
 
 export { LogLevel, ConsoleLogger, noopLogger } from "./logger";
 export type { ILogger } from "./logger";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -23,14 +23,16 @@ export interface LedgerEntry {
   error?: string;
 }
 
-export interface ILedger {
+export interface IStorageAdapter {
+  connect?(): Promise<void>;
+  close?(): Promise<void>;
   append(entry: LedgerEntry): Promise<void>;
   readAll(workflowName: string, runId: string): Promise<LedgerEntry[]>;
   lastCheckpoint(workflowName: string, runId: string): Promise<LedgerEntry | null>;
   listRuns(workflowName: string): Promise<string[]>;
 }
 
-export class MemoryLedger implements ILedger {
+export class MemoryAdapter implements IStorageAdapter {
   private readonly entries: LedgerEntry[] = [];
 
   async append(entry: LedgerEntry): Promise<void> {
@@ -61,7 +63,7 @@ export class MemoryLedger implements ILedger {
 // Each entry gets its own file: <dir>/<workflowName>/<runId>/<ts>-<rand>.ndjson
 // Bun.write to a new path never truncates existing entries — safe on crash.
 // readAll globs all entry files and sorts by the ts field for deterministic order.
-export class NdjsonLedger implements ILedger {
+export class NdjsonAdapter implements IStorageAdapter {
   constructor(private readonly dir: string) {}
 
   private runDir(workflowName: string, runId: string): string {

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -1,4 +1,4 @@
-import type { ILedger, LedgerEntry } from "./ledger";
+import type { IStorageAdapter, LedgerEntry } from "./ledger";
 import { LedgerEvent } from "./ledger";
 import type { ControlClient, ExecClient } from "@drej/opensandbox";
 import type { ILogger } from "./logger";
@@ -41,7 +41,7 @@ export interface WorkflowHooks {
 export interface WorkflowDeps {
   control: ControlClient;
   resolveExec: (sandboxId: string) => Promise<ExecClient>;
-  ledger: ILedger;
+  ledger: IStorageAdapter;
   logger?: ILogger;
   hooks?: WorkflowHooks;
 }

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -1,14 +1,14 @@
 import {
   Workflow,
-  NdjsonLedger,
-  MemoryLedger,
+  NdjsonAdapter,
+  MemoryAdapter,
   LedgerEvent,
   buildStep,
   resolveExecClient,
   shouldSnapshot,
   waitForSnapshot,
   type WorkflowDeps,
-  type ILedger,
+  type IStorageAdapter,
   type LedgerEntry,
   type SnapshotConfig,
   type StepDef,
@@ -27,7 +27,7 @@ import {
 import type { WorkflowBuilder } from "./workflow";
 
 export { LedgerEvent };
-export type { LedgerEntry, SnapshotConfig, StepDef };
+export type { LedgerEntry, SnapshotConfig, StepDef, IStorageAdapter };
 export type {
   Sandbox,
   SandboxState,
@@ -55,7 +55,12 @@ export interface DrejClientOptions {
   baseUrl: string;
   /** OpenSandbox API key (empty string for local dev) */
   apiKey?: string;
-  /** Directory for durable NDJSON ledger. Omit to use an in-memory ledger. */
+  /**
+   * Pluggable storage adapter. Implement IStorageAdapter to use any database.
+   * Defaults to an in-memory adapter when omitted.
+   */
+  adapter?: IStorageAdapter;
+  /** Directory for durable NDJSON storage. Shorthand for `adapter: new NdjsonAdapter(dir)`. */
   ledgerDir?: string;
 }
 
@@ -64,7 +69,7 @@ export interface RunOptions {
 }
 
 // WorkflowEvent is a ledger entry — the same record emitted during execution
-// and stored in the ledger.
+// and stored in the adapter.
 export type WorkflowEvent = LedgerEntry;
 
 export class WorkflowRun implements AsyncIterable<WorkflowEvent> {
@@ -81,16 +86,30 @@ export class WorkflowRun implements AsyncIterable<WorkflowEvent> {
 
 export class DrejClient {
   private readonly control: ControlClient;
-  private readonly ledger: ILedger;
+  private readonly adapter: IStorageAdapter;
 
   constructor(options: DrejClientOptions) {
     this.control = new ControlClient({
       baseUrl: options.baseUrl,
       apiKey: options.apiKey ?? "",
     });
-    this.ledger = options.ledgerDir
-      ? new NdjsonLedger(options.ledgerDir)
-      : new MemoryLedger();
+    if (options.adapter) {
+      this.adapter = options.adapter;
+    } else if (options.ledgerDir) {
+      this.adapter = new NdjsonAdapter(options.ledgerDir);
+    } else {
+      this.adapter = new MemoryAdapter();
+    }
+  }
+
+  /** Call once before first use when using a DB-backed adapter. */
+  async connect(): Promise<void> {
+    await this.adapter.connect?.();
+  }
+
+  /** Releases adapter resources (e.g. closes DB connection pool). */
+  async close(): Promise<void> {
+    await this.adapter.close?.();
   }
 
   // ── Sandbox management ────────────────────────────────────────────────────
@@ -185,7 +204,7 @@ export class DrejClient {
     runId: string,
     w: WorkflowBuilder,
   ): Promise<WorkflowRun> {
-    const entries = await this.ledger.readAll(name, runId);
+    const entries = await this.adapter.readAll(name, runId);
     const snapEntry = [...entries].reverse().find((e) => e.event === LedgerEvent.Snapshot);
     if (!snapEntry) throw new DrejError(`No snapshot found in ledger for ${name}/${runId}`, 404);
     const { snapshotId } = snapEntry.payload as { snapshotId: string };
@@ -219,14 +238,14 @@ export class DrejClient {
     return new WorkflowRun(name, runId, stream);
   }
 
-  // ── Ledger access ─────────────────────────────────────────────────────────
+  // ── Adapter access ────────────────────────────────────────────────────────
 
   listRuns(workflowName: string): Promise<string[]> {
-    return this.ledger.listRuns(workflowName);
+    return this.adapter.listRuns(workflowName);
   }
 
   getRunLedger(workflowName: string, runId: string): Promise<WorkflowEvent[]> {
-    return this.ledger.readAll(workflowName, runId) as Promise<WorkflowEvent[]>;
+    return this.adapter.readAll(workflowName, runId) as Promise<WorkflowEvent[]>;
   }
 
   // ── Internal ──────────────────────────────────────────────────────────────
@@ -269,7 +288,7 @@ export class DrejClient {
   }
 
   // Runs `execute` in the background and returns an async generator that
-  // yields WorkflowEvents in real-time as they are appended to the ledger.
+  // yields WorkflowEvents in real-time as they are appended to the adapter.
   private _makeStream(
     name: string,
     runId: string,
@@ -286,20 +305,20 @@ export class DrejClient {
       fn?.();
     };
 
-    const teeLedger: ILedger = {
+    const teeAdapter: IStorageAdapter = {
       append: async (entry) => {
-        await this.ledger.append(entry);
+        await this.adapter.append(entry);
         enqueue(entry);
       },
-      readAll: (n, id) => this.ledger.readAll(n, id),
-      lastCheckpoint: (n, id) => this.ledger.lastCheckpoint(n, id),
-      listRuns: (n) => this.ledger.listRuns(n),
+      readAll: (n, id) => this.adapter.readAll(n, id),
+      lastCheckpoint: (n, id) => this.adapter.lastCheckpoint(n, id),
+      listRuns: (n) => this.adapter.listRuns(n),
     };
 
     const teeDeps: WorkflowDeps = {
       control: this.control,
       resolveExec: (sandboxId) => resolveExecClient(this.control, sandboxId),
-      ledger: teeLedger,
+      ledger: teeAdapter,
     };
 
     // Emit run_started before kicking off execution

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -5,6 +5,7 @@ export type {
   SnapshotConfig,
   WorkflowEvent,
   StepDef,
+  IStorageAdapter,
   Sandbox,
   SandboxState,
   SandboxStatus,


### PR DESCRIPTION
Rename ILedger → IStorageAdapter with optional connect()/close() lifecycle methods. Built-in impls renamed to MemoryAdapter and NdjsonAdapter. Add adapter option to DrejClientOptions so users can supply any IStorageAdapter implementation (e.g. a DB-backed one). DrejClient gains connect() and close() methods that delegate to the adapter lifecycle.

Add @drej/adapter-postgres: PostgresAdapter backed by the `postgres` npm package. Accepts a connection string, owns its schema via idempotent migrations run on connect(), and implements all IStorageAdapter methods against a drej_events table.