### PR TITLE
feat: add snapshot() as a first-class workflow step

### DIFF
--- a/.changeset/snapshot-step.md
+++ b/.changeset/snapshot-step.md
@@ -1,0 +1,22 @@
+---
+"drej": minor
+"@drejt/core": minor
+---
+
+Add `s.snapshot()` as a first-class workflow step
+
+Previously, capturing a sandbox snapshot required passing `snapshotConfig: { afterSteps: [N] }` to `client.run()` — which meant counting step indices upfront and re-counting whenever steps were reordered.
+
+`s.snapshot()` declares the checkpoint inline, where it belongs:
+
+```ts
+workflow("build").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
+  s.exec("npm ci")
+   .snapshot()      // checkpoint: deps installed
+   .exec("npm test"),
+)
+```
+
+The snapshot ID is persisted to the ledger and stored in workflow state as `snapshotId`. `client.replayFromSnapshot()` works the same way regardless of which method was used to take the snapshot.
+
+`snapshotConfig` on `client.run()` remains supported — it is useful when you need to snapshot a workflow you didn't write, or snapshot on a cadence (`everyNSteps`) rather than at a fixed point.

--- a/examples/snapshot-replay/index.ts
+++ b/examples/snapshot-replay/index.ts
@@ -1,9 +1,13 @@
 /**
- * Demonstrates workflow snapshots and replay.
+ * Demonstrates two ways to capture sandbox snapshots and replay from them.
  *
- * An initial run installs dependencies and captures a snapshot. A replay run
- * boots from that snapshot directly — skipping the install — and runs an
- * updated script against the same environment.
+ * Pattern A — s.snapshot() inline step (preferred):
+ *   Declare the checkpoint directly in the workflow definition. Position-aware,
+ *   no step indices to count.
+ *
+ * Pattern B — snapshotConfig on client.run() (external):
+ *   Snapshot a workflow you didn't write, or snapshot on a cadence
+ *   (everyNSteps) rather than at a fixed point.
  */
 import { DrejClient, workflow } from "drej";
 import { SQLiteAdapter } from "@drejt/sqlite";
