### PR TITLE
feat: add file ops steps and ref() builder API

### DIFF
--- a/.changeset/file-ops-and-ref.md
+++ b/.changeset/file-ops-and-ref.md
@@ -1,0 +1,28 @@
+---
+"drej": minor
+"@drej/core": minor
+---
+
+Add file ops steps and `ref()` builder API
+
+New step types: `deleteFile`, `moveFile`, `listDirectory`, `searchFiles`.
+
+`listDirectory` stores `DirectoryEntry[]` in state under the given key; `searchFiles` stores `string[]` which can be passed directly to `forEach`.
+
+New `ref<T>(name)` function creates a typed state reference. Use it instead of raw `"{{name}}"` strings anywhere the builder accepts a captured value:
+
+```ts
+const sha = ref<string>("sha")
+const tsFiles = ref<string[]>("tsFiles")
+
+workflow("build").sandbox({ image: { uri: "node:20" } }, (s) =>
+  s.exec("git rev-parse HEAD", { capture: sha })
+   .searchFiles("**/*.ts", { as: tsFiles })
+   .forEach(tsFiles, (s, file) => s.exec(`tsc ${file}`))
+   .exec("deploy.sh", { envs: { GIT_SHA: sha } })
+)
+```
+
+`Ref<T>` objects also work naturally in template literals: `` `echo ${sha}` `` expands to `"echo {{sha}}"` at build time.
+
+Also fixes: `cwd` and `envs` values in `exec()` are now interpolated against workflow state at runtime (previously passed verbatim).

