### PR TITLE
feat: add OpenTelemetry adapter and typed workflow hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
       "name": "drej-example-capture",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -20,7 +20,7 @@
       "name": "drej-example-control-flow",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -28,7 +28,7 @@
       "name": "drej-example-error-handling",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -36,7 +36,7 @@
       "name": "drej-example-exec-code",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -44,7 +44,7 @@
       "name": "drej-example-hello-world",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -52,7 +52,7 @@
       "name": "drej-example-read-file",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -60,7 +60,7 @@
       "name": "drej-example-run-bash-script",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
@@ -68,15 +68,30 @@
       "name": "drej-example-snapshot-replay",
       "version": "0.0.0",
       "dependencies": {
-        "@drejt/sqlite": "workspace:*",
+        "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
       },
     },
-    "packages/adapters/postgres": {
-      "name": "@drejt/postgres",
-      "version": "0.1.1",
+    "packages/adapters/otel": {
+      "name": "@drej/otel",
+      "version": "0.1.0",
       "dependencies": {
-        "@drejt/core": "workspace:*",
+        "@drej/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "bun-types": "latest",
+        "typescript": "latest",
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0",
+      },
+    },
+    "packages/adapters/postgres": {
+      "name": "@drej/postgres",
+      "version": "0.1.2",
+      "dependencies": {
+        "@drej/core": "workspace:*",
         "postgres": "^3.4.5",
       },
       "devDependencies": {
@@ -85,10 +100,10 @@
       },
     },
     "packages/adapters/sqlite": {
-      "name": "@drejt/sqlite",
-      "version": "0.1.1",
+      "name": "@drej/sqlite",
+      "version": "0.1.2",
       "dependencies": {
-        "@drejt/core": "workspace:*",
+        "@drej/core": "workspace:*",
       },
       "devDependencies": {
         "bun-types": "latest",
@@ -96,10 +111,10 @@
       },
     },
     "packages/core": {
-      "name": "@drejt/core",
-      "version": "0.1.1",
+      "name": "@drej/core",
+      "version": "0.2.0",
       "dependencies": {
-        "@drejt/opensandbox": "workspace:*",
+        "@drej/opensandbox": "workspace:*",
       },
       "devDependencies": {
         "bun-types": "latest",
@@ -107,8 +122,8 @@
       },
     },
     "packages/opensandbox": {
-      "name": "@drejt/opensandbox",
-      "version": "0.1.1",
+      "name": "@drej/opensandbox",
+      "version": "0.1.2",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "latest",
@@ -116,10 +131,10 @@
     },
     "packages/sdks/typescript": {
       "name": "drej",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
-        "@drejt/core": "workspace:*",
-        "@drejt/opensandbox": "workspace:*",
+        "@drej/core": "workspace:*",
+        "@drej/opensandbox": "workspace:*",
       },
       "devDependencies": {
         "bun-types": "latest",
@@ -165,13 +180,15 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@drejt/core": ["@drejt/core@workspace:packages/core"],
+    "@drej/core": ["@drej/core@workspace:packages/core"],
 
-    "@drejt/opensandbox": ["@drejt/opensandbox@workspace:packages/opensandbox"],
+    "@drej/opensandbox": ["@drej/opensandbox@workspace:packages/opensandbox"],
 
-    "@drejt/postgres": ["@drejt/postgres@workspace:packages/adapters/postgres"],
+    "@drej/otel": ["@drej/otel@workspace:packages/adapters/otel"],
 
-    "@drejt/sqlite": ["@drejt/sqlite@workspace:packages/adapters/sqlite"],
+    "@drej/postgres": ["@drej/postgres@workspace:packages/adapters/postgres"],
+
+    "@drej/sqlite": ["@drej/sqlite@workspace:packages/adapters/sqlite"],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -244,6 +261,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "packages/sdks/typescript",
     "packages/adapters/postgres",
     "packages/adapters/sqlite",
+    "packages/adapters/otel",
     "examples/*"
   ],
   "scripts": {
     "build": "bunx tsc --project packages/opensandbox/tsconfig.build.json && bunx tsc --project packages/core/tsconfig.build.json && bun run --cwd packages/sdks/typescript build",
-    "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json"
+    "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/otel/tsconfig.json"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0"

--- a/packages/adapters/otel/package.json
+++ b/packages/adapters/otel/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@drej/otel",
+  "version": "0.1.0",
+  "publishConfig": { "access": "public" },
+  "main": "./src/index.ts",
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0"
+  },
+  "dependencies": {
+    "@drej/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "bun-types": "latest",
+    "typescript": "latest"
+  }
+}

