### PR TITLE
feat: add typed workflow errors and strict exec option

### DIFF
--- a/.changeset/typed-errors.md
+++ b/.changeset/typed-errors.md
@@ -1,0 +1,8 @@
+---
+"drej": minor
+"@drejt/core": minor
+---
+
+Add typed workflow errors: `SandboxError`, `ExecConnectionError`, `CommandError`.
+
+Infra failures (sandbox boot failure, execd connection timeout) now throw typed errors instead of generic `Error`. Add `strict` option to `exec()` — when enabled, a non-zero exit code throws `CommandError` with the exit code attached. Errors propagate through the `WorkflowRun` async iterator so callers can catch them with a standard `try/catch` around the `for await` loop. All failures continue to be recorded in the ledger via `LedgerEvent.StepFailed`.

--- a/examples/error-handling/index.ts
+++ b/examples/error-handling/index.ts
@@ -1,0 +1,60 @@
+import { DrejClient, workflow, CommandError, SandboxError, ExecConnectionError } from "drej";
+import { SQLiteAdapter } from "@drejt/sqlite";
+
+const client = new DrejClient({
+  baseUrl: process.env.OPENSANDBOX_URL ?? "http://localhost:8080",
+  adapter: new SQLiteAdapter("./drej.db"),
+});
+await client.connect();
+
+// --- Pattern A: default (non-strict) ---
+// Non-zero exit puts exitCode in state; workflow continues.
+// Use when() to branch on success vs failure.
+console.log("\n=== Pattern A: non-strict exec with when() branching ===");
+const runA = await client.run(
+  workflow("error-handling-a").sandbox({ image: { uri: "debian:bookworm-slim" } }, (s) =>
+    s
+      .exec("exit 1")
+      .when({ op: "eq", field: "exitCode", value: 0 },
+        (s) => s.exec("echo success"),
+        (s) => s.exec("echo 'command failed, handled gracefully'"),
+      ),
+  ),
+);
+for await (const ev of runA) {
+  if (ev.event === "exec_event" && (ev.payload as { type: string; text?: string }).type === "stdout") {
+    process.stdout.write((ev.payload as { text: string }).text);
+  }
+}
+
+// --- Pattern B: strict exec ---
+// Non-zero exit throws CommandError with the exit code.
+// Catch it outside the for-await loop.
+console.log("\n=== Pattern B: strict exec — catch CommandError ===");
+const runB = await client.run(
+  workflow("error-handling-b").sandbox({ image: { uri: "debian:bookworm-slim" } }, (s) =>
+    s
+      .exec("echo 'about to fail'")
+      .exec("exit 42", { strict: true })
+      .exec("echo 'this line never runs'"),
+  ),
+);
+try {
+  for await (const ev of runB) {
+    if (ev.event === "exec_event" && (ev.payload as { type: string; text?: string }).type === "stdout") {
+      process.stdout.write((ev.payload as { text: string }).text);
+    }
+  }
+} catch (e) {
+  if (e instanceof CommandError) {
+    console.error(`CommandError: exit code ${e.exitCode} — "${e.command}"`);
+  } else if (e instanceof SandboxError) {
+    console.error(`SandboxError: ${e.message}`, e.sandboxId ? `(sandbox: ${e.sandboxId})` : "");
+  } else if (e instanceof ExecConnectionError) {
+    console.error(`ExecConnectionError: execd unreachable for sandbox ${e.sandboxId}`);
+  } else {
+    throw e;
+  }
+}
+
+await client.close();

