### PR TITLE
feat: add example READMEs, enable useServerProxy, fix SDK for code-in…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Example: before writing a `bun build` command or debugging a workspace install i
 ## Commands
 
 ```bash
-# Run an example (requires uvx opensandbox-server)
+# Run an example (requires OpenSandbox server — use drejx init or uvx opensandbox-server)
 bun examples/hello-world/index.ts
 
 # Run all unit tests
@@ -41,6 +41,7 @@ bunx tsc --noEmit --strict --project packages/workflow/tsconfig.json
 bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json
 bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json
 bunx tsc --noEmit --strict --project packages/adapters/otel/tsconfig.json
+bunx tsc --noEmit --strict --project packages/cli/tsconfig.json
 
 # Changesets (required on every PR touching publishable packages)
 bunx changeset        # add a changeset
@@ -62,7 +63,7 @@ bunx changeset status # verify one exists
 ### Integration test conventions
 
 - **Run with**: `bun examples/<name>/index.ts` from the repo root (examples are also the integration tests).
-- **Requires**: `uvx opensandbox-server` running locally (see Local OpenSandbox setup).
+- **Requires**: OpenSandbox server running locally — either `drejx init` (Docker-based, recommended) or `uvx opensandbox-server` (manual). If using `drejx init`, pass `useServerProxy: true` to `new Drej(...)` so the SDK routes through the server instead of container-direct IPs.
 - **Client setup**: `new Drej({ baseUrl: ..., adapter: new SQLiteAdapter("./ledger.db") })` — no `connect()` or `close()` needed.
 - **Sandbox lifecycle**: always wrap in `try/finally { await sb.close(); }` to avoid container leaks.
 - **Assertion**: `const { stdout } = await sb.exec("cmd")` — assert on the returned value. For error cases, catch `CommandError`.
@@ -108,6 +109,17 @@ packages/adapters/sqlite/         — SQLite storage adapter (published as "@dre
 
 packages/adapters/otel/           — OpenTelemetry hooks adapter (published as "@drej/otel")
   src/index.ts                    — otelHooks(tracer, opts?) → SandboxHooks
+
+packages/cli/                     — drejx CLI (published to npm as "drejx", not part of changeset versioning)
+  src/index.ts                    — CLI entry point (shebang, command dispatch)
+  src/commands/init.ts            — drejx init: starts OpenSandbox in Docker, writes .drej/config.json
+  src/commands/add.ts             — drejx add <url>: fetches registry item, builds sandbox, checkpoints
+  src/commands/list.ts            — drejx list: prints sandboxes from .drej/sandboxes.json
+  src/commands/remove.ts          — drejx remove <name>: deletes sandbox entry
+  src/schema.ts                   — RegistryItem interface + validateRegistryItem()
+  src/config.ts                   — DrejxConfig, readConfig(), writeConfig(), serverConfigContent()
+  src/sandboxes.ts                — SandboxEntry, readSandboxes(), writeSandboxes()
+  src/docker.ts                   — checkDocker(), getContainerState(), startContainer(), runContainer(), pollHealth()
 ```
 
 ### Key design points