--- a/packages/adapters/otel/src/index.ts
+++ b/packages/adapters/otel/src/index.ts
@@ -1,0 +1,117 @@
+import type { Tracer, Span, SpanStatusCode } from "@opentelemetry/api";
+import { SpanStatusCode as StatusCode, context, trace } from "@opentelemetry/api";
+import type {
+  WorkflowHooks,
+  StepHookInfo,
+  StepCompleteHookInfo,
+  StepFailedHookInfo,
+  WorkflowCompleteHookInfo,
+  WorkflowFailedHookInfo,
+  WorkflowHookInfo,
+} from "@drej/core";
+
+export interface OtelHooksOptions {
+  /** Include sandbox ID as a span attribute when present in step output. Default: true. */
+  recordSandboxId?: boolean;
+  /** Include exit code as a span attribute on exec_command steps. Default: true. */
+  recordExitCode?: boolean;
+}
+
+/**
+ * Returns `WorkflowHooks` that emit OpenTelemetry traces for every workflow run.
+ *
+ * Pass the result to `client.run(wf, { hooks: otelHooks(tracer) })`.
+ *
+ * Span structure:
+ * ```
+ * workflow.run          ← root span, name = workflow name
+ *   workflow.step       ← child per step, name = step type
+ *   workflow.step
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { otelHooks } from "@drej/otel";
+ * import { trace } from "@opentelemetry/api";
+ *
+ * const tracer = trace.getTracer("my-app");
+ * const run = await client.run(wf, { hooks: otelHooks(tracer) });
+ * ```
+ */
+export function otelHooks(tracer: Tracer, opts: OtelHooksOptions = {}): WorkflowHooks {
+  const { recordSandboxId = true, recordExitCode = true } = opts;
+
+  let rootSpan: Span | undefined;
+  let rootCtx: ReturnType<typeof context.active> | undefined;
+  const stepSpans = new Map<number, Span>();
+
+  return {
+    onWorkflowStart({ workflowName, runId }: WorkflowHookInfo) {
+      rootCtx = context.active();
+      rootSpan = tracer.startSpan(
+        "workflow.run",
+        {
+          attributes: {
+            "drej.workflow.name": workflowName,
+            "drej.run.id": runId,
+          },
+        },
+        rootCtx,
+      );
+    },
+
+    onStepStart({ stepIndex, stepId }: StepHookInfo) {
+      if (!rootSpan || !rootCtx) return;
+      const spanCtx = trace.setSpan(rootCtx, rootSpan);
+      const span = tracer.startSpan(
+        "workflow.step",
+        {
+          attributes: {
+            "drej.step.index": stepIndex,
+            "drej.step.type": stepId,
+          },
+        },
+        spanCtx,
+      );
+      stepSpans.set(stepIndex, span);
+    },
+
+    onStepComplete({ stepIndex, output }: StepCompleteHookInfo) {
+      const span = stepSpans.get(stepIndex);
+      if (!span) return;
+      if (recordSandboxId) {
+        const sandboxId = (output as Record<string, unknown>)?.sandboxId;
+        if (typeof sandboxId === "string") span.setAttribute("drej.sandbox.id", sandboxId);
+      }
+      if (recordExitCode) {
+        const exitCode = (output as Record<string, unknown>)?.exitCode;
+        if (typeof exitCode === "number") span.setAttribute("process.exit_code", exitCode);
+      }
+      span.setStatus({ code: StatusCode.OK });
+      span.end();
+      stepSpans.delete(stepIndex);
+    },
+
+    onStepFailed({ stepIndex, error }: StepFailedHookInfo) {
+      const span = stepSpans.get(stepIndex);
+      if (!span) return;
+      span.recordException(error);
+      span.setStatus({ code: StatusCode.ERROR, message: error.message });
+      span.end();
+      stepSpans.delete(stepIndex);
+    },
+
+    onWorkflowComplete(_info: WorkflowCompleteHookInfo) {
+      rootSpan?.setStatus({ code: StatusCode.OK });
+      rootSpan?.end();
+      rootSpan = undefined;
+    },
+
+    onWorkflowFailed({ error }: WorkflowFailedHookInfo) {
+      rootSpan?.recordException(error);
+      rootSpan?.setStatus({ code: StatusCode.ERROR, message: error.message });
+      rootSpan?.end();
+      rootSpan = undefined;
+    },
+  };
+}