--- a/packages/core/src/steps/exec.ts
+++ b/packages/core/src/steps/exec.ts
@@ -16,10 +16,14 @@ export function buildExecCommandStep(def: Extract<StepDef, { type: StepType.Exec
       const raw = interpolate(def.command, state);
       // base64-encode so newlines, quotes, special chars survive the JSON boundary
       const command = `echo ${Buffer.from(raw).toString("base64")} | base64 -d | bash`;
+      const cwd = def.cwd ? interpolate(def.cwd, state) : undefined;
+      const envs = def.envs
+        ? Object.fromEntries(Object.entries(def.envs).map(([k, v]) => [k, interpolate(v, state)]))
+        : undefined;
       const events: SSEEvent[] = [];
       let exitCode = 0;
       const stdoutChunks: string[] = [];
-      for await (const ev of exec.executeCommand({ command, cwd: def.cwd, envs: def.envs })) {
+      for await (const ev of exec.executeCommand({ command, cwd, envs })) {
         await ctx.emit({
           ts: Date.now(),
           workflowName: ctx.workflowName,

--- a/packages/core/src/steps/file.ts
+++ b/packages/core/src/steps/file.ts
@@ -1,5 +1,6 @@
 import type { WorkflowRunContext, WorkflowStep } from "../workflow";
 import { StepType, Encoding, type StepDef, type WorkflowState } from "./types";
+import { interpolate } from "./utils";
 
 export function buildWriteFileStep(def: Extract<StepDef, { type: StepType.WriteFile }>): WorkflowStep {
   return {
@@ -8,10 +9,11 @@ export function buildWriteFileStep(def: Extract<StepDef, { type: StepType.WriteF
       const state = (input ?? {}) as WorkflowState;
       if (!state.sandboxId) throw new Error("write_file requires sandboxId in workflow state");
       const exec = await ctx.resolveExec(state.sandboxId);
+      const path = interpolate(def.path, state);
       const content: string | ArrayBuffer = def.encoding === Encoding.Base64
         ? Buffer.from(def.content, "base64").buffer as ArrayBuffer
-        : def.content;
-      await exec.uploadFile(def.path, content);
+        : interpolate(def.content, state);
+      await exec.uploadFile(path, content);
       return state;
     },
   };
@@ -24,7 +26,7 @@ export function buildReadFileStep(def: Extract<StepDef, { type: StepType.ReadFil
       const state = (input ?? {}) as WorkflowState;
       if (!state.sandboxId) throw new Error("read_file requires sandboxId in workflow state");
       const exec = await ctx.resolveExec(state.sandboxId);
-      const stream = await exec.downloadFile(def.path);
+      const stream = await exec.downloadFile(interpolate(def.path, state));
       const chunks: Uint8Array[] = [];
       const reader = stream.getReader();
       try {
@@ -39,6 +41,59 @@ export function buildReadFileStep(def: Extract<StepDef, { type: StepType.ReadFil
       const bytes = Buffer.concat(chunks);
       const content = def.encoding === Encoding.Base64 ? bytes.toString("base64") : bytes.toString("utf8");
       return { ...state, [def.as]: content };
+    },
+  };
+}
+
+export function buildDeleteFileStep(def: Extract<StepDef, { type: StepType.DeleteFile }>): WorkflowStep {
+  return {
+    id: StepType.DeleteFile,
+    async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+      const state = (input ?? {}) as WorkflowState;
+      if (!state.sandboxId) throw new Error("delete_file requires sandboxId in workflow state");
+      const exec = await ctx.resolveExec(state.sandboxId);
+      await exec.deleteFile(interpolate(def.path, state));
+      return state;
+    },
+  };
+}
+
+export function buildMoveFileStep(def: Extract<StepDef, { type: StepType.MoveFile }>): WorkflowStep {
+  return {
+    id: StepType.MoveFile,
+    async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+      const state = (input ?? {}) as WorkflowState;
+      if (!state.sandboxId) throw new Error("move_file requires sandboxId in workflow state");
+      const exec = await ctx.resolveExec(state.sandboxId);
+      await exec.moveFile(interpolate(def.from, state), interpolate(def.to, state));
+      return state;
+    },
+  };
+}
+
+export function buildListDirectoryStep(def: Extract<StepDef, { type: StepType.ListDirectory }>): WorkflowStep {
+  return {
+    id: StepType.ListDirectory,
+    async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+      const state = (input ?? {}) as WorkflowState;
+      if (!state.sandboxId) throw new Error("list_directory requires sandboxId in workflow state");
+      const exec = await ctx.resolveExec(state.sandboxId);
+      const entries = await exec.listDirectory(interpolate(def.path, state), def.depth);
+      return { ...state, [def.as]: entries };
+    },
+  };
+}
+
+export function buildSearchFilesStep(def: Extract<StepDef, { type: StepType.SearchFiles }>): WorkflowStep {
+  return {
+    id: StepType.SearchFiles,
+    async run(input: unknown, ctx: WorkflowRunContext): Promise<unknown> {
+      const state = (input ?? {}) as WorkflowState;
+      if (!state.sandboxId) throw new Error("search_files requires sandboxId in workflow state");
+      const exec = await ctx.resolveExec(state.sandboxId);
+      const dir = def.dir ? interpolate(def.dir, state) : undefined;
+      const matches = await exec.searchFiles(interpolate(def.pattern, state), dir);
+      return { ...state, [def.as]: matches };
     },
   };
 }

--- a/packages/core/src/steps/index.ts
+++ b/packages/core/src/steps/index.ts
@@ -2,7 +2,7 @@ import type { WorkflowStep } from "../workflow";
 import { StepType, type StepDef } from "./types";
 import { buildCreateSandboxStep, buildDeleteSandboxStep } from "./sandbox";
 import { buildExecCommandStep, buildExecCodeStep } from "./exec";
-import { buildWriteFileStep, buildReadFileStep } from "./file";
+import { buildWriteFileStep, buildReadFileStep, buildDeleteFileStep, buildMoveFileStep, buildListDirectoryStep, buildSearchFilesStep } from "./file";
 import { buildSnapshotStep } from "./snapshot";
 import {
   buildRetryStep,
@@ -20,6 +20,10 @@ export function buildStep(def: StepDef): WorkflowStep {
     case StepType.ExecCode:      return buildExecCodeStep(def);
     case StepType.WriteFile:     return buildWriteFileStep(def);
     case StepType.ReadFile:      return buildReadFileStep(def);
+    case StepType.DeleteFile:    return buildDeleteFileStep(def);
+    case StepType.MoveFile:      return buildMoveFileStep(def);
+    case StepType.ListDirectory: return buildListDirectoryStep(def);
+    case StepType.SearchFiles:   return buildSearchFilesStep(def);
     case StepType.Snapshot:      return buildSnapshotStep();
     case StepType.Retry:         return buildRetryStep(def, buildStep);
     case StepType.Conditional:   return buildConditionalStep(def, buildStep);

--- a/packages/core/src/steps/types.ts
+++ b/packages/core/src/steps/types.ts
@@ -13,6 +13,10 @@ export enum StepType {
   DeleteSandbox = "delete_sandbox",
   WriteFile     = "write_file",
   ReadFile      = "read_file",
+  DeleteFile    = "delete_file",
+  MoveFile      = "move_file",
+  ListDirectory = "list_directory",
+  SearchFiles   = "search_files",
   Snapshot      = "snapshot",
   Retry         = "retry",
   Conditional   = "conditional",
@@ -47,6 +51,10 @@ export type StepDef =
   | { type: StepType.DeleteSandbox }
   | { type: StepType.WriteFile; path: string; content: string; encoding?: Encoding }
   | { type: StepType.ReadFile; path: string; as: string; encoding?: Encoding }
+  | { type: StepType.DeleteFile; path: string }
+  | { type: StepType.MoveFile; from: string; to: string }
+  | { type: StepType.ListDirectory; path: string; as: string; depth?: number }
+  | { type: StepType.SearchFiles; pattern: string; as: string; dir?: string }
   | { type: StepType.Snapshot }
   | { type: StepType.Retry; step: StepDef; maxAttempts: number; delayMs?: number; backoff?: Backoff }
   | { type: StepType.Conditional; condition: Predicate; then: StepDef[]; else?: StepDef[] }

--- a/packages/sdks/typescript/src/builder/index.ts
+++ b/packages/sdks/typescript/src/builder/index.ts
@@ -1,3 +1,4 @@
 export { workflow, WorkflowBuilder } from "./workflow";
 export { SandboxStepBuilder, CodeLanguage } from "./sandbox-step";
-export type { SandboxOpts, LoopItem } from "./types";
+export { ref } from "./types";
+export type { SandboxOpts, LoopItem, Ref } from "./types";

--- a/packages/sdks/typescript/src/builder/sandbox-step.ts
+++ b/packages/sdks/typescript/src/builder/sandbox-step.ts
@@ -1,12 +1,12 @@
 import type { StepDef, Predicate } from "@drej/core";
 import { StepType, Encoding, Backoff } from "@drej/core";
 import { CodeLanguage } from "@drej/opensandbox";
-import { createLoopVar, wrapSteps, type LoopItem } from "./types";
+import { createLoopVar, wrapSteps, refKey, refStr, Ref, type LoopItem } from "./types";
 
 export { CodeLanguage };
 
 type ForEachOpts = { concurrency?: number; as?: string };
-type ForEachSource = unknown[] | { from: string };
+type ForEachSource = unknown[] | { from: string } | Ref<unknown[]>;
 type ForEachCallback = (s: SandboxStepBuilder, item: LoopItem) => SandboxStepBuilder | string;
 
 /**
@@ -31,8 +31,15 @@ export class SandboxStepBuilder {
    * s.exec("npm test", { strict: true })
    * ```
    */
-  exec(command: string, opts?: { cwd?: string; envs?: Record<string, string>; capture?: string; strict?: boolean }): this {
-    this._steps.push({ type: StepType.ExecCommand, command, ...opts });
+  exec(command: string, opts?: { cwd?: string; envs?: Record<string, Ref<string> | string>; capture?: Ref<string> | string; strict?: boolean }): this {
+    this._steps.push({
+      type: StepType.ExecCommand,
+      command,
+      ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      ...(opts?.envs ? { envs: Object.fromEntries(Object.entries(opts.envs).map(([k, v]) => [k, refStr(v)])) } : {}),
+      ...(opts?.capture !== undefined ? { capture: refKey(opts.capture) } : {}),
+      ...(opts?.strict !== undefined ? { strict: opts.strict } : {}),
+    });
     return this;
   }
 
@@ -62,8 +69,8 @@ export class SandboxStepBuilder {
    *  .exec("echo Result was {{result}}")
    * ```
    */
-  readFile(path: string, opts: { as: string; encoding?: Encoding }): this {
-    this._steps.push({ type: StepType.ReadFile, path, as: opts.as, ...(opts.encoding ? { encoding: opts.encoding } : {}) });
+  readFile(path: string, opts: { as: Ref<string> | string; encoding?: Encoding }): this {
+    this._steps.push({ type: StepType.ReadFile, path, as: refKey(opts.as), ...(opts.encoding ? { encoding: opts.encoding } : {}) });
     return this;
   }
 
@@ -89,8 +96,8 @@ export class SandboxStepBuilder {
    * s.writeFile("/app/data.bin", b64data, Encoding.Base64)
    * ```
    */
-  writeFile(path: string, content: string, encoding?: Encoding): this {
-    this._steps.push({ type: StepType.WriteFile, path, content, ...(encoding ? { encoding } : {}) });
+  writeFile(path: string, content: Ref<string> | string, encoding?: Encoding): this {
+    this._steps.push({ type: StepType.WriteFile, path, content: refStr(content), ...(encoding ? { encoding } : {}) });
     return this;
   }
 
@@ -145,11 +152,14 @@ export class SandboxStepBuilder {
         ? [{ type: StepType.ExecCommand, command: result }]
         : result.build();
 
+    const over = Array.isArray(source) ? { items: source }
+      : source instanceof Ref ? { over: source.key }
+      : { over: (source as { from: string }).from };
     this._steps.push({
       type: StepType.Loop,
       as: varName,
       steps,
-      ...(Array.isArray(source) ? { items: source } : { over: source.from }),
+      ...over,
       ...(opts.concurrency !== undefined && opts.concurrency > 1 ? { maxConcurrency: opts.concurrency } : {}),
     });
 
@@ -190,6 +200,65 @@ export class SandboxStepBuilder {
       ...(elseSteps ? { else: elseSteps } : {}),
     });
 
+    return this;
+  }
+
+  /**
+   * Delete a file from the sandbox filesystem.
+   *
+   * @example
+   * ```ts
+   * s.deleteFile("/tmp/build.log")
+   * s.deleteFile(`/tmp/${sha}.tar.gz`)
+   * ```
+   */
+  deleteFile(path: string): this {
+    this._steps.push({ type: StepType.DeleteFile, path });
+    return this;
+  }
+
+  /**
+   * Move or rename a file inside the sandbox filesystem.
+   *
+   * @example
+   * ```ts
+   * s.moveFile("/app/dist", "/app/release")
+   * s.moveFile(`/tmp/${sha}`, "/app/current")
+   * ```
+   */
+  moveFile(from: string, to: string): this {
+    this._steps.push({ type: StepType.MoveFile, from, to });
+    return this;
+  }
+
+  /**
+   * List a directory inside the sandbox and store the entries in workflow state.
+   *
+   * @example
+   * ```ts
+   * const entries = ref<DirectoryEntry[]>("entries")
+   * s.listDirectory("/app/dist", { as: entries })
+   *  .forEach(entries, (s, entry) => s.exec(`echo ${entry}`))
+   * ```
+   */
+  listDirectory(path: string, opts: { as: Ref<unknown[]> | string; depth?: number }): this {
+    this._steps.push({ type: StepType.ListDirectory, path, as: refKey(opts.as), ...(opts.depth !== undefined ? { depth: opts.depth } : {}) });
+    return this;
+  }
+
+  /**
+   * Search for files matching a glob pattern and store the matching paths in workflow state.
+   * The result is a `string[]` that can be passed directly to `forEach`.
+   *
+   * @example
+   * ```ts
+   * const tsFiles = ref<string[]>("tsFiles")
+   * s.searchFiles("**\/*.ts", { as: tsFiles })
+   *  .forEach(tsFiles, (s, file) => s.exec(`tsc --noEmit ${file}`))
+   * ```
+   */
+  searchFiles(pattern: string, opts: { as: Ref<string[]> | string; dir?: string }): this {
+    this._steps.push({ type: StepType.SearchFiles, pattern, as: refKey(opts.as), ...(opts.dir !== undefined ? { dir: opts.dir } : {}) });
     return this;
   }
 

--- a/packages/sdks/typescript/src/builder/types.ts
+++ b/packages/sdks/typescript/src/builder/types.ts
@@ -1,6 +1,31 @@
 import { StepType, type StepDef } from "@drej/core";
 import type { ImageSpec, Resources } from "@drej/opensandbox";
 
+/**
+ * A typed reference to a workflow state key. Use `ref("name")` to create one.
+ * Resolves to the value stored under `name` in workflow state at runtime.
+ * Works naturally in template literals: `\`echo ${sha}\`` → `"echo {{sha}}"`.
+ */
+export class Ref<T> {
+  constructor(readonly key: string) {}
+  toString(): string { return `{{${this.key}}}`; }
+}
+
+/** Create a typed reference to a workflow state key. */
+export function ref<T>(name: string): Ref<T> {
+  return new Ref<T>(name);
+}
+
+/** @internal */
+export function refKey(val: Ref<unknown> | string): string {
+  return val instanceof Ref ? val.key : val;
+}
+
+/** @internal */
+export function refStr(val: Ref<unknown> | string): string {
+  return val instanceof Ref ? val.toString() : val;
+}
+
 /** Options for creating a sandbox within a workflow step. */
 export type SandboxOpts = {
   /** Container image to boot. Omit when booting from a `snapshotId`. */

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -30,6 +30,6 @@ export type {
   WorkflowFailedHookInfo,
 } from "./client";
 
-export { workflow, WorkflowBuilder, SandboxStepBuilder, CodeLanguage } from "./builder/index";
-export type { SandboxOpts, LoopItem } from "./builder/index";
+export { workflow, WorkflowBuilder, SandboxStepBuilder, CodeLanguage, ref } from "./builder/index";
+export type { SandboxOpts, LoopItem, Ref } from "./builder/index";
 export type { CodeContext } from "@drej/opensandbox";


### PR DESCRIPTION
- New step types: DeleteFile, MoveFile, ListDirectory, SearchFiles
- listDirectory stores DirectoryEntry[] in state; searchFiles stores string[] which can be passed directly to forEach
- ref<T>(name) creates a typed state reference replacing raw "{{name}}" strings
- Ref<T> works in template literals, envs values, capture, as, forEach source
- Fix: cwd and envs values in exec_command are now interpolated against state