@@ -16,7 +20,6 @@ const client = new DrejClient({
 
 await client.connect();
 
-const WORKFLOW = "snapshot-replay-demo";
 const sandbox = { image: { uri: "python:3.11-slim" }, resourceLimits: { cpu: "1", memory: "512Mi" } };
 
 const script = `
@@ -32,21 +35,24 @@ print(f"Python {sys.version.split()[0]} (replay)")
 print(json.dumps(r.json(), indent=2))
 `.trim();
 
-// ── Initial run ───────────────────────────────────────────────────────────────
-// Installs deps and captures a snapshot after the install step.
+// ── Pattern A: s.snapshot() inline ───────────────────────────────────────────
+// The checkpoint is declared where it belongs — in the workflow itself.
+
+console.log("=== Pattern A: inline s.snapshot() ===\n");
+
+const WORKFLOW_A = "snapshot-inline";
 
 const run1 = await client.run(
-  workflow(WORKFLOW).sandbox(sandbox, (s) =>
+  workflow(WORKFLOW_A).sandbox(sandbox, (s) =>
     s
       .exec("pip install -q requests && echo installed")
+      .snapshot()                           // checkpoint declared inline
       .writeFile("/tmp/script.py", script)
       .exec("python3 /tmp/script.py"),
   ),
-  { snapshotConfig: { afterSteps: [1] } },
 );
 
 console.log(`run: ${run1.id}`);
-
 for await (const ev of run1) {
   if (ev.event === "exec_event") {
     const { text } = ev.payload as { text?: string };
@@ -57,21 +63,66 @@ for await (const ev of run1) {
   }
 }
 
-// ── Replay ────────────────────────────────────────────────────────────────────
-// Boots from the snapshot (deps already present), skips the install step.
-
-const run2 = await client.replayFromSnapshot(
-  WORKFLOW,
+const replay1 = await client.replayFromSnapshot(
+  WORKFLOW_A,
   run1.id,
-  workflow(WORKFLOW).sandbox(
+  workflow(WORKFLOW_A).sandbox(
     { resourceLimits: sandbox.resourceLimits },
     (s) => s.writeFile("/tmp/script.py", replayScript).exec("python3 /tmp/script.py"),
   ),
 );
 
-console.log(`replay: ${run2.id}`);
+console.log(`\nreplay: ${replay1.id}`);
+for await (const ev of replay1) {
+  if (ev.event === "exec_event") {
+    const { text } = ev.payload as { text?: string };
+    if (text) process.stdout.write(text);
+  }
+}
 
+// ── Pattern B: snapshotConfig on client.run() ─────────────────────────────────
+// Useful when you can't or don't want to modify the workflow definition —
+// e.g. snapshotting a shared workflow, or snapshotting every N steps.
+
+console.log("\n=== Pattern B: snapshotConfig on client.run() ===\n");
+
+const WORKFLOW_B = "snapshot-external";
+
+const externalWorkflow = workflow(WORKFLOW_B).sandbox(sandbox, (s) =>
+  s
+    .exec("pip install -q requests && echo installed")
+    .writeFile("/tmp/script.py", script)
+    .exec("python3 /tmp/script.py"),
+);
+
+// afterSteps index 1 corresponds to the exec after create_sandbox (index 0).
+// This is more fragile than s.snapshot() — reordering steps silently shifts indices.
+const run2 = await client.run(externalWorkflow, {
+  snapshotConfig: { afterSteps: [1] },
+});
+
+console.log(`run: ${run2.id}`);
 for await (const ev of run2) {
+  if (ev.event === "exec_event") {
+    const { text } = ev.payload as { text?: string };
+    if (text) process.stdout.write(text);
+  } else if (ev.event === "snapshot") {
+    const { snapshotId } = ev.payload as { snapshotId: string };
+    console.log(`snapshot: ${snapshotId}`);
+  }
+}
+
+const replay2 = await client.replayFromSnapshot(
+  WORKFLOW_B,
+  run2.id,
+  workflow(WORKFLOW_B).sandbox(
+    { resourceLimits: sandbox.resourceLimits },
+    (s) => s.writeFile("/tmp/script.py", replayScript).exec("python3 /tmp/script.py"),
+  ),
+);
+
+console.log(`\nreplay: ${replay2.id}`);
+for await (const ev of replay2) {
   if (ev.event === "exec_event") {
     const { text } = ev.payload as { text?: string };
     if (text) process.stdout.write(text);

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -26,6 +26,7 @@ export type StepDef =
   | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string> }
   | { type: "delete_sandbox" }
   | { type: "write_file"; path: string; content: string; encoding?: "utf8" | "base64" }
+  | { type: "snapshot" }
   | { type: "retry"; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: "conditional"; condition: Predicate; then: StepDef[]; else?: StepDef[] }
   | { type: "loop"; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
@@ -231,6 +232,26 @@ export function buildStep(def: StepDef): WorkflowStep {
             : def.content;
           await exec.uploadFile(def.path, content);
           return state;
+        },
+      };
+
+    case "snapshot":
+      return {
+        id: "snapshot",
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          const state = (input ?? {}) as WorkflowState;
+          if (!state.sandboxId) throw new Error("snapshot requires sandboxId in workflow state");
+          const snap = await ctx.control.createSnapshot(state.sandboxId);
+          await waitForSnapshot(ctx.control, snap.id);
+          await ctx.emit({
+            ts: Date.now(),
+            workflowName: ctx.workflowName,
+            runId: ctx.runId,
+            stepIndex: ctx.stepIndex,
+            event: LedgerEvent.Snapshot,
+            payload: { snapshotId: snap.id, sandboxId: state.sandboxId },
+          });
+          return { ...state, snapshotId: snap.id };
         },
       };
 

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -285,8 +285,9 @@ export class DrejClient {
    * The new run boots from the snapshot image, skipping any steps that ran
    * before the snapshot was taken (e.g. dependency installs).
    *
-   * The original run must have been executed with `snapshotConfig` set so
-   * that a `LedgerEvent.Snapshot` entry exists in the ledger.
+   * The original run must contain a `LedgerEvent.Snapshot` entry — produced
+   * either by a `s.snapshot()` step in the workflow or by the
+   * `snapshotConfig` option passed to `client.run()`.
    */
   async replayFromSnapshot(
     name: string,

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -92,6 +92,27 @@ export class SandboxStepBuilder {
   }
 
   /**
+   * Capture a snapshot of the sandbox at this point in the workflow.
+   *
+   * The snapshot ID is stored in workflow state as `snapshotId` and persisted
+   * to the ledger. Use {@link DrejClient.replayFromSnapshot} to boot a future
+   * run from this checkpoint, skipping any steps that ran before it.
+   *
+   * @example
+   * ```ts
+   * workflow("build").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
+   *   s.exec("npm ci")
+   *    .snapshot()          // checkpoint after deps installed
+   *    .exec("npm test"),
+   * )
+   * ```
+   */
+  snapshot(): this {
+    this._steps.push({ type: "snapshot" });
+    return this;
+  }
+
+  /**
    * Write a file into the sandbox filesystem.
    *
    * @param encoding Defaults to `utf8`. Use `base64` for binary content.


### PR DESCRIPTION
Replace the fragile afterSteps index approach with s.snapshot() declared inline in the workflow builder. The step calls createSnapshot, waits for readiness, emits LedgerEvent.Snapshot (same payload shape as the hook), and stores snapshotId in workflow state. snapshotConfig on client.run() remains for external/cadence-based snapshotting.