--- a/packages/adapters/otel/tsconfig.json
+++ b/packages/adapters/otel/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,13 +4,19 @@ export type { LedgerEntry, IStorageAdapter } from "./ledger";
 export { LogLevel, ConsoleLogger, noopLogger } from "./logger";
 export type { ILogger } from "./logger";
 
-export { Workflow, WorkflowStatus } from "./workflow";
+export { Workflow, WorkflowStatus, mergeHooks } from "./workflow";
 export type {
   WorkflowRunContext,
   WorkflowStep,
   WorkflowCheckpoint,
   WorkflowDeps,
   WorkflowHooks,
+  WorkflowHookInfo,
+  StepHookInfo,
+  StepCompleteHookInfo,
+  StepFailedHookInfo,
+  WorkflowCompleteHookInfo,
+  WorkflowFailedHookInfo,
 } from "./workflow";
 
 export { buildStep, resolveExecClient, shouldSnapshot, waitForSnapshot } from "./steps";

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -1,4 +1,4 @@
-import { ControlClient, ExecClient, SandboxState, SnapshotState, SSEEventType } from "@drej/opensandbox";
+import { ControlClient, ExecClient, SandboxState, SnapshotState, SSEEventType, CodeLanguage } from "@drej/opensandbox";
 import type { SSEEvent } from "@drej/opensandbox";
 import { LedgerEvent } from "./ledger";
 import { SandboxError, ExecConnectionError, CommandError } from "./errors";
@@ -23,7 +23,7 @@ export type StepDef =
       metadata?: Record<string, string>;
       resourceLimits?: { cpu?: string; memory?: string; gpu?: string };
     }
-  | { type: "exec_code"; code: string; context?: { id: string; language: string } }
+  | { type: "exec_code"; code: string; context?: { id: string; language: CodeLanguage } }
   | { type: "exec_command"; command: string; cwd?: string; envs?: Record<string, string>; capture?: string; strict?: boolean }
   | { type: "delete_sandbox" }
   | { type: "write_file"; path: string; content: string; encoding?: "utf8" | "base64" }

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -35,13 +35,64 @@ export enum WorkflowStatus {
   RolledBack = "rolled_back",
 }
 
