### PR TITLE
feat: add vitest test suite and pin all dependency versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "drej",
       "devDependencies": {
-        "@changesets/cli": "^2.31.0",
+        "@changesets/cli": "2.31.0",
       },
     },
     "examples/capture": {
@@ -79,9 +79,9 @@
         "@drej/core": "workspace:*",
       },
       "devDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "bun-types": "latest",
-        "typescript": "latest",
+        "@opentelemetry/api": "1.9.1",
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -92,11 +92,11 @@
       "version": "0.1.2",
       "dependencies": {
         "@drej/core": "workspace:*",
-        "postgres": "^3.4.5",
+        "postgres": "3.4.9",
       },
       "devDependencies": {
-        "bun-types": "latest",
-        "typescript": "latest",
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
       },
     },
     "packages/adapters/sqlite": {
@@ -106,8 +106,8 @@
         "@drej/core": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
-        "typescript": "latest",
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
       },
     },
     "packages/core": {
@@ -117,16 +117,17 @@
         "@drej/opensandbox": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
-        "typescript": "latest",
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
+        "vitest": "4.1.9",
       },
     },
     "packages/opensandbox": {
       "name": "@drej/opensandbox",
       "version": "0.1.2",
       "devDependencies": {
-        "bun-types": "latest",
-        "typescript": "latest",
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
       },
     },
     "packages/sdks/typescript": {
@@ -137,9 +138,10 @@
         "@drej/opensandbox": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
-        "tsup": "^8.5.1",
-        "typescript": "latest",
+        "bun-types": "1.3.14",
+        "tsup": "8.5.1",
+        "typescript": "6.0.3",
+        "vitest": "4.1.9",
       },
     },
   },
@@ -189,6 +191,12 @@
     "@drej/postgres": ["@drej/postgres@workspace:packages/adapters/postgres"],
 
     "@drej/sqlite": ["@drej/sqlite@workspace:packages/adapters/sqlite"],
+
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -256,6 +264,8 @@
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -263,6 +273,40 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
 
@@ -314,9 +358,31 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
@@ -330,6 +396,8 @@
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -339,6 +407,8 @@
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
@@ -350,11 +420,15 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -378,9 +452,15 @@
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
@@ -430,6 +510,30 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
@@ -454,7 +558,11 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
+    "nanoid": ["nanoid@3.3.14", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
@@ -488,6 +596,8 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
@@ -506,6 +616,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
     "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -518,15 +630,23 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -540,15 +660,21 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
@@ -560,7 +686,13 @@
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "@inquirer/external-editor/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
@@ -573,6 +705,8 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/otel/tsconfig.json"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.31.0"
+    "@changesets/cli": "2.31.0"
   }
 }

--- a/packages/adapters/otel/package.json
+++ b/packages/adapters/otel/package.json
@@ -10,8 +10,8 @@
     "@drej/core": "workspace:*"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.9.0",
