### PR TITLE
feat: add capture option to exec() for storing stdout in workflow state

### DIFF
--- a/.changeset/capture-stdout.md
+++ b/.changeset/capture-stdout.md
@@ -1,0 +1,18 @@
+---
+"drej": minor
+"@drejt/core": minor
+---
+
+Add `capture` option to `exec()` for storing stdout in workflow state
+
+Pass `{ capture: "key" }` to store a command's stdout under that key in
+workflow state. The value is immediately available for interpolation in
+subsequent steps via `{{key}}`, or accessible on `WorkflowState` after
+the run. Trailing newlines are trimmed.
+
+```ts
+workflow("deploy").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
+  s.exec("git rev-parse HEAD", { capture: "sha" })
+   .exec("echo deploying commit {{sha}}"),
+)
+```

--- a/examples/capture/index.ts
+++ b/examples/capture/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Demonstrates exec() with { capture } — storing stdout in workflow state
+ * so it can be interpolated into subsequent steps.
+ */
+import { DrejClient, workflow } from "drej";
+import { SQLiteAdapter } from "@drejt/sqlite";
+
+const client = new DrejClient({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+});
+
+await client.connect();
+
+const run = await client.run(
+  workflow("capture-demo").sandbox(
+    { image: { uri: "node:20-slim" }, resourceLimits: { cpu: "500m", memory: "256Mi" } },
+    (s) =>
+      s
+        // Capture the git SHA into state as "sha"
+        .exec("node -e \"process.stdout.write(process.version)\"", { capture: "nodeVersion" })
+
+        // Interpolate the captured value into the next command
+        .exec("echo \"Running on Node {{nodeVersion}}\"")
+
+        // Capture can also feed into writeFile content via a workaround:
+        // write a dynamic file using the captured value
+        .exec("echo '{\"node\":\"'\"$NODE_VERSION\"'\"}' > /tmp/info.json", {
+          envs: { NODE_VERSION: "{{nodeVersion}}" },
+        })
+        .exec("cat /tmp/info.json", { capture: "info" })
+        .exec("echo \"Captured JSON: {{info}}\""),
+  ),
+);
+
+console.log(`Run ID: ${run.id}\n`);
+
+let finalState: Record<string, unknown> | undefined;
+for await (const ev of run) {
+  if (ev.event === "exec_event") {
+    const { text } = ev.payload as { text?: string };
+    if (text) process.stdout.write(text);
+  } else if (ev.event === "step_complete") {
+    finalState = ev.payload as Record<string, unknown>;
+  }
+}
+
+if (finalState) {
+  console.log("\n--- captured state ---");
+  console.log("nodeVersion:", finalState.nodeVersion);
+  console.log("info:", finalState.info);
+}
+
+await client.close();

--- a/examples/capture/package.json
+++ b/examples/capture/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "drej-example-capture",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0",
+    "@drejt/sqlite": "^0.0.1"
+  }
+}

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -23,7 +23,7 @@ export type StepDef =
       resourceLimits?: { cpu?: string; memory?: string; gpu?: string };
     }
   | { type: "exec_code"; code: string; context?: { id: string; language: string } }
-  | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string> }
+  | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string>; capture?: string }
   | { type: "delete_sandbox" }
   | { type: "write_file"; path: string; content: string; encoding?: "utf8" | "base64" }
   | { type: "snapshot" }
@@ -192,6 +192,7 @@ export function buildStep(def: StepDef): WorkflowStep {
           const command = `echo ${Buffer.from(raw).toString("base64")} | base64 -d | bash`;
           const events: SSEEvent[] = [];
           let exitCode = 0;
+          const stdoutChunks: string[] = [];
           for await (const ev of exec.executeCommand({ command, cwd: def.cwd, envs: def.envs })) {
             await ctx.emit({
               ts: Date.now(),
@@ -205,8 +206,13 @@ export function buildStep(def: StepDef): WorkflowStep {
               const code = Number(ev.error.evalue);
               if (!isNaN(code)) exitCode = code;
             }
+            if (def.capture && ev.type === "stdout" && ev.text) {
+              stdoutChunks.push(ev.text);
+            }
           }
-          return { ...state, commandEvents: events, exitCode };
+          const next: WorkflowState = { ...state, commandEvents: events, exitCode };
+          if (def.capture) next[def.capture] = stdoutChunks.join("").trimEnd();
+          return next;
         },
       };
 

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -55,13 +55,17 @@ export class SandboxStepBuilder {
   /**
    * Run a shell command inside the sandbox.
    *
+   * @param opts.capture Store stdout in workflow state under this key, making it
+   *   available for interpolation in subsequent steps via `{{key}}`.
+   *
    * @example
    * ```ts
    * s.exec("npm ci").exec("npm test")
    * s.exec("python script.py", { cwd: "/app" })
+   * s.exec("git rev-parse HEAD", { capture: "sha" }).exec("echo deploying {{sha}}")
    * ```
    */
-  exec(command: string, opts?: { cwd?: string; envs?: Record<string, string> }): this {
+  exec(command: string, opts?: { cwd?: string; envs?: Record<string, string>; capture?: string }): this {
     this._steps.push({ type: "exec_command", command, ...opts });
     return this;
   }


### PR DESCRIPTION
Collects stdout SSE events and trims the result into state[capture] so the value is immediately interpolatable in subsequent steps via {{key}}. Enables data pipelines without a file roundtrip.