--- a/examples/error-handling/package.json
+++ b/examples/error-handling/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "drej-example-error-handling",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "drej": "^0.5.0",
+    "@drejt/sqlite": "^0.0.1"
+  }
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,46 @@
+/** Base class for all drej workflow runtime errors. */
+export class WorkflowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowError";
+  }
+}
+
+/** Thrown when a sandbox fails to create, boot, or reach `Running` state. */
+export class SandboxError extends WorkflowError {
+  constructor(
+    message: string,
+    /** The sandbox ID, if one was assigned before the failure. */
+    public readonly sandboxId?: string,
+  ) {
+    super(message);
+    this.name = "SandboxError";
+  }
+}
+
+/**
+ * Thrown when execd inside a sandbox never becomes ready within the retry window.
+ * The sandbox is `Running` from the control plane's perspective, but the exec
+ * daemon is not accepting connections.
+ */
+export class ExecConnectionError extends WorkflowError {
+  constructor(public readonly sandboxId: string) {
+    super(`execd not ready for sandbox ${sandboxId}`);
+    this.name = "ExecConnectionError";
+  }
+}
+
+/**
+ * Thrown when an `exec()` step exits with a non-zero exit code and the
+ * `strict` option is enabled. Carries the exit code and original command.
+ */
+export class CommandError extends WorkflowError {
+  constructor(
+    public readonly exitCode: number,
+    public readonly command: string,
+    public readonly sandboxId: string,
+  ) {
+    super(`Command exited with code ${exitCode}: ${command}`);
+    this.name = "CommandError";
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,15 +4,14 @@ export type { LedgerEntry, IStorageAdapter } from "./ledger";
 export { LogLevel, ConsoleLogger, noopLogger } from "./logger";
 export type { ILogger } from "./logger";
 
+export { Workflow, WorkflowStatus } from "./workflow";
 export type {
   WorkflowRunContext,
   WorkflowStep,
   WorkflowCheckpoint,
-  WorkflowStatus,
   WorkflowDeps,
   WorkflowHooks,
 } from "./workflow";
-export { Workflow } from "./workflow";
 
 export { buildStep, resolveExecClient, shouldSnapshot, waitForSnapshot } from "./steps";
 export type { StepDef, Predicate, WorkflowState, SnapshotConfig } from "./steps";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,3 +18,5 @@ export { buildStep, resolveExecClient, shouldSnapshot, waitForSnapshot } from ".
 export type { StepDef, Predicate, WorkflowState, SnapshotConfig } from "./steps";
 
 export { validateWorkflow } from "./validate";
+
+export { WorkflowError, SandboxError, ExecConnectionError, CommandError } from "./errors";

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -1,4 +1,4 @@
-import { ControlClient, ExecClient } from "@drejt/opensandbox";
+import { ControlClient, ExecClient, SandboxState, SnapshotState, SSEEventType } from "@drejt/opensandbox";
 import type { SSEEvent } from "@drejt/opensandbox";
 import { LedgerEvent } from "./ledger";
 import { SandboxError, ExecConnectionError, CommandError } from "./errors";
@@ -85,8 +85,8 @@ export async function waitForSnapshot(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const snap = await control.getSnapshot(snapshotId);
-    if (snap.state === "Ready") return;
-    if (snap.state === "Failed") throw new Error(`Snapshot ${snapshotId} failed`);
+    if (snap.state === SnapshotState.Ready) return;
+    if (snap.state === SnapshotState.Failed) throw new Error(`Snapshot ${snapshotId} failed`);
     await new Promise<void>((r) => setTimeout(r, 2_000));
   }
   throw new Error(`Snapshot ${snapshotId} did not become ready within ${timeoutMs}ms`);
@@ -145,8 +145,8 @@ export function buildStep(def: StepDef): WorkflowStep {
           const deadline = Date.now() + 120_000;
           while (Date.now() < deadline) {
             const s = await ctx.control.getSandbox(sb.id);
-            if (s.status.state === "Running") break;
-            if (s.status.state === "Failed" || s.status.state === "Terminated") {
+            if (s.status.state === SandboxState.Running) break;
+            if (s.status.state === SandboxState.Failed || s.status.state === SandboxState.Terminated) {
               throw new SandboxError(
                 `Sandbox entered state ${s.status.state}: ${s.status.message ?? ""}`,
                 sb.id,
@@ -154,7 +154,7 @@ export function buildStep(def: StepDef): WorkflowStep {
             }
             await new Promise<void>((r) => setTimeout(r, 1_000));
           }
-          if ((await ctx.control.getSandbox(sb.id)).status.state !== "Running") {
+          if ((await ctx.control.getSandbox(sb.id)).status.state !== SandboxState.Running) {
             throw new SandboxError(`Sandbox timed out waiting to reach Running state`, sb.id);
           }
 
@@ -206,11 +206,11 @@ export function buildStep(def: StepDef): WorkflowStep {
               payload: ev,
             });
             events.push(ev as unknown as SSEEvent);
-            if (ev.type === "error" && ev.error?.evalue !== undefined) {
+            if (ev.type === SSEEventType.Error && ev.error?.evalue !== undefined) {
               const code = Number(ev.error.evalue);
               if (!isNaN(code)) exitCode = code;
             }
-            if (def.capture && ev.type === "stdout" && ev.text) {
+            if (def.capture && ev.type === SSEEventType.Stdout && ev.text) {
               stdoutChunks.push(ev.text);
             }
           }

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -1,6 +1,7 @@
 import { ControlClient, ExecClient } from "@drejt/opensandbox";
 import type { SSEEvent } from "@drejt/opensandbox";
 import { LedgerEvent } from "./ledger";
+import { SandboxError, ExecConnectionError, CommandError } from "./errors";
 import type { WorkflowRunContext, WorkflowStep } from "./workflow";
 
 // ── Step types ─────────────────────────────────────────────────────────────
@@ -23,7 +24,7 @@ export type StepDef =
       resourceLimits?: { cpu?: string; memory?: string; gpu?: string };
     }
   | { type: "exec_code"; code: string; context?: { id: string; language: string } }
-  | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string>; capture?: string }
+  | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string>; capture?: string; strict?: boolean }
   | { type: "delete_sandbox" }
   | { type: "write_file"; path: string; content: string; encoding?: "utf8" | "base64" }
   | { type: "read_file"; path: string; as: string; encoding?: "utf8" | "base64" }
@@ -61,7 +62,7 @@ export async function resolveExecClient(
       await client.listContexts();
       return client;
     } catch {
-      if (attempt === retries) throw new Error(`execd not ready after ${retries}s for sandbox ${sandboxId}`);
+      if (attempt === retries) throw new ExecConnectionError(sandboxId);
       await new Promise<void>((r) => setTimeout(r, delayMs));
     }
   }
@@ -146,9 +147,15 @@ export function buildStep(def: StepDef): WorkflowStep {
             const s = await ctx.control.getSandbox(sb.id);
             if (s.status.state === "Running") break;
             if (s.status.state === "Failed" || s.status.state === "Terminated") {
-              throw new Error(`Sandbox ${sb.id} entered state ${s.status.state}: ${s.status.message ?? ""}`);
+              throw new SandboxError(
+                `Sandbox entered state ${s.status.state}: ${s.status.message ?? ""}`,
+                sb.id,
+              );
             }
             await new Promise<void>((r) => setTimeout(r, 1_000));
+          }
+          if ((await ctx.control.getSandbox(sb.id)).status.state !== "Running") {
+            throw new SandboxError(`Sandbox timed out waiting to reach Running state`, sb.id);
           }
 
           return { ...state, sandboxId: sb.id };
@@ -209,6 +216,9 @@ export function buildStep(def: StepDef): WorkflowStep {
           }
           const next: WorkflowState = { ...state, commandEvents: events, exitCode };
           if (def.capture) next[def.capture] = stdoutChunks.join("").trimEnd();
+          if (def.strict && exitCode !== 0) {
+            throw new CommandError(exitCode, def.command, state.sandboxId!);
+          }
           return next;
         },
       };

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -27,7 +27,13 @@ export interface WorkflowCheckpoint {
   timestamp: number;
 }
 
-export type WorkflowStatus = "idle" | "running" | "completed" | "failed" | "rolled_back";
+export enum WorkflowStatus {
+  Idle = "idle",
+  Running = "running",
+  Completed = "completed",
+  Failed = "failed",
+  RolledBack = "rolled_back",
+}
 
 export interface WorkflowHooks {
   onStepStart?(info: { workflowName: string; runId: string; stepIndex: number; stepId: string }): void | Promise<void>;
@@ -49,7 +55,7 @@ export interface WorkflowDeps {
 export class Workflow {
   readonly name: string;
   readonly runId: string;
-  private _status: WorkflowStatus = "idle";
+  private _status: WorkflowStatus = WorkflowStatus.Idle;
   private readonly completedSteps = new Map<number, { output: unknown; completedAt: number }>();
   private readonly log: ILogger;
 
@@ -82,7 +88,7 @@ export class Workflow {
   }
 
   async run(input: unknown, startFromStep = 0): Promise<unknown> {
-    this._status = "running";
+    this._status = WorkflowStatus.Running;
     this.log.info("workflow started", { workflowName: this.name, runId: this.runId, startFromStep, totalSteps: this.steps.length });
 
     let current: unknown =
@@ -121,7 +127,7 @@ export class Workflow {
           payload: this.snapshot(),
         });
       } catch (err) {
-        this._status = "failed";
+        this._status = WorkflowStatus.Failed;
         const error = err instanceof Error ? err : new Error(String(err));
         this.log.error("step failed", { workflowName: this.name, runId: this.runId, stepIndex: i, stepId: step.id, error: error.message });
         await this.callHook("onStepFailed", { workflowName: this.name, runId: this.runId, stepIndex: i, stepId: step.id, error });
@@ -138,7 +144,7 @@ export class Workflow {
       }
     }
 
-    this._status = "completed";
+    this._status = WorkflowStatus.Completed;
     this.log.info("workflow complete", { workflowName: this.name, runId: this.runId });
     await this.deps.adapter.append({
       ts: Date.now(),
@@ -175,7 +181,7 @@ export class Workflow {
       }
     }
 
-    this._status = "rolled_back";
+    this._status = WorkflowStatus.RolledBack;
     this.log.info("workflow rolled back", { workflowName: this.name, runId: this.runId });
     await this.deps.adapter.append({
       ts: Date.now(),

--- a/packages/opensandbox/src/control.ts
+++ b/packages/opensandbox/src/control.ts
@@ -1,9 +1,9 @@
+import { SnapshotState } from "./types";
 import type {
   Sandbox,
   CreateSandboxOptions,
   ListSandboxesOptions,
   Snapshot,
-  SnapshotState,
   ListSnapshotsOptions,
   SandboxEndpoint,
   DiagnosticLog,

--- a/packages/opensandbox/src/exec.ts
+++ b/packages/opensandbox/src/exec.ts
@@ -1,6 +1,6 @@
+import { SSEEventType } from "./types";
 import type {
   SSEEvent,
-  SSEEventType,
   CodeContext,
   ExecuteCodeOptions,
   ExecuteCommandOptions,
@@ -37,7 +37,7 @@ async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSE
             else if (line.startsWith("data:")) data = line.slice(5).trim();
           }
           if (data !== undefined) {
-            yield { type: (type ?? "message") as SSEEventType, ...JSON.parse(data) };
+            yield { type: (type ?? SSEEventType.Message) as SSEEventType, ...JSON.parse(data) };
           }
         }
       }

--- a/packages/opensandbox/src/index.ts
+++ b/packages/opensandbox/src/index.ts
@@ -1,22 +1,20 @@
 export { ControlClient, OpenSandboxError } from "./control";
 export { ExecClient } from "./exec";
+export { SandboxState, SnapshotState, SSEEventType } from "./types";
 export type {
   Resources,
   ImageAuth,
   ImageSpec,
   Sandbox,
-  SandboxState,
   SandboxStatus,
   CreateSandboxOptions,
   ListSandboxesOptions,
   Snapshot,
-  SnapshotState,
   ListSnapshotsOptions,
   SandboxEndpoint,
   DiagnosticLog,
   DiagnosticEvent,
   SSEEvent,
-  SSEEventType,
   CodeContext,
   ExecuteCodeOptions,
   ExecuteCommandOptions,

--- a/packages/opensandbox/src/types.ts
+++ b/packages/opensandbox/src/types.ts
@@ -14,16 +14,17 @@ export interface ImageSpec {
   auth?: ImageAuth;
 }
 
-export type SandboxState =
-  | "Pending"
-  | "Running"
-  | "Pausing"
-  | "Paused"
-  | "Resuming"
-  | "Stopping"
-  | "Terminated"
-  | "Failed"
-  | "Unknown";
+export enum SandboxState {
+  Pending = "Pending",
+  Running = "Running",
+  Pausing = "Pausing",
+  Paused = "Paused",
+  Resuming = "Resuming",
+  Stopping = "Stopping",
+  Terminated = "Terminated",
+  Failed = "Failed",
+  Unknown = "Unknown",
+}
 
 export interface SandboxStatus {
   state: SandboxState;
@@ -61,7 +62,13 @@ export interface ListSandboxesOptions {
   offset?: number;
 }
 
-export type SnapshotState = "Pending" | "Committing" | "Pushing" | "Ready" | "Failed";
+export enum SnapshotState {
+  Pending = "Pending",
+  Committing = "Committing",
+  Pushing = "Pushing",
+  Ready = "Ready",
+  Failed = "Failed",
+}
 
 export interface Snapshot {
   id: string;
@@ -95,17 +102,18 @@ export interface DiagnosticEvent {
   message: string;
 }
 
-export type SSEEventType =
-  | "init"
-  | "status"
-  | "stdout"
-  | "stderr"
-  | "result"
-  | "execution_complete"
-  | "execution_count"
-  | "error"
-  | "ping"
-  | "message";
+export enum SSEEventType {
+  Init = "init",
+  Status = "status",
+  Stdout = "stdout",
+  Stderr = "stderr",
+  Result = "result",
+  ExecutionComplete = "execution_complete",
+  ExecutionCount = "execution_count",
+  Error = "error",
+  Ping = "ping",
+  Message = "message",
+}
 
 export interface SSEEvent {
   type: SSEEventType;

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -11,11 +11,11 @@ import {
   type SnapshotConfig,
   type StepDef,
 } from "@drejt/core";
-export { WorkflowError, SandboxError, ExecConnectionError, CommandError } from "@drejt/core";
+export { WorkflowError, SandboxError, ExecConnectionError, CommandError, WorkflowStatus } from "@drejt/core";
 import {
   ControlClient,
+  SandboxState,
   type Sandbox,
-  type SandboxState,
   type CreateSandboxOptions,
   type ListSandboxesOptions,
   type Snapshot,
@@ -29,7 +29,6 @@ export { LedgerEvent };
 export type { LedgerEntry, SnapshotConfig, StepDef, IStorageAdapter };
 export type {
   Sandbox,
-  SandboxState,
   CreateSandboxOptions,
   ListSandboxesOptions,
   Snapshot,
@@ -37,7 +36,8 @@ export type {
   DiagnosticLog,
   DiagnosticEvent,
 } from "@drejt/opensandbox";
-export type { SandboxStatus, SnapshotState, Resources, ImageSpec, ImageAuth } from "@drejt/opensandbox";
+export { SandboxState, SnapshotState, SSEEventType } from "@drejt/opensandbox";
+export type { SandboxStatus, Resources, ImageSpec, ImageAuth } from "@drejt/opensandbox";
 
 /** Thrown when an OpenSandbox API call returns a non-2xx response. */
 export class DrejError extends Error {
@@ -209,8 +209,8 @@ export class DrejClient {
     while (Date.now() < deadline) {
       const sandbox = await this.control.getSandbox(id);
       const { state } = sandbox.status;
-      if (state === "Running") return sandbox;
-      if (state === "Failed" || state === "Terminated") {
+      if (state === SandboxState.Running) return sandbox;
+      if (state === SandboxState.Failed || state === SandboxState.Terminated) {
         throw new DrejError(`Sandbox ${id} entered state ${state}`, 500);
       }
       await new Promise<void>((r) => setTimeout(r, pollIntervalMs));

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -11,6 +11,7 @@ import {
   type SnapshotConfig,
   type StepDef,
 } from "@drejt/core";
+export { WorkflowError, SandboxError, ExecConnectionError, CommandError } from "@drejt/core";
 import {
   ControlClient,
   type Sandbox,
@@ -381,8 +382,9 @@ export class DrejClient {
       const wf = new Workflow(name, runId, steps.map(buildStep), deps);
       try {
         await wf.run(initialState);
-      } catch {
+      } catch (err) {
         try { await wf.rollback(); } catch { /* ignore */ }
+        throw err;
       }
     });
   }
@@ -424,12 +426,11 @@ export class DrejClient {
     // Emit run_started before kicking off execution
     enqueue({ ts: Date.now(), workflowName: name, runId, stepIndex: -1, event: LedgerEvent.RunStarted, payload: { workflowName: name, runId } });
 
-    execute(teeDeps).finally(() => {
-      done = true;
-      const fn = wakeup;
-      wakeup = null;
-      fn?.();
-    });
+    let executionError: unknown = undefined;
+    execute(teeDeps).then(
+      () => { done = true; const fn = wakeup; wakeup = null; fn?.(); },
+      (err) => { executionError = err; done = true; const fn = wakeup; wakeup = null; fn?.(); },
+    );
 
     return (async function* () {
       while (true) {
@@ -438,6 +439,7 @@ export class DrejClient {
         await new Promise<void>((r) => { wakeup = r; });
       }
       while (queue.length > 0) yield queue.shift()!;
+      if (executionError !== undefined) throw executionError;
     })();
   }
 }

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -57,15 +57,19 @@ export class SandboxStepBuilder {
    *
    * @param opts.capture Store stdout in workflow state under this key, making it
    *   available for interpolation in subsequent steps via `{{key}}`.
+   * @param opts.strict Throw a `CommandError` if the command exits with a non-zero
+   *   code. When `false` (default), the exit code is stored in state as `exitCode`
+   *   and the workflow continues — use `when({ field: "exitCode", eq: 0 }, ...)` to branch.
    *
    * @example
    * ```ts
    * s.exec("npm ci").exec("npm test")
    * s.exec("python script.py", { cwd: "/app" })
    * s.exec("git rev-parse HEAD", { capture: "sha" }).exec("echo deploying {{sha}}")
+   * s.exec("npm test", { strict: true }) // throws CommandError on non-zero exit
    * ```
    */
-  exec(command: string, opts?: { cwd?: string; envs?: Record<string, string>; capture?: string }): this {
+  exec(command: string, opts?: { cwd?: string; envs?: Record<string, string>; capture?: string; strict?: boolean }): this {
     this._steps.push({ type: "exec_command", command, ...opts });
     return this;
   }


### PR DESCRIPTION
Throw SandboxError, ExecConnectionError, and CommandError from the workflow engine instead of generic Error. The new strict option on exec() lets callers opt into throwing CommandError on non-zero exit. Errors now propagate through the WorkflowRun async iterator so callers can catch them with a standard try/catch around the for-await loop.