-    "bun-types": "latest",
-    "typescript": "latest"
+    "@opentelemetry/api": "1.9.1",
+    "bun-types": "1.3.14",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -4,11 +4,11 @@
   "publishConfig": { "access": "public" },
   "main": "./src/index.ts",
   "dependencies": {
-    "postgres": "^3.4.5",
+    "postgres": "3.4.9",
     "@drej/core": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest",
-    "typescript": "latest"
+    "bun-types": "1.3.14",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -7,7 +7,7 @@
     "@drej/core": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest",
-    "typescript": "latest"
+    "bun-types": "1.3.14",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,13 +8,16 @@
   ],
   "publishConfig": { "access": "public" },
   "scripts": {
-    "build:types": "tsc --project tsconfig.build.json"
+    "build:types": "tsc --project tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@drej/opensandbox": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest",
-    "typescript": "latest"
+    "bun-types": "1.3.14",
+    "typescript": "6.0.3",
+    "vitest": "4.1.9"
   }
 }

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { evaluate, getPath, interpolate, runWithConcurrency } from "../src/steps/utils.ts";
+
+describe("getPath", () => {
+  it("returns a top-level value", () => {
+    expect(getPath({ a: 1 }, "a")).toBe(1);
+  });
+
+  it("traverses nested paths", () => {
+    expect(getPath({ a: { b: { c: 42 } } }, "a.b.c")).toBe(42);
+  });
+
+  it("returns undefined for missing keys", () => {
+    expect(getPath({ a: 1 }, "b")).toBeUndefined();
+  });
+
+  it("returns undefined when traversing through a non-object", () => {
+    expect(getPath({ a: null }, "a.b")).toBeUndefined();
+  });
+});
+
+describe("interpolate", () => {
+  it("replaces a known key", () => {
+    expect(interpolate("hello {{name}}", { name: "world" })).toBe("hello world");
+  });
+
+  it("leaves unknown keys as-is", () => {
+    expect(interpolate("hello {{missing}}", {})).toBe("hello {{missing}}");
+  });
+
+  it("replaces multiple occurrences", () => {
+    expect(interpolate("{{a}} and {{b}}", { a: "foo", b: "bar" })).toBe("foo and bar");
+  });
+
+  it("coerces non-string values to string", () => {
+    expect(interpolate("count: {{n}}", { n: 42 })).toBe("count: 42");
+  });
+});
+
+describe("evaluate", () => {
+  it("eq matches equal values", () => {
+    expect(evaluate({ op: "eq", field: "x", value: 1 }, { x: 1 })).toBe(true);
+    expect(evaluate({ op: "eq", field: "x", value: 1 }, { x: 2 })).toBe(false);
+  });
+
+  it("neq matches unequal values", () => {
+    expect(evaluate({ op: "neq", field: "x", value: 1 }, { x: 2 })).toBe(true);
+  });
+
+  it("gt / lt / gte / lte do numeric comparison", () => {
+    expect(evaluate({ op: "gt", field: "n", value: 5 }, { n: 6 })).toBe(true);
+    expect(evaluate({ op: "lt", field: "n", value: 5 }, { n: 4 })).toBe(true);
+    expect(evaluate({ op: "gte", field: "n", value: 5 }, { n: 5 })).toBe(true);
+    expect(evaluate({ op: "lte", field: "n", value: 5 }, { n: 5 })).toBe(true);
+  });
+
+  it("exists / not_exists check presence", () => {
+    expect(evaluate({ op: "exists", field: "x" }, { x: 0 })).toBe(true);
+    expect(evaluate({ op: "exists", field: "x" }, {})).toBe(false);
+    expect(evaluate({ op: "not_exists", field: "x" }, {})).toBe(true);
+  });
+
+  it("and requires all predicates to pass", () => {
+    expect(evaluate({
+      op: "and",
+      predicates: [
+        { op: "eq", field: "x", value: 1 },
+        { op: "eq", field: "y", value: 2 },
+      ],
+    }, { x: 1, y: 2 })).toBe(true);
+
+    expect(evaluate({
+      op: "and",
+      predicates: [
+        { op: "eq", field: "x", value: 1 },
+        { op: "eq", field: "y", value: 9 },
+      ],
+    }, { x: 1, y: 2 })).toBe(false);
+  });
+
+  it("or passes if any predicate passes", () => {
+    expect(evaluate({
+      op: "or",
+      predicates: [
+        { op: "eq", field: "x", value: 99 },
+        { op: "eq", field: "y", value: 2 },
+      ],
+    }, { x: 1, y: 2 })).toBe(true);
+  });
+});
+
+describe("runWithConcurrency", () => {
+  it("runs all tasks and returns results in order", async () => {
+    const tasks = [1, 2, 3].map((n) => () => Promise.resolve(n * 10));
+    expect(await runWithConcurrency(tasks, 2)).toEqual([10, 20, 30]);
+  });
+
+  it("respects concurrency limit", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const tasks = Array.from({ length: 6 }, () => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+      return active;
+    });
+    await runWithConcurrency(tasks, 2);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it("handles empty task list", async () => {
+    expect(await runWithConcurrency([], 4)).toEqual([]);
+  });
+});

