### PR TITLE
feat: add run management API

### DIFF
--- a/.changeset/run-management-api.md
+++ b/.changeset/run-management-api.md
@@ -1,0 +1,10 @@
+---
+"@drej/core": minor
+"@drej/postgres": minor
+"@drej/sqlite": minor
+"drej": minor
+---
+
+feat: run management API
+
+Add `RunStatus` enum, `RunDetails` type, and `ListRunsOptions` for filtering. Replace `listRuns()` with `listRunDetails()`, `listAllRunDetails()`, `getRunDetails()`, and `deleteRun()` on both `IStorageAdapter` and `DrejClient`. Add `WorkflowRun.status` property that tracks execution state as events are consumed.

--- a/packages/adapters/postgres/src/adapter.ts
+++ b/packages/adapters/postgres/src/adapter.ts
@@ -1,5 +1,6 @@
 import postgres from "postgres";
-import type { IStorageAdapter, LedgerEntry, LedgerEvent } from "@drej/core";
+import type { IStorageAdapter, LedgerEntry, LedgerEvent, RunDetails, ListRunsOptions } from "@drej/core";
+import { RunStatus } from "@drej/core";
 import { MIGRATION_SQL } from "./migrations";
 
 type Row = {
@@ -12,6 +13,42 @@ type Row = {
   error: string | null;
   ts: string;
 };
+
+type AggRow = {
+  wf_name: string;
+  run_id: string;
+  started_at: string | null;
+  completed_at: string | null;
+  terminal_event: string | null;
+  error_msg: string | null;
+  step_count: string;
+};
+
+function terminalToStatus(event: string | null): RunStatus {
+  if (event === "workflow_complete") return RunStatus.Completed;
+  if (event === "workflow_failed") return RunStatus.Failed;
+  return RunStatus.Running;
+}
+
+function aggRowToDetails(row: AggRow): RunDetails {
+  return {
+    workflowName: row.wf_name,
+    runId: row.run_id,
+    status: terminalToStatus(row.terminal_event),
+    startedAt: Number(row.started_at),
+    completedAt: row.completed_at != null ? Number(row.completed_at) : undefined,
+    stepCount: Number(row.step_count),
+    error: row.error_msg ?? undefined,
+  };
+}
+
+function applyOpts(details: RunDetails[], opts?: ListRunsOptions): RunDetails[] {
+  let result = details;
+  if (opts?.before != null) result = result.filter((d) => d.startedAt < opts.before!);
+  if (opts?.status != null) result = result.filter((d) => d.status === opts.status);
+  if (opts?.limit != null) result = result.slice(0, opts.limit);
+  return result;
+}
 
 function rowToEntry(row: Row): LedgerEntry {
   return {
@@ -78,10 +115,42 @@ export class PostgresAdapter implements IStorageAdapter {
     return rows.length ? rowToEntry(rows[0]) : null;
   }
 
-  async listRuns(workflowName: string): Promise<string[]> {
-    const rows = await this.sql<{ run_id: string }[]>`
-      SELECT DISTINCT run_id FROM drej_events WHERE wf_name = ${workflowName}
-    `;
-    return rows.map((r) => r.run_id);
+  private async _aggQuery(whereClause: string, params: string[]): Promise<AggRow[]> {
+    return this.sql.unsafe<AggRow[]>(
+      `WITH agg AS (
+        SELECT
+          wf_name,
+          run_id,
+          MIN(CASE WHEN event = 'run_started' THEN ts END) AS started_at,
+          MAX(CASE WHEN event IN ('workflow_complete', 'workflow_failed') THEN ts END) AS completed_at,
+          MAX(CASE WHEN event IN ('workflow_complete', 'workflow_failed') THEN event END) AS terminal_event,
+          MAX(CASE WHEN event = 'workflow_failed' THEN error END) AS error_msg,
+          COUNT(CASE WHEN event = 'step_complete' THEN 1 END)::int AS step_count
+        FROM drej_events
+        ${whereClause}
+        GROUP BY wf_name, run_id
+      )
+      SELECT * FROM agg WHERE started_at IS NOT NULL ORDER BY started_at DESC`,
+      params,
+    );
+  }
+
+  async listRunDetails(workflowName: string, opts?: ListRunsOptions): Promise<RunDetails[]> {
+    const rows = await this._aggQuery("WHERE wf_name = $1", [workflowName]);
+    return applyOpts(rows.map(aggRowToDetails), opts);
+  }
+
+  async listAllRunDetails(opts?: ListRunsOptions): Promise<RunDetails[]> {
+    const rows = await this._aggQuery("", []);
+    return applyOpts(rows.map(aggRowToDetails), opts);
+  }
+
+  async getRunDetails(workflowName: string, runId: string): Promise<RunDetails | null> {
+    const rows = await this._aggQuery("WHERE wf_name = $1 AND run_id = $2", [workflowName, runId]);
+    return rows.length ? aggRowToDetails(rows[0]) : null;
+  }
+
+  async deleteRun(workflowName: string, runId: string): Promise<void> {
+    await this.sql`DELETE FROM drej_events WHERE wf_name = ${workflowName} AND run_id = ${runId}`;
   }
 }

--- a/packages/adapters/sqlite/src/adapter.ts
+++ b/packages/adapters/sqlite/src/adapter.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
-import type { IStorageAdapter, LedgerEntry, LedgerEvent } from "@drej/core";
+import type { IStorageAdapter, LedgerEntry, LedgerEvent, RunDetails, ListRunsOptions } from "@drej/core";
+import { RunStatus } from "@drej/core";
 import { MIGRATION_SQL } from "./migrations";
 
 type Row = {
@@ -12,6 +13,59 @@ type Row = {
   error: string | null;
   ts: number;
 };
+
+type AggRow = {
+  wf_name: string;
+  run_id: string;
+  started_at: number | null;
+  completed_at: number | null;
+  terminal_event: string | null;
+  error_msg: string | null;
+  step_count: number;
+};
+
+const AGG_SQL = (whereClause: string) => `
+  WITH agg AS (
+    SELECT
+      wf_name,
+      run_id,
+      MIN(CASE WHEN event = 'run_started' THEN ts END) AS started_at,
+      MAX(CASE WHEN event IN ('workflow_complete', 'workflow_failed') THEN ts END) AS completed_at,
+      MAX(CASE WHEN event IN ('workflow_complete', 'workflow_failed') THEN event END) AS terminal_event,
+      MAX(CASE WHEN event = 'workflow_failed' THEN error END) AS error_msg,
+      CAST(COUNT(CASE WHEN event = 'step_complete' THEN 1 END) AS INTEGER) AS step_count
+    FROM drej_events
+    ${whereClause}
+    GROUP BY wf_name, run_id
+  )
+  SELECT * FROM agg WHERE started_at IS NOT NULL ORDER BY started_at DESC
+`;
+
+function terminalToStatus(event: string | null): RunStatus {
+  if (event === "workflow_complete") return RunStatus.Completed;
+  if (event === "workflow_failed") return RunStatus.Failed;
+  return RunStatus.Running;
+}
+
+function aggRowToDetails(row: AggRow): RunDetails {
+  return {
+    workflowName: row.wf_name,
+    runId: row.run_id,
+    status: terminalToStatus(row.terminal_event),
+    startedAt: row.started_at!,
+    completedAt: row.completed_at ?? undefined,
+    stepCount: row.step_count,
+    error: row.error_msg ?? undefined,
+  };
+}
+
+function applyOpts(details: RunDetails[], opts?: ListRunsOptions): RunDetails[] {
+  let result = details;
+  if (opts?.before != null) result = result.filter((d) => d.startedAt < opts.before!);
+  if (opts?.status != null) result = result.filter((d) => d.status === opts.status);
+  if (opts?.limit != null) result = result.slice(0, opts.limit);
+  return result;
+}
 
 function rowToEntry(row: Row): LedgerEntry {
   return {
@@ -86,12 +140,28 @@ export class SQLiteAdapter implements IStorageAdapter {
     return row ? rowToEntry(row) : null;
   }
 
-  async listRuns(workflowName: string): Promise<string[]> {
+  async listRunDetails(workflowName: string, opts?: ListRunsOptions): Promise<RunDetails[]> {
     const rows = this.db
-      .prepare<{ run_id: string }, [string]>(
-        `SELECT DISTINCT run_id FROM drej_events WHERE wf_name = ?`,
-      )
+      .prepare<AggRow, [string]>(AGG_SQL("WHERE wf_name = ?"))
       .all(workflowName);
-    return rows.map((r) => r.run_id);
+    return applyOpts(rows.map(aggRowToDetails), opts);
+  }
+
+  async listAllRunDetails(opts?: ListRunsOptions): Promise<RunDetails[]> {
+    const rows = this.db.prepare<AggRow, []>(AGG_SQL("")).all();
+    return applyOpts(rows.map(aggRowToDetails), opts);
+  }
+
+  async getRunDetails(workflowName: string, runId: string): Promise<RunDetails | null> {
+    const row = this.db
+      .prepare<AggRow, [string, string]>(AGG_SQL("WHERE wf_name = ? AND run_id = ?"))
+      .get(workflowName, runId);
+    return row ? aggRowToDetails(row) : null;
+  }
+
+  async deleteRun(workflowName: string, runId: string): Promise<void> {
+    this.db
+      .prepare<void, [string, string]>(`DELETE FROM drej_events WHERE wf_name = ? AND run_id = ?`)
+      .run(workflowName, runId);
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
-export { LedgerEvent } from "./ledger";
-export type { LedgerEntry, IStorageAdapter } from "./ledger";
+export { LedgerEvent, RunStatus } from "./ledger";
+export type { LedgerEntry, IStorageAdapter, RunDetails, ListRunsOptions } from "./ledger";
 
 export { LogLevel, ConsoleLogger, noopLogger } from "./logger";
 export type { ILogger } from "./logger";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1,3 +1,34 @@
+/** Status of a workflow run derived from its ledger events. */
+export enum RunStatus {
+  Running   = "running",
+  Completed = "completed",
+  Failed    = "failed",
+  Cancelled = "cancelled",
+}
+
+/** Derived metadata for a workflow run, computed from its ledger events. */
+export interface RunDetails {
+  workflowName: string;
+  runId: string;
+  status: RunStatus;
+  /** Unix timestamp (ms) of the `run_started` event. */
+  startedAt: number;
+  /** Unix timestamp (ms) of the terminal event, if the run has ended. */
+  completedAt?: number;
+  /** Number of steps that completed successfully. */
+  stepCount: number;
+  /** Error message, present when status is `Failed`. */
+  error?: string;
+}
+
+/** Options for filtering run listings. */
+export interface ListRunsOptions {
+  status?: RunStatus;
+  /** Max number of results to return. */
+  limit?: number;
+  /** Return only runs that started before this Unix timestamp (ms). */
+  before?: number;
+}
 
 /** Events emitted during workflow execution and stored in the ledger. */
 export enum LedgerEvent {
@@ -65,6 +96,12 @@ export interface IStorageAdapter {
   readAll(workflowName: string, runId: string): Promise<LedgerEntry[]>;
   /** Return the most recent checkpoint entry for a run, or `null` if none exists. */
   lastCheckpoint(workflowName: string, runId: string): Promise<LedgerEntry | null>;
-  /** Return all run IDs recorded under a workflow name. */
-  listRuns(workflowName: string): Promise<string[]>;
+  /** Return details for all runs of a workflow, newest first. */
+  listRunDetails(workflowName: string, opts?: ListRunsOptions): Promise<RunDetails[]>;
+  /** Return details for runs across all workflows, newest first. */
+  listAllRunDetails(opts?: ListRunsOptions): Promise<RunDetails[]>;
+  /** Return details for a single run, or `null` if not found. */
+  getRunDetails(workflowName: string, runId: string): Promise<RunDetails | null>;
+  /** Delete all ledger events for a run. */
+  deleteRun(workflowName: string, runId: string): Promise<void>;
 }

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -1,6 +1,7 @@
 import {
   Workflow,
   LedgerEvent,
+  RunStatus,
   buildStep,
   resolveExecClient,
   shouldSnapshot,
@@ -12,8 +13,10 @@ import {
   type LedgerEntry,
   type SnapshotConfig,
   type StepDef,
+  type RunDetails,
+  type ListRunsOptions,
 } from "@drej/core";
-export { WorkflowError, SandboxError, ExecConnectionError, CommandError, WorkflowStatus } from "@drej/core";
+export { WorkflowError, SandboxError, ExecConnectionError, CommandError, WorkflowStatus, RunStatus } from "@drej/core";
 export type {
   WorkflowHooks,
   WorkflowHookInfo,
@@ -22,6 +25,8 @@ export type {
   StepFailedHookInfo,
   WorkflowCompleteHookInfo,
   WorkflowFailedHookInfo,
+  RunDetails,
+  ListRunsOptions,
 } from "@drej/core";
 import {
   ControlClient,
@@ -106,6 +111,11 @@ export type WorkflowEvent = LedgerEntry;
  * ```
  */
 export class WorkflowRun implements AsyncIterable<WorkflowEvent> {
+  private _status: RunStatus = RunStatus.Running;
+
+  /** Current execution status. Updates as events are consumed via `for await`. */
+  get status(): RunStatus { return this._status; }
+
   constructor(
     /** The workflow name passed to `workflow(name)`. */
     public readonly name: string,
@@ -115,7 +125,24 @@ export class WorkflowRun implements AsyncIterable<WorkflowEvent> {
   ) {}
 
   [Symbol.asyncIterator](): AsyncIterator<WorkflowEvent> {
-    return this._events;
+    const self = this;
+    const gen = this._events;
+    return {
+      async next() {
+        try {
+          const r = await gen.next();
+          if (r.done) self._status = RunStatus.Completed;
+          return r;
+        } catch (e) {
+          self._status = RunStatus.Failed;
+          throw e;
+        }
+      },
+      return(v) {
+        self._status = RunStatus.Cancelled;
+        return gen.return?.(v) ?? Promise.resolve({ done: true as const, value: v as WorkflowEvent });
+      },
+    };
   }
 }
 
@@ -349,16 +376,33 @@ export class DrejClient {
     return new WorkflowRun(name, runId, stream);
   }
 
-  // ── Adapter access ────────────────────────────────────────────────────────
+  // ── Run management ────────────────────────────────────────────────────────
 
-  /** Return all run IDs recorded under a workflow name. */
-  listRuns(workflowName: string): Promise<string[]> {
-    return this.adapter.listRuns(workflowName);
+  /** Return details for all runs of a workflow, newest first. */
+  listRunDetails(workflowName: string, opts?: ListRunsOptions): Promise<RunDetails[]> {
+    return this.adapter.listRunDetails(workflowName, opts);
+  }
+
+  /** Return details for runs across all workflows, newest first. */
+  listAllRunDetails(opts?: ListRunsOptions): Promise<RunDetails[]> {
+    return this.adapter.listAllRunDetails(opts);
+  }
+
+  /** Return details for a single run. Throws if the run does not exist. */
+  async getRunDetails(workflowName: string, runId: string): Promise<RunDetails> {
+    const details = await this.adapter.getRunDetails(workflowName, runId);
+    if (!details) throw new DrejError(`Run ${runId} not found under workflow "${workflowName}"`, 404);
+    return details;
   }
 
   /** Return all ledger events for a specific run, in ascending order. */
   getRunLedger(workflowName: string, runId: string): Promise<WorkflowEvent[]> {
     return this.adapter.readAll(workflowName, runId) as Promise<WorkflowEvent[]>;
+  }
+
+  /** Delete all ledger events for a run. */
+  deleteRun(workflowName: string, runId: string): Promise<void> {
+    return this.adapter.deleteRun(workflowName, runId);
   }
 
   // ── Internal ──────────────────────────────────────────────────────────────
@@ -427,7 +471,10 @@ export class DrejClient {
       },
       readAll: (n, id) => this.adapter.readAll(n, id),
       lastCheckpoint: (n, id) => this.adapter.lastCheckpoint(n, id),
-      listRuns: (n) => this.adapter.listRuns(n),
+      listRunDetails: (n, o) => this.adapter.listRunDetails(n, o),
+      listAllRunDetails: (o) => this.adapter.listAllRunDetails(o),
+      getRunDetails: (n, id) => this.adapter.getRunDetails(n, id),
+      deleteRun: (n, id) => this.adapter.deleteRun(n, id),
     };
 
     const teeDeps: WorkflowDeps = {

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -1,4 +1,4 @@
-export { DrejClient, DrejError, WorkflowRun, LedgerEvent } from "./client";
+export { DrejClient, DrejError, WorkflowRun, LedgerEvent, RunStatus } from "./client";
 export type {
   DrejClientOptions,
   RunOptions,
@@ -6,6 +6,8 @@ export type {
   WorkflowEvent,
   StepDef,
   IStorageAdapter,
+  RunDetails,
+  ListRunsOptions,
   Sandbox,
   SandboxState,
   SandboxStatus,


### PR DESCRIPTION
Replace bare `listRuns()` with typed `listRunDetails()`, `listAllRunDetails()`, `getRunDetails()`, and `deleteRun()` on `IStorageAdapter` and `DrejClient`. Add `RunStatus`, `RunDetails`, `ListRunsOptions` types to `@drej/core`. Add `WorkflowRun.status` property that tracks execution state as events are consumed.