### PR TITLE
feat: add CI test job, root test script, and extended test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.9
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -43,6 +43,25 @@ jobs:
         run: bunx tsc --noEmit --strict
         working-directory: packages/adapters/sqlite
 
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build workspace declarations
+        run: bunx tsc --project packages/opensandbox/tsconfig.build.json && bunx tsc --project packages/core/tsconfig.build.json
+
+      - name: Run tests
+        run: bun run test
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -51,7 +70,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.9
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install
@@ -70,7 +89,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.9
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   ],
   "scripts": {
     "build": "bunx tsc --project packages/opensandbox/tsconfig.build.json && bunx tsc --project packages/core/tsconfig.build.json && bun run --cwd packages/sdks/typescript build",
-    "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/otel/tsconfig.json"
+    "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/otel/tsconfig.json",
+    "test": "bun run --cwd packages/core test && bun run --cwd packages/sdks/typescript test && bun run --cwd packages/adapters/sqlite test"
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0"

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "@drej/core": "workspace:*"
   },
+  "scripts": {
+    "test": "bun test"
+  },
   "devDependencies": {
     "bun-types": "1.3.14",
     "typescript": "6.0.3"

--- a/packages/adapters/sqlite/test/adapter.test.ts
+++ b/packages/adapters/sqlite/test/adapter.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { LedgerEvent, RunStatus, type LedgerEntry } from "@drej/core";
+import { SQLiteAdapter } from "../src/adapter.ts";
+
+function entry(overrides?: Partial<LedgerEntry>): LedgerEntry {
+  return {
+    ts: Date.now(),
+    workflowName: "test-wf",
+    runId: "run-1",
+    stepIndex: 0,
+    event: LedgerEvent.StepStart,
+    ...overrides,
+  };
+}
+
+describe("SQLiteAdapter", () => {
+  let db: SQLiteAdapter;
+
+  beforeEach(async () => {
+    db = new SQLiteAdapter(":memory:");
+    await db.connect();
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  // ── append / readAll ────────────────────────────────────────────────────────
+
+  describe("append / readAll", () => {
+    it("stores and retrieves an entry", async () => {
+      await db.append(entry({ event: LedgerEvent.StepStart }));
+      const rows = await db.readAll("test-wf", "run-1");
+      expect(rows).toHaveLength(1);
+      expect(rows[0].event).toBe(LedgerEvent.StepStart);
+    });
+
+    it("returns entries in ascending timestamp order", async () => {
+      await db.append(entry({ ts: 2000, event: LedgerEvent.StepComplete }));
+      await db.append(entry({ ts: 1000, event: LedgerEvent.StepStart }));
+      const rows = await db.readAll("test-wf", "run-1");
+      expect(rows[0].ts).toBe(1000);
+      expect(rows[1].ts).toBe(2000);
+    });
+
+    it("scopes to the given workflow name and run id", async () => {
+      await db.append(entry({ workflowName: "wf-a", runId: "r1" }));
+      await db.append(entry({ workflowName: "wf-b", runId: "r2" }));
+      expect(await db.readAll("wf-a", "r1")).toHaveLength(1);
+      expect(await db.readAll("wf-b", "r2")).toHaveLength(1);
+      expect(await db.readAll("wf-a", "r2")).toHaveLength(0);
+    });
+
+    it("serialises and deserialises JSON payload", async () => {
+      await db.append(entry({ payload: { key: "value", n: 42 } }));
+      const rows = await db.readAll("test-wf", "run-1");
+      expect(rows[0].payload).toEqual({ key: "value", n: 42 });
+    });
+
+    it("preserves null payload as undefined", async () => {
+      await db.append(entry({ payload: undefined }));
+      const rows = await db.readAll("test-wf", "run-1");
+      expect(rows[0].payload).toBeUndefined();
+    });
+
+    it("preserves the branch field", async () => {
+      await db.append(entry({ branch: 2 }));
+      const rows = await db.readAll("test-wf", "run-1");
+      expect(rows[0].branch).toBe(2);
+    });
+
+    it("returns undefined branch when not set", async () => {
+      await db.append(entry());
+      const rows = await db.readAll("test-wf", "run-1");
+      expect(rows[0].branch).toBeUndefined();
+    });
+  });
+
+  // ── lastCheckpoint ──────────────────────────────────────────────────────────
+
+  describe("lastCheckpoint", () => {
+    it("returns null when no checkpoint exists", async () => {
+      expect(await db.lastCheckpoint("test-wf", "run-1")).toBeNull();
+    });
+
+    it("returns the most recent checkpoint", async () => {
+      await db.append(entry({ ts: 1000, event: LedgerEvent.Checkpoint, payload: { step: 1 } }));
+      await db.append(entry({ ts: 2000, event: LedgerEvent.Checkpoint, payload: { step: 2 } }));
+      const cp = await db.lastCheckpoint("test-wf", "run-1");
+      expect((cp!.payload as any).step).toBe(2);
+    });
+
+    it("ignores non-checkpoint events", async () => {
+      await db.append(entry({ event: LedgerEvent.StepStart }));
+      expect(await db.lastCheckpoint("test-wf", "run-1")).toBeNull();
+    });
+  });
+
+  // ── run details ─────────────────────────────────────────────────────────────
+
+  async function seedRun(wf: string, runId: string, terminal: LedgerEvent.WorkflowComplete | LedgerEvent.WorkflowFailed, error?: string) {
+    const ts = Date.now();
+    await db.append(entry({ workflowName: wf, runId, ts, stepIndex: -1, event: LedgerEvent.RunStarted }));
+    await db.append(entry({ workflowName: wf, runId, ts: ts + 1, stepIndex: 0, event: LedgerEvent.StepComplete }));
+    await db.append(entry({ workflowName: wf, runId, ts: ts + 2, stepIndex: -1, event: terminal, error }));
+  }
+
+  describe("getRunDetails", () => {
+    it("returns null for an unknown run", async () => {
+      expect(await db.getRunDetails("wf", "no-such-run")).toBeNull();
+    });
+
+    it("returns Completed status", async () => {
+      await seedRun("wf", "run-1", LedgerEvent.WorkflowComplete);
+      const d = await db.getRunDetails("wf", "run-1");
+      expect(d?.status).toBe(RunStatus.Completed);
+      expect(d?.stepCount).toBe(1);
+    });
+
+    it("returns Failed status with error message", async () => {
+      await seedRun("wf", "run-1", LedgerEvent.WorkflowFailed, "boom");
+      const d = await db.getRunDetails("wf", "run-1");
+      expect(d?.status).toBe(RunStatus.Failed);
+      expect(d?.error).toBe("boom");
+    });
+
+    it("returns Running when no terminal event present", async () => {
+      await db.append(entry({ stepIndex: -1, event: LedgerEvent.RunStarted }));
+      const d = await db.getRunDetails("test-wf", "run-1");
+      expect(d?.status).toBe(RunStatus.Running);
+    });
+  });
+
+  describe("listRunDetails", () => {
+    it("scopes to a single workflow", async () => {
+      await seedRun("wf-a", "r1", LedgerEvent.WorkflowComplete);
+      await seedRun("wf-b", "r2", LedgerEvent.WorkflowComplete);
+      const results = await db.listRunDetails("wf-a");
+      expect(results).toHaveLength(1);
+      expect(results[0].workflowName).toBe("wf-a");
+    });
+
+    it("filters by status", async () => {
+      await seedRun("wf", "r1", LedgerEvent.WorkflowComplete);
+      await seedRun("wf", "r2", LedgerEvent.WorkflowFailed);
+      const completed = await db.listRunDetails("wf", { status: RunStatus.Completed });
+      expect(completed).toHaveLength(1);
+      expect(completed[0].runId).toBe("r1");
+    });
+
+    it("respects the limit option", async () => {
+      await seedRun("wf", "r1", LedgerEvent.WorkflowComplete);
+      await seedRun("wf", "r2", LedgerEvent.WorkflowComplete);
+      expect(await db.listRunDetails("wf", { limit: 1 })).toHaveLength(1);
+    });
+  });
+
+  describe("listAllRunDetails", () => {
+    it("returns runs across all workflows", async () => {
+      await seedRun("wf-a", "r1", LedgerEvent.WorkflowComplete);
+      await seedRun("wf-b", "r2", LedgerEvent.WorkflowComplete);
+      expect(await db.listAllRunDetails()).toHaveLength(2);
+    });
+
+    it("filters by status across workflows", async () => {
+      await seedRun("wf-a", "r1", LedgerEvent.WorkflowComplete);
+      await seedRun("wf-b", "r2", LedgerEvent.WorkflowFailed);
+      const failed = await db.listAllRunDetails({ status: RunStatus.Failed });
+      expect(failed).toHaveLength(1);
+      expect(failed[0].workflowName).toBe("wf-b");
+    });
+  });
+
+  describe("deleteRun", () => {
+    it("removes all entries for the run", async () => {
+      await seedRun("wf", "run-1", LedgerEvent.WorkflowComplete);
+      await db.deleteRun("wf", "run-1");
+      expect(await db.readAll("wf", "run-1")).toHaveLength(0);
+      expect(await db.getRunDetails("wf", "run-1")).toBeNull();
+    });
+
+    it("does not affect other runs", async () => {
+      await seedRun("wf", "r1", LedgerEvent.WorkflowComplete);
+      await seedRun("wf", "r2", LedgerEvent.WorkflowComplete);
+      await db.deleteRun("wf", "r1");
+      expect(await db.getRunDetails("wf", "r2")).not.toBeNull();
+    });
+  });
+});

--- a/packages/core/test/control-flow.test.ts
+++ b/packages/core/test/control-flow.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildConditionalStep,
+  buildLoopStep,
+  buildParallelStep,
+  buildRetryStep,
+  buildSequenceStep,
+} from "../src/steps/control-flow.ts";
+import { Backoff, StepType, type StepDef } from "../src/steps/types.ts";
+import type { WorkflowRunContext, WorkflowStep } from "../src/workflow.ts";
+
+function makeCtx(overrides?: Partial<WorkflowRunContext>): WorkflowRunContext {
+  return {
+    workflowName: "test-wf",
+    runId: "run-1",
+    stepIndex: 0,
+    control: {} as any,
+    resolveExec: async () => ({} as any),
+    emit: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeStep(fn: (input: unknown) => Promise<unknown>): WorkflowStep {
+  return { id: "test", run: (input) => fn(input) };
+}
+
+const identity: WorkflowStep = { id: "identity", run: (input) => Promise.resolve(input) };
+
+// ── buildRetryStep ────────────────────────────────────────────────────────────
+
+describe("buildRetryStep", () => {
+  function retryDef(maxAttempts: number, extra?: object): Extract<StepDef, { type: StepType.Retry }> {
+    return { type: StepType.Retry, maxAttempts, delayMs: 0, step: { type: StepType.ExecCommand, command: "x" }, ...extra };
+  }
+
+  it("returns result on first success", async () => {
+    const step = buildRetryStep(retryDef(3), () => makeStep(async () => "ok"));
+    expect(await step.run({}, makeCtx())).toBe("ok");
+  });
+
+  it("retries and succeeds on a later attempt", async () => {
+    let calls = 0;
+    const step = buildRetryStep(retryDef(3), () =>
+      makeStep(async () => {
+        if (++calls < 3) throw new Error("fail");
+        return "ok";
+      }),
+    );
+    expect(await step.run({}, makeCtx())).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("throws the last error after maxAttempts exhausted", async () => {
+    const step = buildRetryStep(retryDef(3), () =>
+      makeStep(async () => { throw new Error("always fails"); }),
+    );
+    await expect(step.run({}, makeCtx())).rejects.toThrow("always fails");
+  });
+
+  it("emits a retry event for each failed attempt except the last", async () => {
+    let calls = 0;
+    const ctx = makeCtx();
+    const step = buildRetryStep(retryDef(3), () =>
+      makeStep(async () => {
+        if (++calls < 3) throw new Error("fail");
+        return "ok";
+      }),
+    );
+    await step.run({}, ctx);
+    expect(ctx.emit).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses exponential delay when backoff is Exponential", async () => {
+    // delayMs: 0 makes exponential delay 0 * 2^n = 0ms — no real wait
+    let calls = 0;
+    const step = buildRetryStep(
+      retryDef(3, { backoff: Backoff.Exponential }),
+      () => makeStep(async () => {
+        if (++calls < 3) throw new Error("fail");
+        return "done";
+      }),
+    );
+    expect(await step.run({}, makeCtx())).toBe("done");
+  });
+
+  it("inherits rollback from the child step", async () => {
+    const rollback = vi.fn().mockResolvedValue(undefined);
+    const step = buildRetryStep(retryDef(1), () => ({ id: "child", run: async (i) => i, rollback }));
+    expect(step.rollback).toBe(rollback);
+  });
+});
+
+// ── buildConditionalStep ──────────────────────────────────────────────────────
+
+describe("buildConditionalStep", () => {
+  it("runs the then branch when condition is true", async () => {
+    let ran = false;
+    const step = buildConditionalStep(
+      { type: StepType.Conditional, condition: { op: "eq", field: "x", value: 1 }, then: [{ type: StepType.ExecCommand, command: "t" }] },
+      () => makeStep(async (i) => { ran = true; return i; }),
+    );
+    await step.run({ x: 1 }, makeCtx());
+    expect(ran).toBe(true);
+  });
+
+  it("runs the else branch when condition is false", async () => {
+    const order: string[] = [];
+    const step = buildConditionalStep(
+      {
+        type: StepType.Conditional,
+        condition: { op: "eq", field: "x", value: 1 },
+        then: [{ type: StepType.ExecCommand, command: "then" }],
+        else: [{ type: StepType.ExecCommand, command: "else" }],
+      },
+      (def) => makeStep(async (i) => {
+        order.push((def as any).command);
+        return i;
+      }),
+    );
+    await step.run({ x: 99 }, makeCtx());
+    expect(order).toEqual(["else"]);
+  });
+
+  it("returns input unchanged when condition is false and no else branch", async () => {
+    const step = buildConditionalStep(
+      { type: StepType.Conditional, condition: { op: "eq", field: "x", value: 1 }, then: [{ type: StepType.ExecCommand, command: "t" }] },
+      () => identity,
+    );
+    const input = { x: 0 };
+    expect(await step.run(input, makeCtx())).toBe(input);
+  });
+
+  it("passes state through branch steps in sequence", async () => {
+    const step = buildConditionalStep(
+      {
+        type: StepType.Conditional,
+        condition: { op: "eq", field: "x", value: 1 },
+        then: [
+          { type: StepType.ExecCommand, command: "a" },
+          { type: StepType.ExecCommand, command: "b" },
+        ],
+      },
+      (def) => makeStep(async (i) => ({ ...(i as any), [(def as any).command]: true })),
+    );
+    const result = await step.run({ x: 1 }, makeCtx()) as any;
+    expect(result.a).toBe(true);
+    expect(result.b).toBe(true);
+  });
+});
+
+// ── buildLoopStep ─────────────────────────────────────────────────────────────
+
+describe("buildLoopStep", () => {
+  function loopDef(extra: object): Extract<StepDef, { type: StepType.Loop }> {
+    return { type: StepType.Loop, as: "item", steps: [{ type: StepType.ExecCommand, command: "x" }], ...extra };
+  }
+
+  it("iterates over static items and returns loopResults", async () => {
+    const seen: unknown[] = [];
+    const step = buildLoopStep(loopDef({ items: [1, 2, 3] }), () =>
+      makeStep(async (i) => { seen.push((i as any).item); return i; }),
+    );
+    const out = await step.run({}, makeCtx()) as any;
+    expect(seen).toEqual([1, 2, 3]);
+    expect(out.loopResults).toHaveLength(3);
+  });
+
+  it("reads items from state when using over", async () => {
+    const seen: unknown[] = [];
+    const step = buildLoopStep(loopDef({ over: "files" }), () =>
+      makeStep(async (i) => { seen.push((i as any).item); return i; }),
+    );
+    await step.run({ files: ["a.txt", "b.txt"] }, makeCtx());
+    expect(seen).toEqual(["a.txt", "b.txt"]);
+  });
+
+  it("sets the loop variable and loopIndex in state", async () => {
+    const captured: Array<{ item: unknown; index: number }> = [];
+    const step = buildLoopStep(loopDef({ items: ["a", "b"] }), () =>
+      makeStep(async (i) => {
+        captured.push({ item: (i as any).item, index: (i as any).loopIndex });
+        return i;
+      }),
+    );
+    await step.run({}, makeCtx());
+    expect(captured).toEqual([{ item: "a", index: 0 }, { item: "b", index: 1 }]);
+  });
+
+  it("throws when neither items nor over resolves to an array", async () => {
+    const step = buildLoopStep({ type: StepType.Loop, as: "x", steps: [] } as any, () => identity);
+    await expect(step.run({}, makeCtx())).rejects.toThrow("loop:");
+  });
+
+  it("respects maxConcurrency when running iterations", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const step = buildLoopStep(loopDef({ items: [1, 2, 3, 4], maxConcurrency: 2 }), () =>
+      makeStep(async (i) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 10));
+        active--;
+        return i;
+      }),
+    );
+    await step.run({}, makeCtx());
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+});
+
+// ── buildParallelStep ─────────────────────────────────────────────────────────
+
+describe("buildParallelStep", () => {
+  it("runs all branches and merges results", async () => {
+    const step = buildParallelStep(
+      {
+        type: StepType.Parallel,
+        steps: [
+          { type: StepType.ExecCommand, command: "a" },
+          { type: StepType.ExecCommand, command: "b" },
+        ],
+      },
+      (def) => makeStep(async (i) => ({ ...(i as any), [(def as any).command]: true })),
+    );
+    const result = await step.run({ base: 1 }, makeCtx()) as any;
+    expect(result.a).toBe(true);
+    expect(result.b).toBe(true);
+    expect(result.parallelResults).toHaveLength(2);
+  });
+
+  it("tags emitted events with the branch index", async () => {
+    const ctx = makeCtx();
+    const step = buildParallelStep(
+      {
+        type: StepType.Parallel,
+        steps: [
+          { type: StepType.ExecCommand, command: "a" },
+          { type: StepType.ExecCommand, command: "b" },
+        ],
+      },
+      () => makeStep(async (i) => {
+        // Do nothing, just let the branch ctx emit
+        return i;
+      }),
+    );
+    await step.run({}, ctx);
+    // branch ctx is internal — just verify the step completes cleanly
+  });
+
+  it("respects maxConcurrency across branches", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const step = buildParallelStep(
+      {
+        type: StepType.Parallel,
+        steps: new Array(4).fill({ type: StepType.ExecCommand, command: "x" }),
+        maxConcurrency: 2,
+      },
+      () => makeStep(async (i) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 10));
+        active--;
+        return i;
+      }),
+    );
+    await step.run({}, makeCtx());
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+});
+
+// ── buildSequenceStep ─────────────────────────────────────────────────────────
+
+describe("buildSequenceStep", () => {
+  it("runs steps in order, passing output as next input", async () => {
+    const step = buildSequenceStep(
+      {
+        type: StepType.Sequence,
+        steps: [
+          { type: StepType.ExecCommand, command: "a" },
+          { type: StepType.ExecCommand, command: "b" },
+        ],
+      },
+      (def) => makeStep(async (i) => ({ ...(i as any), [(def as any).command]: true })),
+    );
+    const result = await step.run({}, makeCtx()) as any;
+    expect(result.a).toBe(true);
+    expect(result.b).toBe(true);
+  });
+
+  it("rollback runs completed steps in reverse order", async () => {
+    const order: string[] = [];
+    const step = buildSequenceStep(
+      {
+        type: StepType.Sequence,
+        steps: [
+          { type: StepType.ExecCommand, command: "a" },
+          { type: StepType.ExecCommand, command: "b" },
+          { type: StepType.ExecCommand, command: "c" },
+        ],
+      },
+      (def) => ({
+        id: (def as any).command,
+        run: async (i: unknown) => i,
+        rollback: async () => { order.push((def as any).command); },
+      }),
+    );
+    const ctx = makeCtx();
+    await step.run({}, ctx);
+    await step.rollback!({}, ctx);
+    expect(order).toEqual(["c", "b", "a"]);
+  });
+
+  it("skips rollback for steps that have no rollback handler", async () => {
+    const rolledBack: string[] = [];
+    const step = buildSequenceStep(
+      {
+        type: StepType.Sequence,
+        steps: [
+          { type: StepType.ExecCommand, command: "a" },
+          { type: StepType.ExecCommand, command: "b" },
+        ],
+      },
+      (def) => {
+        const cmd = (def as any).command;
+        return cmd === "b"
+          ? { id: cmd, run: async (i: unknown) => i, rollback: async () => { rolledBack.push(cmd); } }
+          : { id: cmd, run: async (i: unknown) => i };
+      },
+    );
+    const ctx = makeCtx();
+    await step.run({}, ctx);
+    await step.rollback!({}, ctx);
+    expect(rolledBack).toEqual(["b"]);
+  });
+});


### PR DESCRIPTION
Adds a test job to CI (parallel to typecheck/build) running all suites via bun run test. Wires a root test script that fans out to core (vitest), sdks/typescript (vitest), and adapters/sqlite (bun test). New tests cover all control-flow builders (retry, conditional, loop, parallel, sequence) and the full SQLiteAdapter surface (append, readAll, checkpoint, run details, filtering, deleteRun). Also bumps bun version in all CI jobs from 1.3.9 to 1.3.14 to match pinned bun-types.