### PR TITLE
feat: make sandbox lifecycle explicit

### DIFF
--- a/.changeset/sandbox-lifecycle.md
+++ b/.changeset/sandbox-lifecycle.md
@@ -1,0 +1,34 @@
+---
+"drej": minor
+"@drejt/core": minor
+---
+
+Make sandbox lifecycle explicit — no more implicit deletion
+
+Previously `workflow().sandbox(opts, fn)` automatically deleted the sandbox
+at the end of the workflow and on rollback. Sandbox lifecycle is now the
+caller's responsibility.
+
+**What changed:**
+
+- `sandbox()` no longer appends a `delete_sandbox` step or rolls back on failure
+- `sandbox()` now accepts an existing `Sandbox` object in place of `SandboxOpts`,
+  letting you pass a sandbox you created and manage yourself
+- Call `client.deleteSandbox(id)` explicitly when you are done with a sandbox
+
+```ts
+// Create a fresh sandbox — stays alive after the workflow
+const run = await client.run(
+  workflow("build").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
+    s.exec("npm ci").exec("npm test"),
+  ),
+);
+for await (const ev of run) { ... }
+await client.deleteSandbox(run.sandboxId); // explicit cleanup
+
+// Or manage the sandbox yourself
+const sb = await client.createSandbox({ image: { uri: "node:20-slim" } });
+await client.run(workflow("build").sandbox(sb, (s) => s.exec("npm test")));
+await client.run(workflow("lint").sandbox(sb, (s) => s.exec("npm run lint")));
+await client.deleteSandbox(sb.id);
+```

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -153,10 +153,6 @@ export function buildStep(def: StepDef): WorkflowStep {
 
           return { ...state, sandboxId: sb.id };
         },
-        async rollback(output: unknown, ctx: WorkflowRunContext): Promise<void> {
-          const state = output as WorkflowState;
-          if (state.sandboxId) await ctx.control.deleteSandbox(state.sandboxId);
-        },
       };
 
     case "exec_code":

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -275,9 +275,9 @@ export class DrejClient {
     w: WorkflowBuilder,
     options?: RunOptions,
   ): Promise<WorkflowRun> {
-    const { name, steps } = w.build();
+    const { name, steps, initialState } = w.build();
     const runId = crypto.randomUUID();
-    return new WorkflowRun(name, runId, this._execute(name, runId, steps, options));
+    return new WorkflowRun(name, runId, this._execute(name, runId, steps, options, initialState));
   }
 
   /**
@@ -354,6 +354,7 @@ export class DrejClient {
     runId: string,
     steps: StepDef[],
     options?: RunOptions,
+    initialState: Record<string, unknown> = {},
   ): AsyncGenerator<WorkflowEvent> {
     return this._makeStream(name, runId, async (teeDeps) => {
       const snapshotHook: WorkflowDeps["hooks"] = options?.snapshotConfig
@@ -379,7 +380,7 @@ export class DrejClient {
       const deps: WorkflowDeps = { ...teeDeps, hooks: snapshotHook };
       const wf = new Workflow(name, runId, steps.map(buildStep), deps);
       try {
-        await wf.run({});
+        await wf.run(initialState);
       } catch {
         try { await wf.rollback(); } catch { /* ignore */ }
       }

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -1,6 +1,6 @@
 import type { StepDef, Predicate } from "@drejt/core";
 import { validateWorkflow } from "@drejt/core";
-import type { ImageSpec, Resources } from "@drejt/opensandbox";
+import type { ImageSpec, Resources, Sandbox } from "@drejt/opensandbox";
 
 // Placeholder that serialises to {{name}} inside template literals.
 // Used as the `item` parameter in forEach callbacks so users write
@@ -303,16 +303,15 @@ class SandboxParallelBuilder {
 class WorkflowParallelBuilder {
   private _branches: StepDef[] = [];
 
-  sandbox(opts: SandboxOpts, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
+  sandbox(optsOrSandbox: SandboxOpts | Sandbox, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
     const sb = new SandboxStepBuilder();
     fn(sb);
+    const innerSteps = sb.build();
     this._branches.push({
       type: "sequence",
-      steps: [
-        { type: "create_sandbox", entrypoint: ["tail", "-f", "/dev/null"], ...opts },
-        ...sb.build(),
-        { type: "delete_sandbox" },
-      ],
+      steps: "id" in optsOrSandbox
+        ? innerSteps
+        : [{ type: "create_sandbox", entrypoint: ["tail", "-f", "/dev/null"], ...optsOrSandbox }, ...innerSteps],
     });
     return this;
   }
@@ -344,21 +343,42 @@ class WorkflowParallelBuilder {
  */
 export class WorkflowBuilder {
   private _steps: StepDef[] = [];
+  private _initialState: Record<string, unknown> = {};
 
   constructor(private _name: string) {}
 
   /**
-   * Add a sandbox step: creates a fresh sandbox, runs the steps defined in `fn`,
-   * then deletes the sandbox. The sandbox is torn down even if a step fails.
+   * Run steps inside a sandbox. Accepts either sandbox options to create a new
+   * sandbox, or an existing `Sandbox` object returned by `client.createSandbox()`.
+   *
+   * The sandbox is NOT deleted when the workflow completes — call
+   * `client.deleteSandbox(id)` explicitly when you are done with it.
+   *
+   * @example
+   * ```ts
+   * // Create a fresh sandbox for this workflow
+   * workflow("build").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
+   *   s.exec("npm ci").exec("npm test"),
+   * )
+   *
+   * // Reuse an existing sandbox
+   * const sb = await client.createSandbox({ image: { uri: "node:20-slim" } });
+   * workflow("build").sandbox(sb, (s) => s.exec("npm test"))
+   * await client.deleteSandbox(sb.id);
+   * ```
    */
-  sandbox(opts: SandboxOpts, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
+  sandbox(optsOrSandbox: SandboxOpts | Sandbox, fn: (s: SandboxStepBuilder) => SandboxStepBuilder): this {
     const sb = new SandboxStepBuilder();
     fn(sb);
-    this._steps.push(
-      { type: "create_sandbox", entrypoint: ["tail", "-f", "/dev/null"], ...opts },
-      ...sb.build(),
-      { type: "delete_sandbox" },
-    );
+    if ("id" in optsOrSandbox) {
+      this._initialState.sandboxId = optsOrSandbox.id;
+      this._steps.push(...sb.build());
+    } else {
+      this._steps.push(
+        { type: "create_sandbox", entrypoint: ["tail", "-f", "/dev/null"], ...optsOrSandbox },
+        ...sb.build(),
+      );
+    }
     return this;
   }
 
@@ -369,9 +389,9 @@ export class WorkflowBuilder {
     return this;
   }
 
-  build(): { name: string; steps: StepDef[] } {
+  build(): { name: string; steps: StepDef[]; initialState: Record<string, unknown> } {
     validateWorkflow(this._name, this._steps);
-    return { name: this._name, steps: this._steps };
+    return { name: this._name, steps: this._steps, initialState: this._initialState };
   }
 }
 


### PR DESCRIPTION
Remove implicit delete_sandbox from WorkflowBuilder.sandbox() and remove the rollback on create_sandbox. Sandbox stays alive after workflow completion — caller calls client.deleteSandbox() when done.

sandbox() now also accepts an existing Sandbox object so the same running sandbox can be reused across multiple workflow runs. A new set_sandbox step type injects the sandbox ID into workflow state without creating one.