### PR TITLE
feat: concurrency limits for client and step execution

### DIFF
--- a/.changeset/concurrency-limits.md
+++ b/.changeset/concurrency-limits.md
@@ -1,0 +1,8 @@
+---
+"@drej/core": minor
+"drej": minor
+---
+
+feat: concurrency limits
+
+Add `maxConcurrency` to `DrejClientOptions` to cap simultaneous workflow runs — `run()` awaits a slot before starting when at capacity. Add `maxConcurrency` to `parallel` and `loop` StepDefs so branches and loop iterations are throttled via a worker-pool; the `parallel()` and `forEach()` builders expose this as an `opts.concurrency` argument.

--- a/packages/core/src/steps.ts
+++ b/packages/core/src/steps.ts
@@ -31,8 +31,8 @@ export type StepDef =
   | { type: "snapshot" }
   | { type: "retry"; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: "fixed" | "exponential" }
   | { type: "conditional"; condition: Predicate; then: StepDef[]; else?: StepDef[] }
-  | { type: "loop"; over?: string; items?: unknown[]; as: string; steps: StepDef[]; concurrently?: boolean }
-  | { type: "parallel"; steps: StepDef[] }
+  | { type: "loop"; over?: string; items?: unknown[]; as: string; steps: StepDef[]; maxConcurrency?: number }
+  | { type: "parallel"; steps: StepDef[]; maxConcurrency?: number }
   | { type: "sequence"; steps: StepDef[] };
 
 export type WorkflowState = Record<string, unknown> & { sandboxId?: string };
@@ -121,6 +121,21 @@ function evaluate(predicate: Predicate, state: unknown): boolean {
     case "and": return predicate.predicates.every((p) => evaluate(p, state));
     case "or":  return predicate.predicates.some((p) => evaluate(p, state));
   }
+}
+
+// ── Concurrency helper ─────────────────────────────────────────────────────
+
+async function runWithConcurrency<T>(tasks: Array<() => Promise<T>>, max: number): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < tasks.length) {
+      const i = nextIndex++;
+      results[i] = await tasks[i]();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(max, tasks.length) }, worker));
+  return results;
 }
 
 // ── Step builder ───────────────────────────────────────────────────────────
@@ -354,13 +369,11 @@ export function buildStep(def: StepDef): WorkflowStep {
             return current;
           };
 
-          const loopResults = def.concurrently
-            ? await Promise.all(arr.map((item, i) => runIteration(item, i)))
-            : await arr.reduce<Promise<unknown[]>>(async (accP, item, i) => {
-                const acc = await accP;
-                acc.push(await runIteration(item, i));
-                return acc;
-              }, Promise.resolve([]));
+          const max = def.maxConcurrency ?? 1;
+          const tasks = arr.map((item, i) => () => runIteration(item, i));
+          const loopResults = max === 1
+            ? await tasks.reduce<Promise<unknown[]>>(async (accP, t) => { const acc = await accP; acc.push(await t()); return acc; }, Promise.resolve([]))
+            : await runWithConcurrency(tasks, max);
 
           return { ...(input as WorkflowState), loopResults };
         },