--- a/packages/core/test/validate.test.ts
+++ b/packages/core/test/validate.test.ts
@@ -1,0 +1,75 @@
+import { StepType } from "../src/steps/types.ts";
+import { validateWorkflow } from "../src/validate.ts";
+import { describe, expect, it } from "vitest";
+
+describe("validateWorkflow", () => {
+  it("passes for a workflow with no execCode steps", () => {
+    expect(() =>
+      validateWorkflow("wf", [{ type: StepType.ExecCommand, command: "echo hi" }]),
+    ).not.toThrow();
+  });
+
+  it("throws when execCode is used without a code-interpreter sandbox", () => {
+    expect(() =>
+      validateWorkflow("wf", [
+        { type: StepType.CreateSandbox, entrypoint: ["tail", "-f", "/dev/null"] },
+        { type: StepType.ExecCode, code: "print(1)" },
+      ]),
+    ).toThrow(/code-interpreter/);
+  });
+
+  it("passes when execCode is used with a code-interpreter sandbox", () => {
+    expect(() =>
+      validateWorkflow("wf", [
+        {
+          type: StepType.CreateSandbox,
+          entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
+        },
+        { type: StepType.ExecCode, code: "print(1)" },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("catches execCode inside a Retry step", () => {
+    expect(() =>
+      validateWorkflow("wf", [
+        { type: StepType.CreateSandbox, entrypoint: ["tail", "-f", "/dev/null"] },
+        {
+          type: StepType.Retry,
+          maxAttempts: 3,
+          step: { type: StepType.ExecCode, code: "x = 1" },
+        },
+      ]),
+    ).toThrow(/code-interpreter/);
+  });
+
+  it("catches execCode inside a Conditional then branch", () => {
+    expect(() =>
+      validateWorkflow("wf", [
+        { type: StepType.CreateSandbox, entrypoint: ["tail", "-f", "/dev/null"] },
+        {
+          type: StepType.Conditional,
+          condition: { op: "eq", field: "x", value: 1 },
+          then: [{ type: StepType.ExecCode, code: "x = 1" }],
+        },
+      ]),
+    ).toThrow(/code-interpreter/);
+  });
+
+  it("deduplicates repeated error messages for the same sandbox violation", () => {
+    let errorMessage = "";
+    try {
+      validateWorkflow("wf", [
+        { type: StepType.CreateSandbox, entrypoint: ["tail", "-f", "/dev/null"] },
+        { type: StepType.ExecCode, code: "x = 1" },
+        { type: StepType.ExecCode, code: "y = 2" },
+      ]);
+    } catch (e) {
+      errorMessage = (e as Error).message;
+    }
+    // Two execCode steps produce the same error string; Set deduplication means
+    // only one error block appears in the joined message.
+    const errorBlocks = errorMessage.split("\n\n").filter(Boolean);
+    expect(errorBlocks).toHaveLength(1);
+  });
+});

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/packages/opensandbox/package.json
+++ b/packages/opensandbox/package.json
@@ -12,7 +12,7 @@
     "build:types": "tsc --project tsconfig.build.json"
   },
   "devDependencies": {
-    "bun-types": "latest",
-    "typescript": "latest"
+    "bun-types": "1.3.14",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -15,15 +15,18 @@
   ],
   "publishConfig": { "access": "public" },
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@drej/core": "workspace:*",
     "@drej/opensandbox": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest",
-    "tsup": "^8.5.1",
-    "typescript": "latest"
+    "bun-types": "1.3.14",
+    "tsup": "8.5.1",
+    "typescript": "6.0.3",
+    "vitest": "4.1.9"
   }
 }

--- a/packages/sdks/typescript/test/builder.test.ts
+++ b/packages/sdks/typescript/test/builder.test.ts
@@ -1,0 +1,219 @@
+import { Backoff, Encoding, StepType } from "@drej/core";
+import { describe, expect, it } from "vitest";
+import { SandboxStepBuilder } from "../src/builder/sandbox-step.ts";
+import { createLoopVar, wrapSteps } from "../src/builder/types.ts";
+import { workflow } from "../src/builder/workflow.ts";
+
+// ── wrapSteps ────────────────────────────────────────────────────────────────
+
+describe("wrapSteps", () => {
+  it("returns the step directly when there is only one", () => {
+    const step = { type: StepType.ExecCommand as const, command: "echo hi" };
+    expect(wrapSteps([step])).toBe(step);
+  });
+
+  it("wraps multiple steps in a Sequence", () => {
+    const steps = [
+      { type: StepType.ExecCommand as const, command: "a" },
+      { type: StepType.ExecCommand as const, command: "b" },
+    ];
+    expect(wrapSteps(steps)).toEqual({ type: StepType.Sequence, steps });
+  });
+});
+
+// ── createLoopVar ─────────────────────────────────────────────────────────────
+
+describe("createLoopVar", () => {
+  it("serialises to the interpolation template", () => {
+    expect(String(createLoopVar("file"))).toBe("{{file}}");
+  });
+
+  it("uses the given name in the template", () => {
+    expect(String(createLoopVar("row"))).toBe("{{row}}");
+  });
+});
+
+// ── SandboxStepBuilder ────────────────────────────────────────────────────────
+
+describe("SandboxStepBuilder", () => {
+  it("exec adds an ExecCommand step", () => {
+    const steps = new SandboxStepBuilder().exec("ls -la").build();
+    expect(steps).toEqual([{ type: StepType.ExecCommand, command: "ls -la" }]);
+  });
+
+  it("exec forwards optional fields", () => {
+    const steps = new SandboxStepBuilder()
+      .exec("npm test", { cwd: "/app", capture: "output", strict: true })
+      .build();
+    expect(steps[0]).toMatchObject({ cwd: "/app", capture: "output", strict: true });
+  });
+
+  it("writeFile adds a WriteFile step with optional encoding", () => {
+    const steps = new SandboxStepBuilder()
+      .writeFile("/tmp/a.txt", "hello")
+      .writeFile("/tmp/b.bin", "data", Encoding.Base64)
+      .build();
+    expect(steps[0]).toEqual({ type: StepType.WriteFile, path: "/tmp/a.txt", content: "hello" });
+    expect(steps[1]).toEqual({ type: StepType.WriteFile, path: "/tmp/b.bin", content: "data", encoding: Encoding.Base64 });
+  });
+
+  it("readFile adds a ReadFile step", () => {
+    const steps = new SandboxStepBuilder().readFile("/tmp/out.txt", { as: "result" }).build();
+    expect(steps[0]).toEqual({ type: StepType.ReadFile, path: "/tmp/out.txt", as: "result" });
+  });
+
+  it("snapshot adds a Snapshot step", () => {
+    const steps = new SandboxStepBuilder().snapshot().build();
+    expect(steps[0]).toEqual({ type: StepType.Snapshot });
+  });
+
+  it("retry wraps inner steps and sets maxAttempts", () => {
+    const steps = new SandboxStepBuilder()
+      .retry(3, (r) => r.exec("flaky"), { delayMs: 100, backoff: Backoff.Exponential })
+      .build();
+    expect(steps[0]).toMatchObject({
+      type: StepType.Retry,
+      maxAttempts: 3,
+      delayMs: 100,
+      backoff: Backoff.Exponential,
+    });
+    expect((steps[0] as any).step).toEqual({ type: StepType.ExecCommand, command: "flaky" });
+  });
+
+  it("retry wraps multiple inner steps in a Sequence", () => {
+    const steps = new SandboxStepBuilder()
+      .retry(2, (r) => r.exec("a").exec("b"))
+      .build();
+    expect((steps[0] as any).step.type).toBe(StepType.Sequence);
+  });
+
+  it("forEach with static items produces a Loop step", () => {
+    const steps = new SandboxStepBuilder()
+      .forEach(["a.txt", "b.txt"], (s, item) => s.exec(`cat ${item}`))
+      .build();
+    expect(steps[0]).toMatchObject({
+      type: StepType.Loop,
+      items: ["a.txt", "b.txt"],
+      as: "item",
+    });
+  });
+
+  it("forEach with { from } uses the over field", () => {
+    const steps = new SandboxStepBuilder()
+      .forEach({ from: "files" }, (s, item) => s.exec(`process ${item}`))
+      .build();
+    expect(steps[0]).toMatchObject({ type: StepType.Loop, over: "files" });
+  });
+
+  it("forEach with custom as name sets the loop variable", () => {
+    const steps = new SandboxStepBuilder()
+      .forEach(["x"], { as: "row" }, (s, item) => s.exec(`echo ${item}`))
+      .build();
+    expect((steps[0] as any).as).toBe("row");
+  });
+
+  it("forEach with concurrency sets maxConcurrency", () => {
+    const steps = new SandboxStepBuilder()
+      .forEach(["a", "b"], { concurrency: 4 }, (s, item) => s.exec(`echo ${item}`))
+      .build();
+    expect((steps[0] as any).maxConcurrency).toBe(4);
+  });
+
+  it("when adds a Conditional step with then branch", () => {
+    const steps = new SandboxStepBuilder()
+      .when({ op: "eq", field: "exitCode", value: 0 }, (s) => s.exec("echo ok"))
+      .build();
+    expect(steps[0]).toMatchObject({ type: StepType.Conditional });
+    expect((steps[0] as any).then).toEqual([{ type: StepType.ExecCommand, command: "echo ok" }]);
+    expect((steps[0] as any).else).toBeUndefined();
+  });
+
+  it("when adds an else branch when provided", () => {
+    const steps = new SandboxStepBuilder()
+      .when(
+        { op: "eq", field: "x", value: 1 },
+        (s) => s.exec("echo yes"),
+        (s) => s.exec("echo no"),
+      )
+      .build();
+    expect((steps[0] as any).else).toEqual([{ type: StepType.ExecCommand, command: "echo no" }]);
+  });
+
+  it("parallel adds a Parallel step with branches", () => {
+    const steps = new SandboxStepBuilder()
+      .parallel((p) => p.branch((b) => b.exec("lint")).branch((b) => b.exec("test")))
+      .build();
+    expect(steps[0]).toMatchObject({ type: StepType.Parallel });
+    expect((steps[0] as any).steps).toHaveLength(2);
+  });
+
+  it("parallel sets maxConcurrency when provided", () => {
+    const steps = new SandboxStepBuilder()
+      .parallel((p) => p.branch((b) => b.exec("a")), { concurrency: 2 })
+      .build();
+    expect((steps[0] as any).maxConcurrency).toBe(2);
+  });
+
+  it("chains multiple methods in order", () => {
+    const steps = new SandboxStepBuilder()
+      .exec("step1")
+      .writeFile("/tmp/f", "x")
+      .exec("step3")
+      .build();
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toMatchObject({ command: "step1" });
+    expect(steps[2]).toMatchObject({ command: "step3" });
+  });
+});
+
+// ── WorkflowBuilder ──────────────────────────────────────────────────────────
+
+describe("workflow builder", () => {
+  it("sandbox with opts prepends a CreateSandbox step", () => {
+    const { steps } = workflow("test")
+      .sandbox({ image: { uri: "node:20-slim" } }, (s) => s.exec("npm test"))
+      .build();
+
+    expect(steps[0]).toMatchObject({ type: StepType.CreateSandbox, image: { uri: "node:20-slim" } });
+    expect(steps[0]).toMatchObject({ entrypoint: ["tail", "-f", "/dev/null"] });
+    expect(steps[1]).toEqual({ type: StepType.ExecCommand, command: "npm test" });
+  });
+
+  it("sandbox with existing Sandbox object skips CreateSandbox and sets initialState", () => {
+    const { steps, initialState } = workflow("test")
+      .sandbox({ id: "sb-123", status: "running" } as any, (s) => s.exec("ls"))
+      .build();
+
+    expect(steps[0]).toEqual({ type: StepType.ExecCommand, command: "ls" });
+    expect(initialState.sandboxId).toBe("sb-123");
+  });
+
+  it("parallel adds a Parallel step", () => {
+    const { steps } = workflow("test")
+      .parallel((p) =>
+        p
+          .sandbox({ image: { uri: "node:20" } }, (s) => s.exec("lint"))
+          .sandbox({ image: { uri: "node:20" } }, (s) => s.exec("test")),
+      )
+      .build();
+
+    expect(steps[0]).toMatchObject({ type: StepType.Parallel });
+    expect((steps[0] as any).steps).toHaveLength(2);
+  });
+
+  it("parallel forwards concurrency option", () => {
+    const { steps } = workflow("test")
+      .parallel(
+        (p) => p.sandbox({ image: { uri: "node:20" } }, (s) => s.exec("a")),
+        { concurrency: 3 },
+      )
+      .build();
+
+    expect((steps[0] as any).maxConcurrency).toBe(3);
+  });
+
+  it("build returns the workflow name", () => {
+    const { name } = workflow("my-workflow").sandbox({ image: { uri: "alpine" } }, (s) => s.exec("echo hi")).build();
+    expect(name).toBe("my-workflow");
+  });
+});

--- a/packages/sdks/typescript/test/stream.test.ts
+++ b/packages/sdks/typescript/test/stream.test.ts
@@ -1,0 +1,108 @@
+import { LedgerEvent, type IStorageAdapter, type LedgerEntry, type WorkflowDeps } from "@drej/core";
+import { describe, expect, it, vi } from "vitest";
+import { makeStream } from "../src/stream.ts";
+
+function makeAdapter(): IStorageAdapter {
+  return {
+    append: vi.fn().mockResolvedValue(undefined),
+    readAll: vi.fn().mockResolvedValue([]),
+    lastCheckpoint: vi.fn().mockResolvedValue(null),
+    listRunDetails: vi.fn().mockResolvedValue([]),
+    listAllRunDetails: vi.fn().mockResolvedValue([]),
+    getRunDetails: vi.fn().mockResolvedValue(null),
+    deleteRun: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const fakeControl = {} as any;
+
+async function collect<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of gen) items.push(item);
+  return items;
+}
+
+describe("makeStream", () => {
+  it("yields a RunStarted event immediately", async () => {
+    const stream = makeStream("wf", "run-1", makeAdapter(), fakeControl, async () => {});
+    const events = await collect(stream);
+    expect(events[0]).toMatchObject({ event: LedgerEvent.RunStarted, workflowName: "wf", runId: "run-1" });
+  });
+
+  it("yields events appended via the tee adapter", async () => {
+    const execute = async (deps: WorkflowDeps) => {
+      await deps.adapter.append({
+        ts: 1000,
+        workflowName: "wf",
+        runId: "run-1",
+        stepIndex: 0,
+        event: LedgerEvent.StepStart,
+      });
+      await deps.adapter.append({
+        ts: 2000,
+        workflowName: "wf",
+        runId: "run-1",
+        stepIndex: 0,
+        event: LedgerEvent.StepComplete,
+      });
+    };
+
+    const events = await collect(makeStream("wf", "run-1", makeAdapter(), fakeControl, execute));
+    const eventTypes = events.map((e) => (e as LedgerEntry).event);
+    expect(eventTypes).toContain(LedgerEvent.StepStart);
+    expect(eventTypes).toContain(LedgerEvent.StepComplete);
+  });
+
+  it("persists events to the underlying adapter", async () => {
+    const adapter = makeAdapter();
+    const execute = async (deps: WorkflowDeps) => {
+      await deps.adapter.append({
+        ts: 1000,
+        workflowName: "wf",
+        runId: "run-1",
+        stepIndex: 0,
+        event: LedgerEvent.StepStart,
+      });
+    };
+
+    await collect(makeStream("wf", "run-1", adapter, fakeControl, execute));
+    expect(adapter.append).toHaveBeenCalledWith(expect.objectContaining({ event: LedgerEvent.StepStart }));
+  });
+
+  it("terminates after execute resolves with no more events", async () => {
+    const events = await collect(makeStream("wf", "run-1", makeAdapter(), fakeControl, async () => {}));
+    // Only the initial RunStarted
+    expect(events).toHaveLength(1);
+  });
+
+  it("propagates errors thrown by execute", async () => {
+    const execute = async () => { throw new Error("boom"); };
+    await expect(collect(makeStream("wf", "run-1", makeAdapter(), fakeControl, execute))).rejects.toThrow("boom");
+  });
+
+  it("still yields buffered events before propagating the error", async () => {
+    const execute = async (deps: WorkflowDeps) => {
+      await deps.adapter.append({
+        ts: 1000,
+        workflowName: "wf",
+        runId: "run-1",
+        stepIndex: 0,
+        event: LedgerEvent.StepStart,
+      });
+      throw new Error("fail after event");
+    };
+
+    const events: LedgerEntry[] = [];
+    const stream = makeStream("wf", "run-1", makeAdapter(), fakeControl, execute);
+    await expect(async () => {
+      for await (const e of stream) events.push(e as LedgerEntry);
+    }).rejects.toThrow("fail after event");
+
+    expect(events.some((e) => e.event === LedgerEvent.StepStart)).toBe(true);
+  });
+
+  it("includes name and runId on the RunStarted event", async () => {
+    const events = await collect(makeStream("deploy", "abc-123", makeAdapter(), fakeControl, async () => {}));
+    expect(events[0]).toMatchObject({ workflowName: "deploy", runId: "abc-123", stepIndex: -1 });
+  });
+});

--- a/packages/sdks/typescript/tsconfig.test.json
+++ b/packages/sdks/typescript/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/sdks/typescript/vitest.config.ts
+++ b/packages/sdks/typescript/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Sets up Vitest per-package (core, sdks/typescript) following the same pattern as withastro/flue — package-level devDep, vitest.config.ts, tests in test/ directories. Adds 55 tests covering utils, validate, builder DSL, and stream engine. Pins all "latest" and "^" ranges to exact installed versions for stable installs across all packages.