+export interface WorkflowHookInfo {
+  workflowName: string;
+  runId: string;
+}
+
+export interface StepHookInfo extends WorkflowHookInfo {
+  stepIndex: number;
+  stepId: string;
+}
+
+export interface StepCompleteHookInfo extends StepHookInfo {
+  output: unknown;
+}
+
+export interface StepFailedHookInfo extends StepHookInfo {
+  error: Error;
+}
+
+export interface WorkflowCompleteHookInfo extends WorkflowHookInfo {
+  output: unknown;
+}
+
+export interface WorkflowFailedHookInfo extends WorkflowHookInfo {
+  error: Error;
+}
+
 export interface WorkflowHooks {
-  onStepStart?(info: { workflowName: string; runId: string; stepIndex: number; stepId: string }): void | Promise<void>;
-  onStepComplete?(info: { workflowName: string; runId: string; stepIndex: number; stepId: string; output: unknown }): void | Promise<void>;
-  onStepFailed?(info: { workflowName: string; runId: string; stepIndex: number; stepId: string; error: Error }): void | Promise<void>;
-  onStepRolledBack?(info: { workflowName: string; runId: string; stepIndex: number; stepId: string }): void | Promise<void>;
-  onWorkflowComplete?(info: { workflowName: string; runId: string; output: unknown }): void | Promise<void>;
-  onWorkflowFailed?(info: { workflowName: string; runId: string; error: Error }): void | Promise<void>;
+  onWorkflowStart?(info: WorkflowHookInfo): void | Promise<void>;
+  onStepStart?(info: StepHookInfo): void | Promise<void>;
+  onStepComplete?(info: StepCompleteHookInfo): void | Promise<void>;
+  onStepFailed?(info: StepFailedHookInfo): void | Promise<void>;
+  onStepRolledBack?(info: StepHookInfo): void | Promise<void>;
+  onWorkflowComplete?(info: WorkflowCompleteHookInfo): void | Promise<void>;
+  onWorkflowFailed?(info: WorkflowFailedHookInfo): void | Promise<void>;
+}
+
+export function mergeHooks(...hooks: (WorkflowHooks | undefined)[]): WorkflowHooks {
+  const defined = hooks.filter((h): h is WorkflowHooks => h !== undefined);
+  if (defined.length === 0) return {};
+  if (defined.length === 1) return defined[0];
+  const call = async <K extends keyof WorkflowHooks>(
+    name: K,
+    info: Parameters<NonNullable<WorkflowHooks[K]>>[0],
+  ) => {
+    for (const h of defined) {
+      const fn = h[name] as ((i: typeof info) => void | Promise<void>) | undefined;
+      if (fn) await fn(info);
+    }
+  };
+  return {
+    onWorkflowStart: (info) => call("onWorkflowStart", info),
+    onStepStart: (info) => call("onStepStart", info),
+    onStepComplete: (info) => call("onStepComplete", info),
+    onStepFailed: (info) => call("onStepFailed", info),
+    onStepRolledBack: (info) => call("onStepRolledBack", info),
+    onWorkflowComplete: (info) => call("onWorkflowComplete", info),
+    onWorkflowFailed: (info) => call("onWorkflowFailed", info),
+  };
 }
 
 export interface WorkflowDeps {
@@ -90,6 +141,7 @@ export class Workflow {
   async run(input: unknown, startFromStep = 0): Promise<unknown> {
     this._status = WorkflowStatus.Running;
     this.log.info("workflow started", { workflowName: this.name, runId: this.runId, startFromStep, totalSteps: this.steps.length });
+    await this.callHook("onWorkflowStart", { workflowName: this.name, runId: this.runId });
 
     let current: unknown =
       startFromStep > 0 ? (this.completedSteps.get(startFromStep - 1)?.output ?? input) : input;

--- a/packages/opensandbox/src/index.ts
+++ b/packages/opensandbox/src/index.ts
@@ -1,6 +1,6 @@
 export { ControlClient, OpenSandboxError } from "./control";
 export { ExecClient } from "./exec";
-export { SandboxState, SnapshotState, SSEEventType } from "./types";
+export { SandboxState, SnapshotState, SSEEventType, CodeLanguage } from "./types";
 export type {
   Resources,
   ImageAuth,

--- a/packages/opensandbox/src/types.ts
+++ b/packages/opensandbox/src/types.ts
@@ -125,9 +125,18 @@ export interface SSEEvent {
   timestamp: number;
 }
 
+export enum CodeLanguage {
+  Python = "python",
+  JavaScript = "javascript",
+  TypeScript = "typescript",
+  Go = "go",
+  Java = "java",
+  Bash = "bash",
+}
+
 export interface CodeContext {
   id: string;
-  language: string;
+  language: CodeLanguage;
 }
 
 // POST /code body
@@ -135,7 +144,7 @@ export interface ExecuteCodeOptions {
   code: string;
   context?: {
     id: string;
-    language: string;
+    language: CodeLanguage;
   };
 }
 

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -5,13 +5,24 @@ import {
   resolveExecClient,
   shouldSnapshot,
   waitForSnapshot,
+  mergeHooks,
   type WorkflowDeps,
+  type WorkflowHooks,
   type IStorageAdapter,
   type LedgerEntry,
   type SnapshotConfig,
   type StepDef,
 } from "@drej/core";
 export { WorkflowError, SandboxError, ExecConnectionError, CommandError, WorkflowStatus } from "@drej/core";
+export type {
+  WorkflowHooks,
+  WorkflowHookInfo,
+  StepHookInfo,
+  StepCompleteHookInfo,
+  StepFailedHookInfo,
+  WorkflowCompleteHookInfo,
+  WorkflowFailedHookInfo,
+} from "@drej/core";
 import {
   ControlClient,
   SandboxState,
@@ -70,6 +81,8 @@ export interface DrejClientOptions {
 export interface RunOptions {
   /** Capture a sandbox snapshot after specific step indices complete. */
   snapshotConfig?: SnapshotConfig;
+  /** Lifecycle hooks for observability (e.g. pass `otelHooks(tracer)` from `@drej/otel`). */
+  hooks?: WorkflowHooks;
 }
 
 /**
@@ -378,7 +391,7 @@ export class DrejClient {
           }
         : undefined;
 
-      const deps: WorkflowDeps = { ...teeDeps, hooks: snapshotHook };
+      const deps: WorkflowDeps = { ...teeDeps, hooks: mergeHooks(snapshotHook, options?.hooks) };
       const wf = new Workflow(name, runId, steps.map(buildStep), deps);
       try {
         await wf.run(initialState);

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -19,8 +19,15 @@ export type {
   ImageAuth,
   DiagnosticLog,
   DiagnosticEvent,
+  WorkflowHooks,
+  WorkflowHookInfo,
+  StepHookInfo,
+  StepCompleteHookInfo,
+  StepFailedHookInfo,
+  WorkflowCompleteHookInfo,
+  WorkflowFailedHookInfo,
 } from "./client";
 
-export { workflow, WorkflowBuilder, SandboxStepBuilder } from "./workflow";
+export { workflow, WorkflowBuilder, SandboxStepBuilder, CodeLanguage } from "./workflow";
 export type { SandboxOpts, LoopItem } from "./workflow";
 export type { CodeContext } from "@drej/opensandbox";

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -1,6 +1,9 @@
 import type { StepDef, Predicate } from "@drej/core";
 import { validateWorkflow } from "@drej/core";
+import { CodeLanguage } from "@drej/opensandbox";
 import type { ImageSpec, Resources, Sandbox } from "@drej/opensandbox";
+
+export { CodeLanguage };
 
 // Placeholder that serialises to {{name}} inside template literals.
 // Used as the `item` parameter in forEach callbacks so users write
@@ -78,11 +81,11 @@ export class SandboxStepBuilder {
    * Execute code inside the sandbox using a stateful interpreter context.
    *
    * **Requires** the `opensandbox/code-interpreter` image with entrypoint
-   * `["/opt/code-interpreter/code-interpreter.sh"]`. Supported languages:
-   * Python, Node.js, Java, Go, Bash.
+   * `["/opt/code-interpreter/code-interpreter.sh"]`. Pass a `CodeLanguage` value
+   * for the `context.language` field.
    *
    * @param context.id        Reuse a named context across calls to share state (variables, imports).
-   * @param context.language  Language identifier (e.g. `"python"`, `"node"`).
+   * @param context.language  Language to run (e.g. `CodeLanguage.Python`).
    *
    * @example
    * ```ts
@@ -90,11 +93,11 @@ export class SandboxStepBuilder {
    * s.execCode("print('hello')")
    *
    * // Stateful session: second call sees x defined by the first
-   * s.execCode("x = 42", { context: { id: "repl", language: "python" } })
-   * s.execCode("print(x)", { context: { id: "repl", language: "python" } })
+   * s.execCode("x = 42", { context: { id: "repl", language: CodeLanguage.Python } })
+   * s.execCode("print(x)", { context: { id: "repl", language: CodeLanguage.Python } })
    * ```
    */
-  execCode(code: string, opts?: { context?: { id: string; language: string } }): this {
+  execCode(code: string, opts?: { context?: { id: string; language: CodeLanguage } }): this {
     this._steps.push({ type: "exec_code", code, ...(opts?.context ? { context: opts.context } : {}) });
     return this;
   }


### PR DESCRIPTION
- Add CodeLanguage enum to @drej/opensandbox for typed exec_code language identifiers
- Add onWorkflowStart hook and named hook info types (StepHookInfo, StepCompleteHookInfo, etc.)
- Add mergeHooks() utility to compose multiple WorkflowHooks without stomping
- Expose hooks option on RunOptions so callers can pass observability hooks to client.run()
- Add @drej/otel package: otelHooks(tracer) returns WorkflowHooks that emit root + per-step spans