@@ -371,16 +384,17 @@ export function buildStep(def: StepDef): WorkflowStep {
       return {
         id: "parallel",
         async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
-          const results = await Promise.all(
-            def.steps.map((stepDef, branchIndex) => {
-              const branchCtx: WorkflowRunContext = {
-                ...ctx,
-                stepIndex: ctx.stepIndex * 1000 + branchIndex,
-                emit: (entry) => ctx.emit({ ...entry, branch: branchIndex }),
-              };
-              return buildStep(stepDef).run(input, branchCtx);
-            }),
-          );
+          const branchedTasks = def.steps.map((stepDef, branchIndex) => {
+            const branchCtx: WorkflowRunContext = {
+              ...ctx,
+              stepIndex: ctx.stepIndex * 1000 + branchIndex,
+              emit: (entry) => ctx.emit({ ...entry, branch: branchIndex }),
+            };
+            return () => buildStep(stepDef).run(input, branchCtx);
+          });
+          const results = def.maxConcurrency
+            ? await runWithConcurrency(branchedTasks, def.maxConcurrency)
+            : await Promise.all(branchedTasks.map((t) => t()));
 
           const merged = results.reduce<WorkflowState>(
             (acc, result) => ({ ...acc, ...(result as WorkflowState) }),

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -80,6 +80,12 @@ export interface DrejClientOptions {
    * You can also supply any custom `IStorageAdapter` implementation.
    */
   adapter: IStorageAdapter;
+  /**
+   * Maximum number of workflow runs that may execute simultaneously.
+   * When at capacity, `run()` awaits until a slot is free before starting.
+   * Omit or set to `undefined` for no limit.
+   */
+  maxConcurrency?: number;
 }
 
 /** Options passed to {@link DrejClient.run}. */
@@ -174,6 +180,9 @@ export class WorkflowRun implements AsyncIterable<WorkflowEvent> {
 export class DrejClient {
   private readonly control: ControlClient;
   private readonly adapter: IStorageAdapter;
+  private readonly _maxConcurrency: number | undefined;
+  private _activeRuns = 0;
+  private readonly _waiters: Array<() => void> = [];
 
   constructor(options: DrejClientOptions) {
     this.control = new ControlClient({
@@ -181,6 +190,7 @@ export class DrejClient {
       apiKey: options.apiKey ?? "",
     });
     this.adapter = options.adapter;
+    this._maxConcurrency = options.maxConcurrency;
   }
 
   /**
@@ -316,9 +326,10 @@ export class DrejClient {
     w: WorkflowBuilder,
     options?: RunOptions,
   ): Promise<WorkflowRun> {
+    await this._acquireSlot();
     const { name, steps, initialState } = w.build();
     const runId = crypto.randomUUID();
-    return new WorkflowRun(name, runId, this._execute(name, runId, steps, options, initialState));
+    return new WorkflowRun(name, runId, this._withRelease(this._execute(name, runId, steps, options, initialState)));
   }
 
   /**
@@ -406,6 +417,29 @@ export class DrejClient {
   }
 
   // ── Internal ──────────────────────────────────────────────────────────────
+
+  private async _acquireSlot(): Promise<void> {
+    if (!this._maxConcurrency || this._activeRuns < this._maxConcurrency) {
+      this._activeRuns++;
+      return;
+    }
+    await new Promise<void>((resolve) => this._waiters.push(resolve));
+    this._activeRuns++;
+  }
+
+  private _releaseSlot(): void {
+    this._activeRuns--;
+    const next = this._waiters.shift();
+    next?.();
+  }
+
+  private async *_withRelease(gen: AsyncGenerator<WorkflowEvent>): AsyncGenerator<WorkflowEvent> {
+    try {
+      yield* gen;
+    } finally {
+      this._releaseSlot();
+    }
+  }
 
   private _execute(
     name: string,

--- a/packages/sdks/typescript/src/workflow.ts
+++ b/packages/sdks/typescript/src/workflow.ts
@@ -217,7 +217,7 @@ export class SandboxStepBuilder {
       as: varName,
       steps,
       ...(Array.isArray(source) ? { items: source } : { over: source.from }),
-      ...(opts.concurrency !== undefined && opts.concurrency > 1 ? { concurrently: true } : {}),
+      ...(opts.concurrency !== undefined && opts.concurrency > 1 ? { maxConcurrency: opts.concurrency } : {}),
     });
 
     return this;
@@ -274,10 +274,10 @@ export class SandboxStepBuilder {
    * )
    * ```
    */
-  parallel(fn: (p: SandboxParallelBuilder) => SandboxParallelBuilder): this {
+  parallel(fn: (p: SandboxParallelBuilder) => SandboxParallelBuilder, opts?: { concurrency?: number }): this {
     const pb = new SandboxParallelBuilder();
     fn(pb);
-    this._steps.push({ type: "parallel", steps: pb.build() });
+    this._steps.push({ type: "parallel", steps: pb.build(), ...(opts?.concurrency ? { maxConcurrency: opts.concurrency } : {}) });
     return this;
   }
 
@@ -389,10 +389,10 @@ export class WorkflowBuilder {
     return this;
   }
 
-  parallel(fn: (p: WorkflowParallelBuilder) => WorkflowParallelBuilder): this {
+  parallel(fn: (p: WorkflowParallelBuilder) => WorkflowParallelBuilder, opts?: { concurrency?: number }): this {
     const pb = new WorkflowParallelBuilder();
     fn(pb);
-    this._steps.push({ type: "parallel", steps: pb.build() });
+    this._steps.push({ type: "parallel", steps: pb.build(), ...(opts?.concurrency ? { maxConcurrency: opts.concurrency } : {}) });
     return this;
   }
 


### PR DESCRIPTION
Add `DrejClientOptions.maxConcurrency` — run() awaits a semaphore slot before starting execution; the slot is released via a finally-wrapped async generator when the WorkflowRun is exhausted or cancelled. Add `maxConcurrency` to parallel and loop StepDefs; execution uses a worker-pool helper instead of Promise.all when a limit is set. Wire the existing forEach concurrency option through to the StepDef (was previously ignored).