@@ -132,9 +144,11 @@ packages/adapters/otel/           — OpenTelemetry hooks adapter (published as 
 
 **Resource limits required**: `SandboxOptions.resources` (`{ cpu: string; memory: string; gpu?: string }`) is required — the OpenSandbox server rejects requests without it. Always pass at least `{ cpu: "500m", memory: "256Mi" }`. This applies to `client.sandbox()`, `workflow().sandbox()`, and every step in `workflow().sequence()`.
 
+**Server proxy mode**: When OpenSandbox runs in Docker (via `drejx init`), sandbox containers are on a bridge network and their IPs are unreachable from the host. Set `useServerProxy: true` in `DrejOptions` to route execd and proxy traffic through the server (`?use_server_proxy=true` on `getEndpoint`). The server then returns `{eip}/sandboxes/{id}/proxy/{port}` URLs that are reachable from the host. The server config must have `eip = "http://localhost:8080"` set — `drejx init` writes this automatically.
+
 ## Environment variables
 
-`DrejClient` is configured via constructor options, not environment variables. The consuming application is responsible for reading env vars and passing them in:
+`Drej` is configured via constructor options, not environment variables. The consuming application is responsible for reading env vars and passing them in:
 
 | Option | Description |
 |---|---|
@@ -142,8 +156,17 @@ packages/adapters/otel/           — OpenTelemetry hooks adapter (published as 
 | `apiKey` | OpenSandbox API key (empty string for local dev) |
 | `adapter` | `IStorageAdapter` implementation (SQLiteAdapter or PostgresAdapter) |
 | `maxConcurrency` | Max simultaneous workflow runs (default: unlimited) |
+| `useServerProxy` | Route execd/proxy traffic through the server — required when server runs in Docker via `drejx init` (default: `false`) |
 
 ## Local OpenSandbox setup
+
+### Option 1 — drejx init (recommended)
+
+`bunx drejx init` starts OpenSandbox in a Docker container (`opensandbox/server:latest`) and writes `~/.config/drejx/server.toml` and `.drej/config.json` automatically. This is the preferred path for users running the full drejx workflow.
+
+When using a server started this way, pass `useServerProxy: true` to `new Drej(...)` — direct container IPs are not reachable from the host over Docker's bridge network.
+
+### Option 2 — uvx (manual)
 
 Run `uvx opensandbox-server` with `~/.sandbox.toml`:
 
@@ -165,6 +188,8 @@ mode = "direct"
 [egress]
 mode = "dns"
 ```
+
+The `uvx` path does not need `useServerProxy` — the server is on the host, so direct container IPs are reachable.
 
 ## SDK focus
 

--- a/examples/cancellation/README.md
+++ b/examples/cancellation/README.md
@@ -1,0 +1,26 @@
+# cancellation
+
+Demonstrates resource cleanup and error handling patterns when commands fail or time out.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it shows
+
+| Pattern | Description |
+|---------|-------------|
+| `try/finally` | Guarantees `sb.close()` runs even when an exec throws |
+| Bash `timeout` | Limits a command's wall-clock time at the shell level |
+| `CommandError` | Catching the error thrown by a non-zero exit code |
+
+Three sandboxes run sequentially, each demonstrating one pattern.

--- a/examples/cancellation/index.ts
+++ b/examples/cancellation/index.ts
@@ -11,6 +11,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const image = "ubuntu:22.04";

--- a/examples/capture/README.md
+++ b/examples/capture/README.md
@@ -1,0 +1,24 @@
+# capture
+
+Demonstrates capturing exec stdout and using it as input for subsequent steps.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates a `node:20-slim` sandbox
+2. Runs a Node.js one-liner and captures its stdout (the Node version string)
+3. Interpolates the captured value into a subsequent exec command
+4. Writes a JSON file into the sandbox using the captured value
+5. Reads the file back with `sb.readFile()` and prints it

--- a/examples/capture/index.ts
+++ b/examples/capture/index.ts
@@ -8,6 +8,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sb = await client.sandbox({

--- a/examples/control-flow/README.md
+++ b/examples/control-flow/README.md
@@ -1,6 +1,12 @@
 # control-flow
 
-Demonstrates all of drej's built-in control-flow primitives in a single workflow.
+Demonstrates all of drej's built-in workflow control-flow primitives in a single sandbox.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
 
 ## Run
 
@@ -14,6 +20,5 @@ bun start
 | Primitive | Description |
 |-----------|-------------|
 | `retry`   | Retries a flaky command up to 5 times with exponential backoff |
-| `when`    | Branches conditionally on workflow state |
-| `forEach` | Iterates over a list with a loop variable |
-| `parallel`| Runs two branches concurrently inside the same sandbox |
+| `when`    | Branches conditionally based on the previous exec's exit code |
+| `forEach` | Iterates over a list, running a command per item |

--- a/examples/control-flow/index.ts
+++ b/examples/control-flow/index.ts
@@ -14,21 +14,20 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 await workflow(client)
   .sandbox(
     { image: "ubuntu:22.04", resources: { cpu: "500m", memory: "512Mi" }, name: "control-flow" },
     (sb) => {
-      // retry — retries a flaky command up to 5 times with exponential backoff
+      // retry — fails the first 2 attempts, succeeds on the 3rd
       sb.retry(
         5,
         (sb) => {
-          sb.exec(`
-            R=$((RANDOM % 2))
-            if [ $R -eq 0 ]; then echo "[retry] tails — failing"; exit 1; fi
-            echo "[retry] heads — success"
-          `);
+          sb.exec(
+            'COUNT=$(cat /tmp/attempt 2>/dev/null || echo 0); COUNT=$((COUNT+1)); echo $COUNT > /tmp/attempt; echo "[retry] attempt $COUNT"; [ $COUNT -ge 3 ] && echo "[retry] succeeded" || { echo "[retry] failing"; exit 1; }',
+          );
         },
         { delayMs: 200, backoff: "exponential" },
       );
@@ -50,4 +49,3 @@ await workflow(client)
     },
   )
   .pipe(process.stdout);
-

--- a/examples/environments/README.md
+++ b/examples/environments/README.md
@@ -1,0 +1,31 @@
+# environments
+
+Demonstrates sandbox environments: build a reusable sandbox image once, then restore from the snapshot on every subsequent run — skipping the setup entirely.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start        # ~30–60s first run (builds environment)
+bun start        # ~2–3s on subsequent runs (restores from snapshot)
+```
+
+## What it does
+
+**First run** — environment not yet cached:
+1. Installs Python 3 and pip into a `debian:bookworm-slim` container
+2. Installs `numpy` and `pandas` via pip
+3. Snapshots the container and saves the snapshot ID to the ledger
+
+**Subsequent runs** — environment cached:
+1. Finds the existing snapshot in the ledger
+2. Boots directly from the snapshot — no apt-get or pip install
+3. Runs `import numpy, pandas` to prove packages are already present
+
+The ledger entry is keyed by the environment name (`"python-data-science"`), so the snapshot is reused across process restarts.

--- a/examples/environments/index.ts
+++ b/examples/environments/index.ts
@@ -16,14 +16,14 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const env = client.environment("python-data-science", {
-  image: "debian:bookworm-slim",
+  image: "python:3.11-slim",
   resources: { cpu: "500m", memory: "512Mi" },
   setup: async (sb) => {
     console.log("  Running setup (install packages)...");
-    await sb.exec("apt-get update -qq && apt-get install -y python3-pip --no-install-recommends -q");
     await sb.exec("pip install --quiet numpy pandas");
     console.log("  Setup complete.");
   },
@@ -42,9 +42,9 @@ const sb = await env.sandbox();
 console.log(`Ready in ${Date.now() - t0}ms  (sandbox ${sb.sandboxId})`);
 
 try {
-  console.log("\n$ python3 -c \"import numpy, pandas; print(numpy.__version__, pandas.__version__)\"");
+  console.log('\n$ python3 -c "import numpy, pandas; print(numpy.__version__, pandas.__version__)"');
   await sb.exec(
-    "python3 -c \"import numpy, pandas; print(numpy.__version__, pandas.__version__)\"",
+    'python3 -c "import numpy, pandas; print(numpy.__version__, pandas.__version__)"',
   ).pipe(process.stdout);
 } finally {
   await sb.close();

--- a/examples/error-handling/README.md
+++ b/examples/error-handling/README.md
@@ -1,0 +1,26 @@
+# error-handling
+
+Demonstrates the two error-handling modes for exec commands, and the error types you may encounter.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it shows
+
+| Pattern | Description |
+|---------|-------------|
+| Non-strict exec | `exec("...", { strict: false })` returns the result; you inspect `exitCode` yourself |
+| Strict exec (default) | Non-zero exit throws `CommandError` — catch it to handle the failure |
+| Error types | `CommandError`, `SandboxError`, `ExecConnectionError` — when each is thrown |
+
+Two sandboxes run sequentially, one per pattern.

--- a/examples/error-handling/index.ts
+++ b/examples/error-handling/index.ts
@@ -10,6 +10,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sbA = await client.sandbox({

--- a/examples/exec-code/README.md
+++ b/examples/exec-code/README.md
@@ -1,0 +1,25 @@
+# exec-code
+
+Demonstrates `sb.execCode()` for running code through the sandbox's built-in interpreter — stateless one-shot calls and stateful sessions where variables persist across calls.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it shows
+
+| Mode | Description |
+|------|-------------|
+| Stateless | Each `execCode()` call runs in an isolated context; no shared state |
+| Stateful | Calls sharing the same `context` object see each other's variables |
+
+Uses the `opensandbox/code-interpreter` image, which ships a Python interpreter accessible via the execd `/code` endpoint.

--- a/examples/exec-code/index.ts
+++ b/examples/exec-code/index.ts
@@ -2,8 +2,11 @@
  * Demonstrates execCode() for running code in the sandbox interpreter.
  *
  * Two patterns shown:
- *   stateless  — each execCode() call runs in an isolated context
- *   stateful   — calls sharing the same context ID see each other's variables
+ *   isolated  — each call gets its own context; variables don't carry over
+ *   stateful  — calls sharing the same context see each other's variables
+ *
+ * Requires the opensandbox/code-interpreter image, which starts a Jupyter
+ * kernel service via its built-in entrypoint script.
  */
 import { Drej, CodeLanguage } from "drej";
 import { SQLiteAdapter } from "@drej/sqlite";
@@ -12,39 +15,59 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sb = await client.sandbox({
   image: "opensandbox/code-interpreter",
-  env: {},
+  entrypoint: ["/opt/code-interpreter/code-interpreter.sh"],
   name: "exec-code",
   resources: { cpu: "500m", memory: "512Mi" },
 });
 
 console.log(`Sandbox ID: ${sb.sandboxId}\n`);
 
-const ctx = { id: "session", language: CodeLanguage.Python };
-
 try {
-  // Stateless — isolated context
-  await sb.execCode(`
-import sys, math
-print(f"[stateless] Python {sys.version.split()[0]}")
-print(f"[stateless] pi = {math.pi:.6f}")
-  `.trim()).pipe(process.stdout);
+  // Isolated — a fresh context per call; variables do not persist across calls
+  const ctxA = await sb.createCodeContext(CodeLanguage.Python);
+  const ctxB = await sb.createCodeContext(CodeLanguage.Python);
+
+  await sb.execCode(
+    [
+      "import sys, math",
+      'print(f"[isolated-a] Python {sys.version.split()[0]}")',
+      'print(f"[isolated-a] pi = {math.pi:.6f}")',
+    ].join("\n"),
+    { context: ctxA },
+  ).pipe(process.stdout);
+
+  await sb.execCode(
+    [
+      "import sys",
+      'print(f"[isolated-b] Python {sys.version.split()[0]}")',
+    ].join("\n"),
+    { context: ctxB },
+  ).pipe(process.stdout);
 
   // Stateful — variables persist across calls sharing the same context
-  await sb.execCode(`
-data = [2**i for i in range(8)]
-print(f"[stateful 1] data = {data}")
-  `.trim(), { context: ctx }).pipe(process.stdout);
+  const ctx = await sb.createCodeContext(CodeLanguage.Python);
 
-  await sb.execCode(`
-total = sum(data)
-print(f"[stateful 2] sum = {total}")
-print(f"[stateful 2] max = {max(data)}")
-  `.trim(), { context: ctx }).pipe(process.stdout);
+  await sb.execCode(
+    [
+      "data = [2**i for i in range(8)]",
+      'print(f"[stateful 1] data = {data}")',
+    ].join("\n"),
+    { context: ctx },
+  ).pipe(process.stdout);
+
+  await sb.execCode(
+    [
+      "total = sum(data)",
+      'print(f"[stateful 2] sum = {total}")',
+      'print(f"[stateful 2] max = {max(data)}")',
+    ].join("\n"),
+    { context: ctx },
+  ).pipe(process.stdout);
 } finally {
   await sb.close();
 }
-

--- a/examples/file-ops/README.md
+++ b/examples/file-ops/README.md
@@ -1,0 +1,31 @@
+# file-ops
+
+Demonstrates the full sandbox file operations API — no `exec`/`sed` needed for common file tasks.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it covers
+
+| Method | Description |
+|--------|-------------|
+| `writeFile` / `readFile` | Write and read UTF-8 files |
+| `moveFile` / `deleteFile` | Move or remove a file |
+| `createDirectory` / `deleteDirectory` | Create or remove directories |
+| `listDirectory` | List directory contents |
+| `searchFiles` | Find files matching a glob pattern |
+| `getFileInfo` | Stat a file (size, type, mode, timestamps) |
+| `replaceInFiles` | In-place string substitution across one or more files |
+| `transfer` | Copy a file from one sandbox to another |
+
+Two sandboxes are used to demonstrate `transfer()`.

--- a/examples/file-ops/index.ts
+++ b/examples/file-ops/index.ts
@@ -10,6 +10,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sb = await client.sandbox({

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,6 +1,12 @@
 # hello-world
 
-The simplest drej workflow: spin up an Ubuntu sandbox, run `echo "hello world"`, and stream the output.
+The simplest drej example: spin up an Ubuntu sandbox, run `echo "hello world"`, and stream the output.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
 
 ## Run
 
@@ -13,5 +19,9 @@ bun start
 
 1. Creates an Ubuntu 22.04 sandbox
 2. Executes `echo "hello world"` inside it
-3. Streams every workflow event to stdout, printing exec output as it arrives
+3. Streams output to stdout
 4. Deletes the sandbox on completion
+
+## Notes
+
+All examples default to `useServerProxy: true` — traffic routes through the OpenSandbox server so Docker bridge IPs don't need to be reachable directly. Set `USE_SERVER_PROXY=false` to disable (e.g. when using `uvx opensandbox-server` on the host).

--- a/examples/hello-world/index.ts
+++ b/examples/hello-world/index.ts
@@ -5,6 +5,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sb = await client.sandbox({

--- a/examples/ports/README.md
+++ b/examples/ports/README.md
@@ -1,0 +1,27 @@
+# ports
+
+Demonstrates `sb.proxy()`: start an HTTP server inside a sandbox and send requests to it from the host process via the OpenSandbox server proxy.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates a `node:22` sandbox and writes a simple HTTP server to `/server.js`
+2. Starts the server on port 3000 in the background
+3. Calls `sb.proxy(3000)` to get a proxy URL and auth headers
+4. Sends two requests from the host process and prints the JSON responses
+
+## Notes
+
+With `useServerProxy: true` (the default), `sb.proxy()` returns a URL that routes through the OpenSandbox server (`http://localhost:8080/sandboxes/{id}/proxy/3000`). This works regardless of Docker networking because the server relays the request to the container on your behalf.

--- a/examples/ports/index.ts
+++ b/examples/ports/index.ts
@@ -11,6 +11,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 // Sandbox A: runs an HTTP server on port 3000

--- a/examples/read-file/README.md
+++ b/examples/read-file/README.md
@@ -1,0 +1,24 @@
+# read-file
+
+Demonstrates `sb.readFile()` — reading a file written inside the sandbox back to the host process.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates a `node:20-slim` sandbox
+2. Runs a Node.js one-liner that writes the Node version to `/tmp/version.txt`
+3. Reads the file back using `sb.readFile()`
+4. Writes a JSON report to the sandbox using `sb.writeFile()` and reads it back
+5. Prints both captured values to the console

--- a/examples/read-file/index.ts
+++ b/examples/read-file/index.ts
@@ -8,6 +8,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sb = await client.sandbox({

--- a/examples/run-bash-script/README.md
+++ b/examples/run-bash-script/README.md
@@ -2,6 +2,12 @@
 
 Run a multi-line bash script inside an isolated sandbox and stream its output.
 
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
 ## Run
 
 ```bash
@@ -12,6 +18,6 @@ bun start
 ## What it does
 
 1. Creates an Ubuntu 22.04 sandbox
-2. Uploads and runs a bash script that prints system info, disk usage, and writes/reads a file
+2. Runs a bash script that prints system info, disk usage, and writes/reads a file
 3. Streams output to stdout as it arrives
 4. Deletes the sandbox on completion

--- a/examples/run-bash-script/index.ts
+++ b/examples/run-bash-script/index.ts
@@ -5,6 +5,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const script = `
@@ -36,7 +37,7 @@ const sb = await client.sandbox({
 console.log(`Sandbox ID: ${sb.sandboxId}\n`);
 
 try {
-  await sb.exec(script).pipe(process.stdout);
+  await sb.exec(script, { shell: "/bin/bash" }).pipe(process.stdout);
 } finally {
   await sb.close();
 }

--- a/examples/sandbox-fork/README.md
+++ b/examples/sandbox-fork/README.md
@@ -2,6 +2,12 @@
 
 Demonstrates `sb.fork()`: install dependencies once into a base sandbox, then branch into two independent sandboxes that run different workloads in parallel — without repeating the install.
 
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
+
 ## Run
 
 ```bash
@@ -13,7 +19,7 @@ bun start
 
 1. Creates a `python:3.11-slim` sandbox and installs `numpy`
 2. Forks into two independent sandboxes (`track-a`, `track-b`) from the post-install state
-3. Runs a different numpy script on each fork in parallel
+3. Runs a different numpy computation on each fork in parallel
 4. Lists the checkpoints recorded on the original sandbox
 5. Closes all three sandboxes
 

--- a/examples/sandbox-fork/index.ts
+++ b/examples/sandbox-fork/index.ts
@@ -12,6 +12,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const scriptA = `

--- a/examples/snapshot-replay/README.md
+++ b/examples/snapshot-replay/README.md
@@ -1,6 +1,12 @@
 # snapshot-replay
 
-Demonstrates drej's snapshot and replay feature: run a workflow once to install dependencies and capture a snapshot, then replay from that snapshot — skipping the install — to run updated code against the same environment.
+Demonstrates drej's checkpoint and resume feature: run once to install dependencies and capture a snapshot, then resume from that snapshot — skipping the install — to run updated code against the same environment.
+
+## Setup
+
+```bash
+bunx drejx init   # starts OpenSandbox in Docker (one-time setup)
+```
 
 ## Run
 
@@ -14,9 +20,12 @@ bun start
 **Initial run**
 1. Creates a Python 3.11 sandbox
 2. Installs `requests` via pip
-3. Captures a snapshot after the install step
-4. Runs a script against httpbin
+3. Captures a checkpoint (`after-install`)
+4. Runs a script and closes the sandbox
 
-**Replay**
-1. Boots a new sandbox from the snapshot (pip install already done)
-2. Runs an updated script that fetches a different endpoint
+**Resumed run**
+1. Calls `client.resume(sandboxId)` — boots from the snapshot
+2. The `pip install` call returns cached output instantly (never re-runs)
+3. Runs an updated script on the restored container
+
+Run `bun start` twice to see the difference: first run takes ~30–60s; the resume takes ~2–3s.

--- a/examples/snapshot-replay/index.ts
+++ b/examples/snapshot-replay/index.ts
@@ -12,6 +12,7 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://localhost:8080",
   apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
   adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
 });
 
 const sandboxOpts = {

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -191,10 +191,31 @@ export class Sandbox {
   }
 
   /**
+   * Create a code execution context for use with `execCode()`.
+   *
+   * The code interpreter requires a context for every `execCode()` call. Call
+   * this once per session (or once per isolated scope), then pass the returned
+   * object as `opts.context` to `execCode()`. Variables defined in one call
+   * are visible to subsequent calls sharing the same context.
+   *
+   * @example
+   * ```ts
+   * const ctx = await sb.createCodeContext(CodeLanguage.Python);
+   * await sb.execCode('x = 42', { context: ctx });
+   * await sb.execCode('print(x)', { context: ctx }); // prints 42
+   * ```
+   */
+  async createCodeContext(language: import("@drej/opensandbox").CodeLanguage): Promise<import("@drej/opensandbox").CodeContext> {
+    const ec = await this._getExecClient();
+    return ec.createContext(language as string);
+  }
+
+  /**
    * Execute code via the sandbox's code interpreter (Python, JS, etc.).
    *
    * Uses the execd `/code` endpoint for stateful, Jupyter-style execution.
    * Contexts persist across calls — use `opts.context` to target a specific one.
+   * Create a context first with `sb.createCodeContext(language)`.
    */
   execCode(code: string, opts: ExecCodeOptions = {}): ExecHandle {
     const seq = ++this._seq;

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -114,7 +114,7 @@ export class Drej {
         image,
         env: opts.env,
         metadata: opts.metadata,
-        entrypoint: ["tail", "-f", "/dev/null"],
+        entrypoint: opts.entrypoint ?? ["tail", "-f", "/dev/null"],
         resourceLimits: opts.resources,
         timeout: opts.timeout,
       });

--- a/packages/sdks/typescript/src/types.ts
+++ b/packages/sdks/typescript/src/types.ts
@@ -75,4 +75,13 @@ export interface SandboxOptions {
    * Defaults to `"/bin/sh"`.
    */
   shell?: string;
+  /**
+   * Override the container entrypoint. Defaults to `["tail", "-f", "/dev/null"]`
+   * which keeps the container alive without a TTY.
+   *
+   * Set this when using images that need their own init process — for example,
+   * `opensandbox/code-interpreter` requires `["/opt/code-interpreter/code-interpreter.sh"]`
+   * to start the Jupyter kernel service that `execCode()` depends on.
+   */
+  entrypoint?: string[];
 }


### PR DESCRIPTION
…terpreter

- All examples now default to useServerProxy: true (works with drejx init out of the box; set USE_SERVER_PROXY=false to use the uvx path instead)
- Added README.md to all 13 examples covering setup, run steps, and what each example demonstrates
- Fixed run-bash-script: set -euo pipefail fails in /bin/sh (dash); pass shell: "/bin/bash" so pipefail is honoured
- Fixed environments: debian:bookworm-slim rejects pip under PEP 668; switch to python:3.11-slim which ships pip
- Fixed control-flow retry: replaced probabilistic coin-flip (3% fail chance) with deterministic counter that fails attempts 1-2 and succeeds on 3
- Added entrypoint option to SandboxOptions so images like opensandbox/ code-interpreter can run their init script instead of tail -f /dev/null
- Added Sandbox.createCodeContext() to core: the code-interpreter execd requires an explicit context (POST /code/context) before execCode() will accept it
- Updated exec-code example to pass the entrypoint and call createCodeContext()
- Updated CLAUDE.md with drejx init setup, useServerProxy design note, packages/ cli architecture, and individual typecheck command for packages/cli

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
