### PR TITLE
chore: add publishConfig access public to all packages

### DIFF
--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drejt/postgres",
   "version": "0.1.2",
-  "private": false,
+  "publishConfig": { "access": "public" },
   "main": "./src/index.ts",
   "dependencies": {
     "postgres": "^3.4.5",

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drejt/sqlite",
   "version": "0.1.2",
-  "private": false,
+  "publishConfig": { "access": "public" },
   "main": "./src/index.ts",
   "dependencies": {
     "@drejt/core": "workspace:*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "files": [
     "dist"
   ],
+  "publishConfig": { "access": "public" },
   "scripts": {
     "build:types": "tsc --project tsconfig.build.json"
   },

--- a/packages/opensandbox/package.json
+++ b/packages/opensandbox/package.json
@@ -6,6 +6,7 @@
   "files": [
     "dist"
   ],
+  "publishConfig": { "access": "public" },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",
     "build:types": "tsc --project tsconfig.build.json"

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -13,6 +13,7 @@
   "files": [
     "dist"
   ],
+  "publishConfig": { "access": "public" },
   "scripts": {
     "build": "tsup"
   },


### PR DESCRIPTION
Scoped npm packages default to private on first publish. Without this, changeset publish gets E404 from the registry.