### PR TITLE
feat: add readFile() step to read sandbox files into workflow state

### DIFF
--- a/.changeset/readfile.md
+++ b/.changeset/readfile.md
@@ -1,0 +1,18 @@
+---
+"drej": minor
+"@drejt/core": minor
+---
+
+Add `s.readFile(path, { as })` step to read sandbox files into workflow state
+
+File contents are stored under the given key and immediately available for
+interpolation in subsequent steps via `{{key}}`, or accessible on the final
+workflow state after the run. Supports `utf8` (default) and `base64` encoding.
+
+```ts
+workflow("build").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
+  s.exec("node -e \"process.version\" > /tmp/version.txt")
+   .readFile("/tmp/version.txt", { as: "version" })
+   .exec("echo Node version: {{version}}"),
+)
+```

--- a/examples/read-file/index.ts
+++ b/examples/read-file/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Demonstrates readFile() — reading a file from the sandbox into workflow state.
+ *
+ * Two patterns shown:
+ *   interpolation  — use the file content directly in a later exec() command
+ *   caller access  — retrieve the content from workflow state after the run
+ */
+import { DrejClient, workflow } from "drej";
+import { SQLiteAdapter } from "@drejt/sqlite";
+
+const client = new DrejClient({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+});
+
+await client.connect();
+
+const run = await client.run(
+  workflow("read-file-demo").sandbox(
+    { image: { uri: "node:20-slim" }, resourceLimits: { cpu: "500m", memory: "256Mi" } },
+    (s) =>
+      s
+        // Write a file, then read it back into state as "version"
+        .exec("node -e \"require('fs').writeFileSync('/tmp/version.txt', process.version)\"")
+        .readFile("/tmp/version.txt", { as: "version" })
+
+        // Interpolate the captured value in a subsequent command
+        .exec("echo \"Node version from file: {{version}}\"")
+
+        // Write a JSON report using the captured value
+        .writeFile("/tmp/report.json", JSON.stringify({ capturedAt: new Date().toISOString() }))
+        .readFile("/tmp/report.json", { as: "report" })
+        .exec("echo \"Report: {{report}}\""),
+  ),
+);
+
+console.log(`Run ID: ${run.id}\n`);
+
+let finalState: Record<string, unknown> | undefined;
+for await (const ev of run) {
+  if (ev.event === "exec_event") {
+    const { text } = ev.payload as { text?: string };
+    if (text) process.stdout.write(text);
+  } else if (ev.event === "step_complete") {
+    // workflow state is available on each step_complete — last one has all keys
+    finalState = ev.payload as Record<string, unknown>;
+  }
+}
+
+// Access captured file contents from state after the run
+if (finalState) {
+  console.log("\n--- captured state ---");
+  console.log("version:", finalState.version);
+  console.log("report:", finalState.report);
+}
+
+await client.close();

--- a/examples/read-file/package.json
+++ b/examples/read-file/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "drej-example-read-file",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0",
+    "@drejt/sqlite": "^0.0.1"
+  }
+}

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -26,6 +26,7 @@ export type StepDef =
   | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string> }
   | { type: "delete_sandbox" }
   | { type: "write_file"; path: string; content: string; encoding?: "utf8" | "base64" }
+  | { type: "read_file"; path: string; as: string; encoding?: "utf8" | "base64" }
   | { type: "snapshot" }
   | { type: "retry"; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: "conditional"; condition: Predicate; then: StepDef[]; else?: StepDef[] }
@@ -232,6 +233,31 @@ export function buildStep(def: StepDef): WorkflowStep {
             : def.content;
           await exec.uploadFile(def.path, content);
           return state;
+        },
+      };
+
+    case "read_file":
+      return {
+        id: "read_file",
+        async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+          const state = (input ?? {}) as WorkflowState;
+          if (!state.sandboxId) throw new Error("read_file requires sandboxId in workflow state");
+          const exec = await ctx.resolveExec(state.sandboxId);
+          const stream = await exec.downloadFile(def.path);
+          const chunks: Uint8Array[] = [];
+          const reader = stream.getReader();
+          try {
+            for (;;) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              chunks.push(value);
+            }
+          } finally {
+            reader.releaseLock();
+          }
+          const bytes = Buffer.concat(chunks);
+          const content = def.encoding === "base64" ? bytes.toString("base64") : bytes.toString("utf8");
+          return { ...state, [def.as]: content };
         },
       };
 

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -92,6 +92,27 @@ export class SandboxStepBuilder {
   }
 
   /**
+   * Read a file from the sandbox filesystem into workflow state.
+   *
+   * The file contents are stored under `as` and available for interpolation
+   * in subsequent steps via `{{key}}`, or accessible on `WorkflowState` after
+   * the run completes.
+   *
+   * @param encoding Defaults to `utf8`. Use `base64` for binary files.
+   *
+   * @example
+   * ```ts
+   * s.exec("node -e 'console.log(42)' > /tmp/result.txt")
+   *  .readFile("/tmp/result.txt", { as: "result" })
+   *  .exec("echo Result was {{result}}")
+   * ```
+   */
+  readFile(path: string, opts: { as: string; encoding?: "utf8" | "base64" }): this {
+    this._steps.push({ type: "read_file", path, as: opts.as, ...(opts.encoding ? { encoding: opts.encoding } : {}) });
+    return this;
+  }
+
+  /**
    * Capture a snapshot of the sandbox at this point in the workflow.
    *
    * The snapshot ID is stored in workflow state as `snapshotId` and persisted


### PR DESCRIPTION
Reads a file from the sandbox filesystem via execd's /files/download endpoint and stores the content in workflow state under a named key. The value is immediately interpolatable in subsequent exec() commands via {{key}}. Supports utf8 (default) and base64 encoding.