### PR TITLE
chore: add examples to workspace and use workspace:* references

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,9 +8,73 @@
         "@changesets/cli": "^2.31.0",
       },
     },
+    "examples/capture": {
+      "name": "drej-example-capture",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/control-flow": {
+      "name": "drej-example-control-flow",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/error-handling": {
+      "name": "drej-example-error-handling",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/exec-code": {
+      "name": "drej-example-exec-code",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/hello-world": {
+      "name": "drej-example-hello-world",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/read-file": {
+      "name": "drej-example-read-file",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/run-bash-script": {
+      "name": "drej-example-run-bash-script",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
+    "examples/snapshot-replay": {
+      "name": "drej-example-snapshot-replay",
+      "version": "0.0.0",
+      "dependencies": {
+        "@drejt/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
     "packages/adapters/postgres": {
       "name": "@drejt/postgres",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@drejt/core": "workspace:*",
         "postgres": "^3.4.5",
@@ -22,7 +86,7 @@
     },
     "packages/adapters/sqlite": {
       "name": "@drejt/sqlite",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@drejt/core": "workspace:*",
       },
@@ -33,7 +97,7 @@
     },
     "packages/core": {
       "name": "@drejt/core",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@drejt/opensandbox": "workspace:*",
       },
@@ -44,7 +108,7 @@
     },
     "packages/opensandbox": {
       "name": "@drejt/opensandbox",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "latest",
@@ -52,7 +116,7 @@
     },
     "packages/sdks/typescript": {
       "name": "drej",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "dependencies": {
         "@drejt/core": "workspace:*",
         "@drejt/opensandbox": "workspace:*",
@@ -276,6 +340,22 @@
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
     "drej": ["drej@workspace:packages/sdks/typescript"],
+
+    "drej-example-capture": ["drej-example-capture@workspace:examples/capture"],
+
+    "drej-example-control-flow": ["drej-example-control-flow@workspace:examples/control-flow"],
+
+    "drej-example-error-handling": ["drej-example-error-handling@workspace:examples/error-handling"],
+
+    "drej-example-exec-code": ["drej-example-exec-code@workspace:examples/exec-code"],
+
+    "drej-example-hello-world": ["drej-example-hello-world@workspace:examples/hello-world"],
+
+    "drej-example-read-file": ["drej-example-read-file@workspace:examples/read-file"],
+
+    "drej-example-run-bash-script": ["drej-example-run-bash-script@workspace:examples/run-bash-script"],
+
+    "drej-example-snapshot-replay": ["drej-example-snapshot-replay@workspace:examples/snapshot-replay"],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 

--- a/examples/capture/package.json
+++ b/examples/capture/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/control-flow/package.json
+++ b/examples/control-flow/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/error-handling/package.json
+++ b/examples/error-handling/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/exec-code/package.json
+++ b/examples/exec-code/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/read-file/package.json
+++ b/examples/read-file/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/run-bash-script/package.json
+++ b/examples/run-bash-script/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/examples/snapshot-replay/package.json
+++ b/examples/snapshot-replay/package.json
@@ -6,7 +6,7 @@
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "^0.5.0",
-    "@drejt/sqlite": "^0.0.1"
+    "drej": "workspace:*",
+    "@drejt/sqlite": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "packages/opensandbox",
     "packages/sdks/typescript",
     "packages/adapters/postgres",
-    "packages/adapters/sqlite"
+    "packages/adapters/sqlite",
+    "examples/*"
   ],
   "scripts": {
     "build": "bunx tsc --project packages/opensandbox/tsconfig.build.json && bunx tsc --project packages/core/tsconfig.build.json && bun run --cwd packages/sdks/typescript build",


### PR DESCRIPTION
Adds examples/* to the root bun workspace so example packages resolve drej and @drejt/sqlite from the local monorepo instead of npm. This decouples examples from published npm versions and lets them always use the latest in-repo code.