### PR TITLE
feat: add oxlint and oxfmt with initial format pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
         run: bunx tsc --noEmit --strict
         working-directory: packages/adapters/otel
 
+      - name: Lint
+        run: bun run lint
+
+      - name: Format check
+        run: bun run format:check
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript"],
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "warn"
+  },
+  "ignorePatterns": ["**/dist/**", "**/node_modules/**", "**/*.d.ts"]
+}

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,5 +1,7 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
 <!-- END:nextjs-agent-rules -->

--- a/apps/docs/content/docs/adapters/custom.mdx
+++ b/apps/docs/content/docs/adapters/custom.mdx
@@ -35,29 +35,29 @@ import type {
 
 ## Method reference
 
-| Method | Required | Description |
-|---|---|---|
-| `connect()` | No | Initialize connections. Called by `client.connect()`. |
-| `close()` | No | Release connections. Called by `client.close()`. |
-| `append(entry)` | Yes | Persist a single ledger event. Called during every exec. |
-| `readAll(name, sandboxId)` | Yes | Return all events for a session in ascending `ts` order. Used by `resume()`. |
-| `lastCheckpoint(name, sandboxId)` | Yes | Return the most recent `checkpoint_created` entry, or `null`. |
-| `listSandboxDetails(name, opts?)` | Yes | Return sessions with this name, newest first. |
-| `listAllSandboxDetails(opts?)` | Yes | Return all sessions across all names, newest first. |
-| `getSandboxDetails(name, sandboxId)` | Yes | Return a single session, or `null`. |
-| `deleteSandbox(name, sandboxId)` | Yes | Delete all events for a session. |
+| Method                               | Required | Description                                                                  |
+| ------------------------------------ | -------- | ---------------------------------------------------------------------------- |
+| `connect()`                          | No       | Initialize connections. Called by `client.connect()`.                        |
+| `close()`                            | No       | Release connections. Called by `client.close()`.                             |
+| `append(entry)`                      | Yes      | Persist a single ledger event. Called during every exec.                     |
+| `readAll(name, sandboxId)`           | Yes      | Return all events for a session in ascending `ts` order. Used by `resume()`. |
+| `lastCheckpoint(name, sandboxId)`    | Yes      | Return the most recent `checkpoint_created` entry, or `null`.                |
+| `listSandboxDetails(name, opts?)`    | Yes      | Return sessions with this name, newest first.                                |
+| `listAllSandboxDetails(opts?)`       | Yes      | Return all sessions across all names, newest first.                          |
+| `getSandboxDetails(name, sandboxId)` | Yes      | Return a single session, or `null`.                                          |
+| `deleteSandbox(name, sandboxId)`     | Yes      | Delete all events for a session.                                             |
 
 ## LedgerEntry
 
 ```ts
 interface LedgerEntry {
-  ts: number;           // Unix timestamp in milliseconds
-  name: string;         // sandbox name
+  ts: number; // Unix timestamp in milliseconds
+  name: string; // sandbox name
   sandboxId: string;
-  stepIndex: number;    // -1 for sandbox-level events
-  branch?: number;      // parallel branch index
+  stepIndex: number; // -1 for sandbox-level events
+  branch?: number; // parallel branch index
   event: LedgerEvent;
-  payload?: unknown;    // event-specific data
+  payload?: unknown; // event-specific data
   error?: string;
 }
 ```
@@ -84,8 +84,9 @@ export class MemoryAdapter implements IStorageAdapter {
   }
 
   async lastCheckpoint(name: string, sandboxId: string): Promise<LedgerEntry | null> {
-    const checkpoints = (await this.readAll(name, sandboxId))
-      .filter((e) => e.event === LedgerEvent.CheckpointCreated);
+    const checkpoints = (await this.readAll(name, sandboxId)).filter(
+      (e) => e.event === LedgerEvent.CheckpointCreated,
+    );
     return checkpoints.at(-1) ?? null;
   }
 

--- a/apps/docs/content/docs/adapters/index.mdx
+++ b/apps/docs/content/docs/adapters/index.mdx
@@ -4,7 +4,19 @@ description: Choose where drej persists your run ledger.
 ---
 
 <Cards>
-  <Card href="/docs/adapters/sqlite" title="SQLite" description="Zero-config, WAL mode. The right default for local dev and single-process deploys." />
-  <Card href="/docs/adapters/postgres" title="Postgres" description="For production multi-process deployments with a shared ledger." />
-  <Card href="/docs/adapters/custom" title="Custom adapter" description="Implement IStorageAdapter to use any storage backend." />
+  <Card
+    href="/docs/adapters/sqlite"
+    title="SQLite"
+    description="Zero-config, WAL mode. The right default for local dev and single-process deploys."
+  />
+  <Card
+    href="/docs/adapters/postgres"
+    title="Postgres"
+    description="For production multi-process deployments with a shared ledger."
+  />
+  <Card
+    href="/docs/adapters/custom"
+    title="Custom adapter"
+    description="Implement IStorageAdapter to use any storage backend."
+  />
 </Cards>

--- a/apps/docs/content/docs/adapters/postgres.mdx
+++ b/apps/docs/content/docs/adapters/postgres.mdx
@@ -25,7 +25,7 @@ const client = new Drej({
 
 await client.connect(); // runs CREATE TABLE IF NOT EXISTS migrations
 // ...
-await client.close();   // releases the connection pool
+await client.close(); // releases the connection pool
 ```
 
 ## Constructor
@@ -34,8 +34,8 @@ await client.close();   // releases the connection pool
 new PostgresAdapter(connectionString: string)
 ```
 
-| Argument | Type | Description |
-|---|---|---|
+| Argument           | Type     | Description                                                                |
+| ------------------ | -------- | -------------------------------------------------------------------------- |
 | `connectionString` | `string` | Postgres connection string, e.g. `"postgres://user:pass@host:5432/dbname"` |
 
 ## Connection string format
@@ -75,9 +75,7 @@ CREATE TABLE IF NOT EXISTS drej_events (
 ## Environment-based config
 
 ```ts
-const adapter = new PostgresAdapter(
-  process.env.DATABASE_URL ?? "postgres://localhost/drej_dev",
-);
+const adapter = new PostgresAdapter(process.env.DATABASE_URL ?? "postgres://localhost/drej_dev");
 ```
 
 For production, set `DATABASE_URL` in your environment and never hardcode credentials.

--- a/apps/docs/content/docs/adapters/sqlite.mdx
+++ b/apps/docs/content/docs/adapters/sqlite.mdx
@@ -24,7 +24,7 @@ const client = new Drej({
 
 await client.connect(); // creates the file and runs migrations
 // ...
-await client.close();   // closes the database connection
+await client.close(); // closes the database connection
 ```
 
 The file is created if it doesn't exist. `connect()` runs `CREATE TABLE IF NOT EXISTS` migrations so it's safe to call on every startup.
@@ -35,9 +35,9 @@ The file is created if it doesn't exist. `connect()` runs `CREATE TABLE IF NOT E
 new SQLiteAdapter(path: string)
 ```
 
-| Argument | Type | Description |
-|---|---|---|
-| `path` | `string` | File path for the SQLite database. Use `":memory:"` for an in-memory database (data lost on close). |
+| Argument | Type     | Description                                                                                         |
+| -------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `path`   | `string` | File path for the SQLite database. Use `":memory:"` for an in-memory database (data lost on close). |
 
 ## WAL mode
 
@@ -57,6 +57,7 @@ const adapter = new SQLiteAdapter(":memory:");
 ## When to switch to Postgres
 
 Switch to `@drej/postgres` when:
+
 - Multiple processes need to share the same ledger
 - You're deploying to a platform without persistent local disk
 - You need to query ledger data with SQL from external tools

--- a/apps/docs/content/docs/api-reference/builder.mdx
+++ b/apps/docs/content/docs/api-reference/builder.mdx
@@ -48,9 +48,8 @@ Run the same operation across multiple containers simultaneously. All configs re
 
 ```ts
 await workflow(client)
-  .parallel(
-    [{ image: "node:20" }, { image: "node:22" }, { image: "node:24" }],
-    (sb) => sb.exec("npm test"),
+  .parallel([{ image: "node:20" }, { image: "node:22" }, { image: "node:24" }], (sb) =>
+    sb.exec("npm test"),
   )
   .pipe(process.stdout);
 ```
@@ -66,8 +65,18 @@ Run sandboxes one after another. Each step's callback receives the previous step
 ```ts
 await workflow(client)
   .sequence([
-    { image: "node:22", name: "build", resources: { cpu: "1", memory: "512Mi" }, run: (sb) => sb.exec("npm run build") },
-    { image: "ubuntu:22.04", name: "deploy", resources: { cpu: "500m", memory: "256Mi" }, run: (sb, prev) => sb.exec("./deploy.sh") },
+    {
+      image: "node:22",
+      name: "build",
+      resources: { cpu: "1", memory: "512Mi" },
+      run: (sb) => sb.exec("npm run build"),
+    },
+    {
+      image: "ubuntu:22.04",
+      name: "deploy",
+      resources: { cpu: "500m", memory: "256Mi" },
+      run: (sb, prev) => sb.exec("./deploy.sh"),
+    },
   ])
   .pipe(process.stdout);
 ```
@@ -90,8 +99,8 @@ Execute the workflow and return the combined result:
 
 ```ts
 interface WorkflowResult {
-  stdout: string;                    // concatenated stdout from all sandboxes
-  vars: Record<string, unknown>;     // values captured by readFile(path, as)
+  stdout: string; // concatenated stdout from all sandboxes
+  vars: Record<string, unknown>; // values captured by readFile(path, as)
 }
 ```
 
@@ -169,8 +178,8 @@ Queue a retry block. On failure, waits `delayMs` and retries up to `maxAttempts`
 
 ```ts
 interface RetryOptions {
-  delayMs?: number;                    // default: 1000
-  backoff?: "fixed" | "exponential";   // default: "fixed"
+  delayMs?: number; // default: 1000
+  backoff?: "fixed" | "exponential"; // default: "fixed"
 }
 ```
 

--- a/apps/docs/content/docs/api-reference/drej-client.mdx
+++ b/apps/docs/content/docs/api-reference/drej-client.mdx
@@ -15,12 +15,12 @@ new Drej(options: DrejOptions)
 
 ### DrejOptions
 
-| Option | Type | Required | Description |
-|---|---|---|---|
-| `baseUrl` | `string` | Yes | OpenSandbox server URL, e.g. `"http://localhost:8080"` |
-| `apiKey` | `string` | No | OpenSandbox API key. Empty string for local dev with no auth. |
-| `adapter` | `IStorageAdapter` | Yes | Storage adapter for the run ledger |
-| `maxConcurrency` | `number` | No | Max simultaneous active sandboxes. Omit for no limit. |
+| Option           | Type              | Required | Description                                                   |
+| ---------------- | ----------------- | -------- | ------------------------------------------------------------- |
+| `baseUrl`        | `string`          | Yes      | OpenSandbox server URL, e.g. `"http://localhost:8080"`        |
+| `apiKey`         | `string`          | No       | OpenSandbox API key. Empty string for local dev with no auth. |
+| `adapter`        | `IStorageAdapter` | Yes      | Storage adapter for the run ledger                            |
+| `maxConcurrency` | `number`          | No       | Max simultaneous active sandboxes. Omit for no limit.         |
 
 ```ts
 const client = new Drej({
@@ -93,7 +93,7 @@ Throws `DrejError` (404) if the session is not found or has no checkpoint.
 const sbResume = await client.resume(originalSandboxId);
 try {
   await sbResume.exec("pip install -q requests").pipe(process.stdout); // replayed
-  await sbResume.exec("python3 script.py").pipe(process.stdout);       // live
+  await sbResume.exec("python3 script.py").pipe(process.stdout); // live
 } finally {
   await sbResume.close();
 }
@@ -131,11 +131,11 @@ await client.sandboxes.delete("my-job", sandboxId);
 
 ### ListSandboxOptions
 
-| Option | Type | Description |
-|---|---|---|
+| Option   | Type            | Description                                                             |
+| -------- | --------------- | ----------------------------------------------------------------------- |
 | `status` | `SandboxStatus` | Filter by status: `"running"`, `"completed"`, `"failed"`, `"cancelled"` |
-| `limit` | `number` | Max results to return |
-| `before` | `number` | Return only sessions started before this Unix timestamp (ms) |
+| `limit`  | `number`        | Max results to return                                                   |
+| `before` | `number`        | Return only sessions started before this Unix timestamp (ms)            |
 
 ## Sandbox class
 
@@ -143,22 +143,22 @@ See [Sandbox](#sandbox) below for the object returned by `sandbox()` and `resume
 
 ### Sandbox methods
 
-| Method | Returns | Description |
-|---|---|---|
-| `sb.exec(cmd, opts?)` | `ExecHandle` | Run a shell command |
-| `sb.execCode(code, opts?)` | `ExecHandle` | Run code via the interpreter |
-| `sb.writeFile(path, content)` | `Promise<void>` | Write a file into the container |
-| `sb.readFile(path)` | `Promise<string>` | Read a file from the container |
-| `sb.moveFile(from, to)` | `Promise<void>` | Move/rename a file |
-| `sb.deleteFile(path)` | `Promise<void>` | Delete a file |
-| `sb.searchFiles(pattern, path?)` | `Promise<SearchResult[]>` | Search for files matching a glob |
-| `sb.listDirectory(path, opts?)` | `Promise<DirEntry[]>` | List directory entries |
-| `sb.checkpoint(name?)` | `Promise<void>` | Snapshot the container |
-| `sb.close()` | `Promise<void>` | Delete the container and release resources |
+| Method                           | Returns                   | Description                                |
+| -------------------------------- | ------------------------- | ------------------------------------------ |
+| `sb.exec(cmd, opts?)`            | `ExecHandle`              | Run a shell command                        |
+| `sb.execCode(code, opts?)`       | `ExecHandle`              | Run code via the interpreter               |
+| `sb.writeFile(path, content)`    | `Promise<void>`           | Write a file into the container            |
+| `sb.readFile(path)`              | `Promise<string>`         | Read a file from the container             |
+| `sb.moveFile(from, to)`          | `Promise<void>`           | Move/rename a file                         |
+| `sb.deleteFile(path)`            | `Promise<void>`           | Delete a file                              |
+| `sb.searchFiles(pattern, path?)` | `Promise<SearchResult[]>` | Search for files matching a glob           |
+| `sb.listDirectory(path, opts?)`  | `Promise<DirEntry[]>`     | List directory entries                     |
+| `sb.checkpoint(name?)`           | `Promise<void>`           | Snapshot the container                     |
+| `sb.close()`                     | `Promise<void>`           | Delete the container and release resources |
 
 ### Sandbox properties
 
-| Property | Type | Description |
-|---|---|---|
-| `sb.sandboxId` | `string` | OpenSandbox container ID |
-| `sb.name` | `string` | User-provided name or auto-generated |
+| Property       | Type     | Description                          |
+| -------------- | -------- | ------------------------------------ |
+| `sb.sandboxId` | `string` | OpenSandbox container ID             |
+| `sb.name`      | `string` | User-provided name or auto-generated |

--- a/apps/docs/content/docs/api-reference/errors.mdx
+++ b/apps/docs/content/docs/api-reference/errors.mdx
@@ -48,8 +48,8 @@ try {
   await sb.exec("exit 42");
 } catch (e) {
   if (e instanceof CommandError) {
-    console.error(`exit ${e.exitCode}`);      // 42
-    console.error(`command: ${e.command}`);   // "exit 42"
+    console.error(`exit ${e.exitCode}`); // 42
+    console.error(`command: ${e.command}`); // "exit 42"
     console.error(`sandbox: ${e.sandboxId}`);
   }
 }
@@ -57,13 +57,13 @@ try {
 
 ### Properties
 
-| Property | Type | Description |
-|---|---|---|
-| `exitCode` | `number` | The process exit code |
-| `command` | `string` | The command string that was run |
-| `sandboxId` | `string` | The sandbox ID where it ran |
-| `message` | `string` | `"Command exited with code N: <cmd>"` |
-| `name` | `string` | `"CommandError"` |
+| Property    | Type     | Description                           |
+| ----------- | -------- | ------------------------------------- |
+| `exitCode`  | `number` | The process exit code                 |
+| `command`   | `string` | The command string that was run       |
+| `sandboxId` | `string` | The sandbox ID where it ran           |
+| `message`   | `string` | `"Command exited with code N: <cmd>"` |
+| `name`      | `string` | `"CommandError"`                      |
 
 ### Avoiding CommandError
 
@@ -81,22 +81,25 @@ Thrown when a sandbox fails to create, boot, or reach `Running` state. Also thro
 import { SandboxError } from "drej";
 
 try {
-  const sb = await client.sandbox({ image: "nonexistent:image", resources: { cpu: "500m", memory: "256Mi" } });
+  const sb = await client.sandbox({
+    image: "nonexistent:image",
+    resources: { cpu: "500m", memory: "256Mi" },
+  });
 } catch (e) {
   if (e instanceof SandboxError) {
-    console.error(e.message);           // "Sandbox <id> entered state Failed: ..."
-    console.error(e.sandboxId ?? "");   // sandbox ID if assigned before failure
+    console.error(e.message); // "Sandbox <id> entered state Failed: ..."
+    console.error(e.sandboxId ?? ""); // sandbox ID if assigned before failure
   }
 }
 ```
 
 ### Properties
 
-| Property | Type | Description |
-|---|---|---|
+| Property    | Type                  | Description                                         |
+| ----------- | --------------------- | --------------------------------------------------- |
 | `sandboxId` | `string \| undefined` | Container ID if one was assigned before the failure |
-| `message` | `string` | Describes what failed |
-| `name` | `string` | `"SandboxError"` |
+| `message`   | `string`              | Describes what failed                               |
+| `name`      | `string`              | `"SandboxError"`                                    |
 
 ## ExecConnectionError
 
@@ -109,19 +112,19 @@ try {
   await sb.exec("echo test");
 } catch (e) {
   if (e instanceof ExecConnectionError) {
-    console.error(e.message);        // "execd not ready for sandbox <id>"
-    console.error(e.sandboxId);      // the sandbox ID
+    console.error(e.message); // "execd not ready for sandbox <id>"
+    console.error(e.sandboxId); // the sandbox ID
   }
 }
 ```
 
 ### Properties
 
-| Property | Type | Description |
-|---|---|---|
-| `sandboxId` | `string` | The sandbox ID |
-| `message` | `string` | `"execd not ready for sandbox <id>"` |
-| `name` | `string` | `"ExecConnectionError"` |
+| Property    | Type     | Description                          |
+| ----------- | -------- | ------------------------------------ |
+| `sandboxId` | `string` | The sandbox ID                       |
+| `message`   | `string` | `"execd not ready for sandbox <id>"` |
+| `name`      | `string` | `"ExecConnectionError"`              |
 
 This usually means the container image doesn't include execd, or the container started but the execd process crashed.
 
@@ -137,7 +140,7 @@ try {
 } catch (e) {
   if (e instanceof DrejError) {
     console.error(e.message); // "Session nonexistent-id not found"
-    console.error(e.status);  // 404
+    console.error(e.status); // 404
   }
 }
 ```

--- a/apps/docs/content/docs/api-reference/index.mdx
+++ b/apps/docs/content/docs/api-reference/index.mdx
@@ -4,8 +4,24 @@ description: Complete reference for every public symbol exported from drej.
 ---
 
 <Cards>
-  <Card href="/docs/api-reference/drej-client" title="Drej" description="The main client — sandbox(), resume(), connect(), close(), and sandboxes management." />
-  <Card href="/docs/api-reference/workflow-run" title="ExecHandle" description="The PromiseLike returned by sb.exec() — pipe(), stdout() generator, result(), and await." />
-  <Card href="/docs/api-reference/builder" title="Builder API" description="workflow(), WorkflowBuilder, and SandboxBuilder from @drej/workflow." />
-  <Card href="/docs/api-reference/errors" title="Errors" description="CommandError, SandboxError, ExecConnectionError, WorkflowError, DrejError." />
+  <Card
+    href="/docs/api-reference/drej-client"
+    title="Drej"
+    description="The main client — sandbox(), resume(), connect(), close(), and sandboxes management."
+  />
+  <Card
+    href="/docs/api-reference/workflow-run"
+    title="ExecHandle"
+    description="The PromiseLike returned by sb.exec() — pipe(), stdout() generator, result(), and await."
+  />
+  <Card
+    href="/docs/api-reference/builder"
+    title="Builder API"
+    description="workflow(), WorkflowBuilder, and SandboxBuilder from @drej/workflow."
+  />
+  <Card
+    href="/docs/api-reference/errors"
+    title="Errors"
+    description="CommandError, SandboxError, ExecConnectionError, WorkflowError, DrejError."
+  />
 </Cards>

--- a/apps/docs/content/docs/api-reference/workflow-run.mdx
+++ b/apps/docs/content/docs/api-reference/workflow-run.mdx
@@ -51,8 +51,8 @@ Explicit promise form. Equivalent to `await handle`.
 
 ```ts
 interface ExecResult {
-  stdout: string;   // full stdout as a string
-  stderr: string;   // full stderr as a string
+  stdout: string; // full stdout as a string
+  stderr: string; // full stderr as a string
   exitCode: number; // process exit code (0 = success)
 }
 ```
@@ -75,8 +75,8 @@ An `ExecHandle` can only be consumed once — the underlying stream is driven by
 const handle = sb.exec("long-running-command");
 
 // These share the same stream — start them before any awaiting
-void handle.pipe(process.stdout);                      // stream as it runs
-const { exitCode } = await handle.result();            // get result when done
+void handle.pipe(process.stdout); // stream as it runs
+const { exitCode } = await handle.result(); // get result when done
 ```
 
 ## In the workflow builder

--- a/apps/docs/content/docs/building/control-flow.mdx
+++ b/apps/docs/content/docs/building/control-flow.mdx
@@ -33,9 +33,9 @@ await workflow(client)
 
 ### RetryOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `delayMs` | `number` | `1000` | Delay between retries in milliseconds |
+| Option    | Type                       | Default   | Description                                    |
+| --------- | -------------------------- | --------- | ---------------------------------------------- |
+| `delayMs` | `number`                   | `1000`    | Delay between retries in milliseconds          |
 | `backoff` | `"fixed" \| "exponential"` | `"fixed"` | `"exponential"` doubles the delay each attempt |
 
 With exponential backoff, attempt delays are: `delayMs`, `delayMs * 2`, `delayMs * 4`, etc.
@@ -50,8 +50,12 @@ await workflow(client)
     sb.exec("test -f /etc/hostname", { strict: false });
     sb.when(
       (ctx) => ctx.exitCode === 0,
-      (sb) => { sb.exec('echo "/etc/hostname exists"'); },
-      (sb) => { sb.exec('echo "/etc/hostname missing"'); },
+      (sb) => {
+        sb.exec('echo "/etc/hostname exists"');
+      },
+      (sb) => {
+        sb.exec('echo "/etc/hostname missing"');
+      },
     );
   })
   .pipe(process.stdout);
@@ -76,9 +80,9 @@ await workflow(client)
 
 ### ForEachOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `concurrency` | `number` | `1` | Number of items to process simultaneously (within the same sandbox) |
+| Option        | Type     | Default | Description                                                         |
+| ------------- | -------- | ------- | ------------------------------------------------------------------- |
+| `concurrency` | `number` | `1`     | Number of items to process simultaneously (within the same sandbox) |
 
 ## parallel
 
@@ -137,9 +141,13 @@ await workflow(client)
 
 ```ts
 sb.forEach(["a", "b", "c"], (sb, item) => {
-  sb.retry(3, (sb) => {
-    sb.exec(`process ${item}`);
-  }, { backoff: "exponential" });
+  sb.retry(
+    3,
+    (sb) => {
+      sb.exec(`process ${item}`);
+    },
+    { backoff: "exponential" },
+  );
 
   sb.when(
     (ctx) => ctx.exitCode === 0,

--- a/apps/docs/content/docs/building/exec.mdx
+++ b/apps/docs/content/docs/building/exec.mdx
@@ -39,11 +39,11 @@ await sb.exec(script).pipe(process.stdout);
 
 ### ExecOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `strict` | `boolean` | `true` | Throw `CommandError` on non-zero exit. Set to `false` to get the exit code instead. |
-| `cwd` | `string` | — | Working directory inside the sandbox |
-| `env` | `Record<string, string>` | — | Extra environment variables for this exec only |
+| Option   | Type                     | Default | Description                                                                         |
+| -------- | ------------------------ | ------- | ----------------------------------------------------------------------------------- |
+| `strict` | `boolean`                | `true`  | Throw `CommandError` on non-zero exit. Set to `false` to get the exit code instead. |
+| `cwd`    | `string`                 | —       | Working directory inside the sandbox                                                |
+| `env`    | `Record<string, string>` | —       | Extra environment variables for this exec only                                      |
 
 ### Strict vs non-strict
 
@@ -67,9 +67,7 @@ if (exitCode === 0) {
 ### Using captured output in subsequent commands
 
 ```ts
-const { stdout: nodeVersion } = await sb.exec(
-  "node -e \"process.stdout.write(process.version)\"",
-);
+const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
 
 await sb.exec(`echo "Building with ${nodeVersion.trim()}"`).pipe(process.stdout);
 ```
@@ -94,11 +92,15 @@ const sb = await client.sandbox({
 Each call without a context runs in an isolated interpreter session:
 
 ```ts
-await sb.execCode(`
+await sb
+  .execCode(
+    `
 import sys, math
 print(f"Python {sys.version.split()[0]}")
 print(f"pi = {math.pi:.6f}")
-`.trim()).pipe(process.stdout);
+`.trim(),
+  )
+  .pipe(process.stdout);
 ```
 
 ### Stateful execution
@@ -115,8 +117,8 @@ await sb.execCode(`print(f"sum = {sum(data)}")`, { context: ctx }).pipe(process.
 
 ### ExecCodeOptions
 
-| Option | Type | Description |
-|---|---|---|
+| Option    | Type                                     | Description                                                                            |
+| --------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
 | `context` | `{ id: string, language: CodeLanguage }` | Stateful interpreter session. Variables defined in one call are available in the next. |
 
 ### CodeLanguage
@@ -124,7 +126,7 @@ await sb.execCode(`print(f"sum = {sum(data)}")`, { context: ctx }).pipe(process.
 ```ts
 import { CodeLanguage } from "drej";
 
-CodeLanguage.Python     // "python"
-CodeLanguage.JavaScript // "javascript"
-CodeLanguage.TypeScript // "typescript"
+CodeLanguage.Python; // "python"
+CodeLanguage.JavaScript; // "javascript"
+CodeLanguage.TypeScript; // "typescript"
 ```

--- a/apps/docs/content/docs/building/index.mdx
+++ b/apps/docs/content/docs/building/index.mdx
@@ -4,8 +4,24 @@ description: Practical guides for each step type and capability in the builder A
 ---
 
 <Cards>
-  <Card href="/docs/building/exec" title="exec & execCode" description="Run shell commands and code in the sandbox interpreter." />
-  <Card href="/docs/building/file-ops" title="File operations" description="Write, read, search, and manage files inside the container." />
-  <Card href="/docs/building/control-flow" title="Control flow" description="retry, when, forEach, and parallel — composable within a sandbox." />
-  <Card href="/docs/building/snapshots" title="Snapshots & replay" description="Checkpoint the container state and replay from it." />
+  <Card
+    href="/docs/building/exec"
+    title="exec & execCode"
+    description="Run shell commands and code in the sandbox interpreter."
+  />
+  <Card
+    href="/docs/building/file-ops"
+    title="File operations"
+    description="Write, read, search, and manage files inside the container."
+  />
+  <Card
+    href="/docs/building/control-flow"
+    title="Control flow"
+    description="retry, when, forEach, and parallel — composable within a sandbox."
+  />
+  <Card
+    href="/docs/building/snapshots"
+    title="Snapshots & replay"
+    description="Checkpoint the container state and replay from it."
+  />
 </Cards>

--- a/apps/docs/content/docs/concepts/event-stream.mdx
+++ b/apps/docs/content/docs/concepts/event-stream.mdx
@@ -55,8 +55,8 @@ const { exitCode } = await handle.result();
 
 ```ts
 interface ExecResult {
-  stdout: string;   // full stdout as a string
-  stderr: string;   // full stderr as a string
+  stdout: string; // full stdout as a string
+  stderr: string; // full stderr as a string
   exitCode: number; // process exit code
 }
 ```

--- a/apps/docs/content/docs/concepts/index.mdx
+++ b/apps/docs/content/docs/concepts/index.mdx
@@ -4,10 +4,34 @@ description: The core ideas behind drej — what things are and how they relate.
 ---
 
 <Cards>
-  <Card href="/docs/concepts/workflows" title="Workflows" description="What a workflow is, how it's defined, and how it runs." />
-  <Card href="/docs/concepts/sandboxes" title="Sandboxes" description="Isolated Docker containers managed by OpenSandbox." />
-  <Card href="/docs/concepts/steps" title="Steps" description="The unit of work — leaf steps and control-flow steps." />
-  <Card href="/docs/concepts/refs-and-state" title="Refs & state" description="How to capture step output and thread values through a workflow." />
-  <Card href="/docs/concepts/event-stream" title="Event stream" description="The AsyncIterable that streams events as steps execute." />
-  <Card href="/docs/concepts/storage-adapters" title="Storage adapters" description="How the ledger persists every event for durability and replay." />
+  <Card
+    href="/docs/concepts/workflows"
+    title="Workflows"
+    description="What a workflow is, how it's defined, and how it runs."
+  />
+  <Card
+    href="/docs/concepts/sandboxes"
+    title="Sandboxes"
+    description="Isolated Docker containers managed by OpenSandbox."
+  />
+  <Card
+    href="/docs/concepts/steps"
+    title="Steps"
+    description="The unit of work — leaf steps and control-flow steps."
+  />
+  <Card
+    href="/docs/concepts/refs-and-state"
+    title="Refs & state"
+    description="How to capture step output and thread values through a workflow."
+  />
+  <Card
+    href="/docs/concepts/event-stream"
+    title="Event stream"
+    description="The AsyncIterable that streams events as steps execute."
+  />
+  <Card
+    href="/docs/concepts/storage-adapters"
+    title="Storage adapters"
+    description="How the ledger persists every event for durability and replay."
+  />
 </Cards>

--- a/apps/docs/content/docs/concepts/refs-and-state.mdx
+++ b/apps/docs/content/docs/concepts/refs-and-state.mdx
@@ -15,9 +15,7 @@ const sb = await client.sandbox({
   resources: { cpu: "500m", memory: "256Mi" },
 });
 try {
-  const { stdout: nodeVersion } = await sb.exec(
-    "node -e \"process.stdout.write(process.version)\"",
-  );
+  const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
 
   // Use the captured value in the next exec
   await sb.exec(`echo "Running on Node ${nodeVersion.trim()}"`).pipe(process.stdout);
@@ -64,7 +62,7 @@ The `when` predicate also receives runtime state:
 ```ts
 sb.exec("test -f /etc/hostname", { strict: false });
 sb.when(
-  (ctx) => ctx.exitCode === 0,     // ctx.exitCode, ctx.stdout, ctx.vars
+  (ctx) => ctx.exitCode === 0, // ctx.exitCode, ctx.stdout, ctx.vars
   (sb) => sb.exec("echo exists"),
   (sb) => sb.exec("echo missing"),
 );

--- a/apps/docs/content/docs/concepts/sandboxes.mdx
+++ b/apps/docs/content/docs/concepts/sandboxes.mdx
@@ -16,20 +16,21 @@ const sb = await client.sandbox({
 ```
 
 `client.sandbox()` does three things:
+
 1. Calls the OpenSandbox control API to create the container
 2. Waits until the container reaches `Running` state
 3. Returns the `Sandbox` object
 
 ## SandboxOptions
 
-| Option | Type | Description |
-|---|---|---|
-| `image` | `string \| { uri, auth? }` | Container image. String form: `"ubuntu:22.04"`. Object form for private registries: `{ uri: "ghcr.io/org/image", auth: { username, password } }` |
-| `resources` | `{ cpu?, memory?, gpu? }` | Resource limits. `cpu` is a Kubernetes-style string like `"500m"` or `"2"`. `memory` is `"256Mi"`, `"1Gi"`, etc. |
-| `env` | `Record<string, string>` | Environment variables set in the container at startup |
-| `name` | `string` | User-provided name for the run — used as the ledger key. Auto-generated if omitted. |
-| `timeout` | `number` | Sandbox lifetime in seconds. Defaults to the OpenSandbox server's default. |
-| `hooks` | `SandboxHooks` | Lifecycle callbacks for observability. See [Observability](/docs/patterns/observability). |
+| Option      | Type                       | Description                                                                                                                                      |
+| ----------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `image`     | `string \| { uri, auth? }` | Container image. String form: `"ubuntu:22.04"`. Object form for private registries: `{ uri: "ghcr.io/org/image", auth: { username, password } }` |
+| `resources` | `{ cpu?, memory?, gpu? }`  | Resource limits. `cpu` is a Kubernetes-style string like `"500m"` or `"2"`. `memory` is `"256Mi"`, `"1Gi"`, etc.                                 |
+| `env`       | `Record<string, string>`   | Environment variables set in the container at startup                                                                                            |
+| `name`      | `string`                   | User-provided name for the run — used as the ledger key. Auto-generated if omitted.                                                              |
+| `timeout`   | `number`                   | Sandbox lifetime in seconds. Defaults to the OpenSandbox server's default.                                                                       |
+| `hooks`     | `SandboxHooks`             | Lifecycle callbacks for observability. See [Observability](/docs/patterns/observability).                                                        |
 
 ## Sandbox lifecycle
 
@@ -54,8 +55,8 @@ try {
 ## Sandbox properties
 
 ```ts
-sb.sandboxId  // OpenSandbox container ID — also the unique ledger key
-sb.name       // User-provided name, or "sandbox-<short-id>" if omitted
+sb.sandboxId; // OpenSandbox container ID — also the unique ledger key
+sb.name; // User-provided name, or "sandbox-<short-id>" if omitted
 ```
 
 ## Multiple sandboxes
@@ -64,7 +65,10 @@ Each `client.sandbox()` call creates an independent container. Hold them as sepa
 
 ```ts
 const sbA = await client.sandbox({ image: "node:22", resources: { cpu: "500m", memory: "512Mi" } });
-const sbB = await client.sandbox({ image: "python:3.11", resources: { cpu: "500m", memory: "512Mi" } });
+const sbB = await client.sandbox({
+  image: "python:3.11",
+  resources: { cpu: "500m", memory: "512Mi" },
+});
 
 try {
   await sbA.exec("node --version").pipe(process.stdout);

--- a/apps/docs/content/docs/concepts/steps.mdx
+++ b/apps/docs/content/docs/concepts/steps.mdx
@@ -47,14 +47,14 @@ Requires a code-interpreter image (e.g. `opensandbox/code-interpreter`).
 
 ## File operations
 
-| Method | Description |
-|---|---|
-| `sb.writeFile(path, content)` | Write a UTF-8 string into the container |
-| `sb.readFile(path)` | Read a file as a UTF-8 string |
-| `sb.moveFile(from, to)` | Move or rename a file inside the container |
-| `sb.deleteFile(path)` | Delete a file from the container |
+| Method                           | Description                                                   |
+| -------------------------------- | ------------------------------------------------------------- |
+| `sb.writeFile(path, content)`    | Write a UTF-8 string into the container                       |
+| `sb.readFile(path)`              | Read a file as a UTF-8 string                                 |
+| `sb.moveFile(from, to)`          | Move or rename a file inside the container                    |
+| `sb.deleteFile(path)`            | Delete a file from the container                              |
 | `sb.searchFiles(pattern, path?)` | Search for files matching a glob; returns an array of matches |
-| `sb.listDirectory(path, opts?)` | List directory entries; `opts.depth` controls recursion depth |
+| `sb.listDirectory(path, opts?)`  | List directory entries; `opts.depth` controls recursion depth |
 
 See [File operations](/docs/building/file-ops) for full examples.
 

--- a/apps/docs/content/docs/concepts/storage-adapters.mdx
+++ b/apps/docs/content/docs/concepts/storage-adapters.mdx
@@ -8,15 +8,16 @@ Every exec, checkpoint, and sandbox lifecycle event is written to a storage adap
 ## Why persistence matters
 
 The ledger enables:
+
 - **Audit** — see which commands ran, when, and what they output
 - **Resume** — `client.resume(sandboxId)` reads the ledger to rebuild replay cache and restore the container
 - **Observability** — `client.sandboxes.list()` returns run history across all sessions
 
 ## Choosing an adapter
 
-| Adapter | Package | When to use |
-|---|---|---|
-| `SQLiteAdapter` | `@drej/sqlite` | Local dev, single-process apps, scripts |
+| Adapter           | Package          | When to use                              |
+| ----------------- | ---------------- | ---------------------------------------- |
+| `SQLiteAdapter`   | `@drej/sqlite`   | Local dev, single-process apps, scripts  |
 | `PostgresAdapter` | `@drej/postgres` | Production, multi-process, shared ledger |
 
 ## SQLite
@@ -56,21 +57,21 @@ Always call `await client.connect()` before first use and `await client.close()`
 ```ts
 await client.connect(); // opens connection, runs migrations
 // ... use client ...
-await client.close();   // releases connections
+await client.close(); // releases connections
 ```
 
 `connect()` is where migrations run — `CREATE TABLE IF NOT EXISTS` so it's safe to call on every startup.
 
 ## Events written to the ledger
 
-| Event | When |
-|---|---|
-| `sandbox_created` | Container created and reached Running state |
-| `exec_start` | `sb.exec()` or `sb.execCode()` called |
-| `exec_event` | Stdout/stderr chunk received from execd |
-| `exec_complete` | exec finished; payload has `{ seq, exitCode }` |
+| Event                | When                                                      |
+| -------------------- | --------------------------------------------------------- |
+| `sandbox_created`    | Container created and reached Running state               |
+| `exec_start`         | `sb.exec()` or `sb.execCode()` called                     |
+| `exec_event`         | Stdout/stderr chunk received from execd                   |
+| `exec_complete`      | exec finished; payload has `{ seq, exitCode }`            |
 | `checkpoint_created` | `sb.checkpoint()` completed; payload has `{ snapshotId }` |
-| `sandbox_closed` | `sb.close()` called |
+| `sandbox_closed`     | `sb.close()` called                                       |
 
 ## Custom adapter
 

--- a/apps/docs/content/docs/concepts/workflows.mdx
+++ b/apps/docs/content/docs/concepts/workflows.mdx
@@ -37,6 +37,7 @@ try {
 ```
 
 Use the direct API when:
+
 - You need to branch on output values mid-workflow
 - You want to run different commands based on external state
 - Your workflow is straightforward (a few steps, no retry logic)
@@ -49,18 +50,16 @@ Use the direct API when:
 import { workflow } from "@drej/workflow";
 
 await workflow(client)
-  .sandbox(
-    { image: "node:22", resources: { cpu: "500m", memory: "512Mi" } },
-    (sb) => {
-      sb.exec("npm ci");
-      sb.checkpoint("after-install");
-      sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
-    },
-  )
+  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "512Mi" } }, (sb) => {
+    sb.exec("npm ci");
+    sb.checkpoint("after-install");
+    sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
+  })
   .pipe(process.stdout);
 ```
 
 Use the workflow builder when:
+
 - You need `retry`, `when`, `forEach`, or `parallel`
 - You want lifecycle managed automatically (no try/finally)
 - You're building multi-sandbox pipelines with `.parallel()` or `.sequence()`
@@ -72,14 +71,22 @@ Use the workflow builder when:
 ```ts
 // Sequential: stage 2 starts after stage 1 finishes
 await workflow(client)
-  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => { sb.exec("npm run build"); })
-  .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => { sb.exec("./deploy.sh"); })
+  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => {
+    sb.exec("npm run build");
+  })
+  .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => {
+    sb.exec("./deploy.sh");
+  })
   .pipe(process.stdout);
 
 // Parallel: all run simultaneously, results merged
 await workflow(client)
   .parallel(
-    [{ image: "node:20", resources: { cpu: "500m", memory: "256Mi" } }, { image: "node:22", resources: { cpu: "500m", memory: "256Mi" } }, { image: "node:24", resources: { cpu: "500m", memory: "256Mi" } }],
+    [
+      { image: "node:20", resources: { cpu: "500m", memory: "256Mi" } },
+      { image: "node:22", resources: { cpu: "500m", memory: "256Mi" } },
+      { image: "node:24", resources: { cpu: "500m", memory: "256Mi" } },
+    ],
     (sb) => sb.exec("npm test"),
   )
   .pipe(process.stdout);
@@ -87,8 +94,18 @@ await workflow(client)
 // Sequence: each step receives the previous step's result
 await workflow(client)
   .sequence([
-    { image: "node:22", name: "build", resources: { cpu: "500m", memory: "256Mi" }, run: (sb) => sb.exec("npm run build") },
-    { image: "ubuntu:22.04", name: "deploy", resources: { cpu: "500m", memory: "256Mi" }, run: (sb, prev) => sb.exec("./deploy.sh") },
+    {
+      image: "node:22",
+      name: "build",
+      resources: { cpu: "500m", memory: "256Mi" },
+      run: (sb) => sb.exec("npm run build"),
+    },
+    {
+      image: "ubuntu:22.04",
+      name: "deploy",
+      resources: { cpu: "500m", memory: "256Mi" },
+      run: (sb, prev) => sb.exec("./deploy.sh"),
+    },
   ])
   .pipe(process.stdout);
 ```

--- a/apps/docs/content/docs/core/adapters/custom.mdx
+++ b/apps/docs/content/docs/core/adapters/custom.mdx
@@ -35,29 +35,29 @@ import type {
 
 ## Method reference
 
-| Method | Required | Description |
-|---|---|---|
-| `connect()` | No | Initialize connections. Called by `client.connect()`. |
-| `close()` | No | Release connections. Called by `client.close()`. |
-| `append(entry)` | Yes | Persist a single ledger event. Called during every exec. |
-| `readAll(name, sandboxId)` | Yes | Return all events for a session in ascending `ts` order. Used by `resume()`. |
-| `lastCheckpoint(name, sandboxId)` | Yes | Return the most recent `checkpoint_created` entry, or `null`. |
-| `listSandboxDetails(name, opts?)` | Yes | Return sessions with this name, newest first. |
-| `listAllSandboxDetails(opts?)` | Yes | Return all sessions across all names, newest first. |
-| `getSandboxDetails(name, sandboxId)` | Yes | Return a single session, or `null`. |
-| `deleteSandbox(name, sandboxId)` | Yes | Delete all events for a session. |
+| Method                               | Required | Description                                                                  |
+| ------------------------------------ | -------- | ---------------------------------------------------------------------------- |
+| `connect()`                          | No       | Initialize connections. Called by `client.connect()`.                        |
+| `close()`                            | No       | Release connections. Called by `client.close()`.                             |
+| `append(entry)`                      | Yes      | Persist a single ledger event. Called during every exec.                     |
+| `readAll(name, sandboxId)`           | Yes      | Return all events for a session in ascending `ts` order. Used by `resume()`. |
+| `lastCheckpoint(name, sandboxId)`    | Yes      | Return the most recent `checkpoint_created` entry, or `null`.                |
+| `listSandboxDetails(name, opts?)`    | Yes      | Return sessions with this name, newest first.                                |
+| `listAllSandboxDetails(opts?)`       | Yes      | Return all sessions across all names, newest first.                          |
+| `getSandboxDetails(name, sandboxId)` | Yes      | Return a single session, or `null`.                                          |
+| `deleteSandbox(name, sandboxId)`     | Yes      | Delete all events for a session.                                             |
 
 ## LedgerEntry
 
 ```ts
 interface LedgerEntry {
-  ts: number;           // Unix timestamp in milliseconds
-  name: string;         // sandbox name
+  ts: number; // Unix timestamp in milliseconds
+  name: string; // sandbox name
   sandboxId: string;
-  stepIndex: number;    // -1 for sandbox-level events
-  branch?: number;      // parallel branch index
+  stepIndex: number; // -1 for sandbox-level events
+  branch?: number; // parallel branch index
   event: LedgerEvent;
-  payload?: unknown;    // event-specific data
+  payload?: unknown; // event-specific data
   error?: string;
 }
 ```
@@ -84,8 +84,9 @@ export class MemoryAdapter implements IStorageAdapter {
   }
 
   async lastCheckpoint(name: string, sandboxId: string): Promise<LedgerEntry | null> {
-    const checkpoints = (await this.readAll(name, sandboxId))
-      .filter((e) => e.event === LedgerEvent.CheckpointCreated);
+    const checkpoints = (await this.readAll(name, sandboxId)).filter(
+      (e) => e.event === LedgerEvent.CheckpointCreated,
+    );
     return checkpoints.at(-1) ?? null;
   }
 

--- a/apps/docs/content/docs/core/adapters/index.mdx
+++ b/apps/docs/content/docs/core/adapters/index.mdx
@@ -4,7 +4,19 @@ description: Choose where drej persists your run ledger.
 ---
 
 <Cards>
-  <Card href="/docs/adapters/sqlite" title="SQLite" description="Zero-config, WAL mode. The right default for local dev and single-process deploys." />
-  <Card href="/docs/adapters/postgres" title="Postgres" description="For production multi-process deployments with a shared ledger." />
-  <Card href="/docs/adapters/custom" title="Custom adapter" description="Implement IStorageAdapter to use any storage backend." />
+  <Card
+    href="/docs/adapters/sqlite"
+    title="SQLite"
+    description="Zero-config, WAL mode. The right default for local dev and single-process deploys."
+  />
+  <Card
+    href="/docs/adapters/postgres"
+    title="Postgres"
+    description="For production multi-process deployments with a shared ledger."
+  />
+  <Card
+    href="/docs/adapters/custom"
+    title="Custom adapter"
+    description="Implement IStorageAdapter to use any storage backend."
+  />
 </Cards>

--- a/apps/docs/content/docs/core/adapters/postgres.mdx
+++ b/apps/docs/content/docs/core/adapters/postgres.mdx
@@ -25,7 +25,7 @@ const client = new Drej({
 
 await client.connect(); // runs CREATE TABLE IF NOT EXISTS migrations
 // ...
-await client.close();   // releases the connection pool
+await client.close(); // releases the connection pool
 ```
 
 ## Constructor
@@ -34,8 +34,8 @@ await client.close();   // releases the connection pool
 new PostgresAdapter(connectionString: string)
 ```
 
-| Argument | Type | Description |
-|---|---|---|
+| Argument           | Type     | Description                                                                |
+| ------------------ | -------- | -------------------------------------------------------------------------- |
 | `connectionString` | `string` | Postgres connection string, e.g. `"postgres://user:pass@host:5432/dbname"` |
 
 ## Connection string format
@@ -75,9 +75,7 @@ CREATE TABLE IF NOT EXISTS drej_events (
 ## Environment-based config
 
 ```ts
-const adapter = new PostgresAdapter(
-  process.env.DATABASE_URL ?? "postgres://localhost/drej_dev",
-);
+const adapter = new PostgresAdapter(process.env.DATABASE_URL ?? "postgres://localhost/drej_dev");
 ```
 
 For production, set `DATABASE_URL` in your environment and never hardcode credentials.

--- a/apps/docs/content/docs/core/adapters/sqlite.mdx
+++ b/apps/docs/content/docs/core/adapters/sqlite.mdx
@@ -24,7 +24,7 @@ const client = new Drej({
 
 await client.connect(); // creates the file and runs migrations
 // ...
-await client.close();   // closes the database connection
+await client.close(); // closes the database connection
 ```
 
 The file is created if it doesn't exist. `connect()` runs `CREATE TABLE IF NOT EXISTS` migrations so it's safe to call on every startup.
@@ -35,9 +35,9 @@ The file is created if it doesn't exist. `connect()` runs `CREATE TABLE IF NOT E
 new SQLiteAdapter(path: string)
 ```
 
-| Argument | Type | Description |
-|---|---|---|
-| `path` | `string` | File path for the SQLite database. Use `":memory:"` for an in-memory database (data lost on close). |
+| Argument | Type     | Description                                                                                         |
+| -------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `path`   | `string` | File path for the SQLite database. Use `":memory:"` for an in-memory database (data lost on close). |
 
 ## WAL mode
 
@@ -57,6 +57,7 @@ const adapter = new SQLiteAdapter(":memory:");
 ## When to switch to Postgres
 
 Switch to `@drej/postgres` when:
+
 - Multiple processes need to share the same ledger
 - You're deploying to a platform without persistent local disk
 - You need to query ledger data with SQL from external tools

--- a/apps/docs/content/docs/core/api-reference/drej-client.mdx
+++ b/apps/docs/content/docs/core/api-reference/drej-client.mdx
@@ -15,12 +15,12 @@ new Drej(options: DrejOptions)
 
 ### DrejOptions
 
-| Option | Type | Required | Description |
-|---|---|---|---|
-| `baseUrl` | `string` | Yes | OpenSandbox server URL, e.g. `"http://localhost:8080"` |
-| `apiKey` | `string` | No | OpenSandbox API key. Empty string for local dev with no auth. |
-| `adapter` | `IStorageAdapter` | Yes | Storage adapter for the run ledger |
-| `maxConcurrency` | `number` | No | Max simultaneous active sandboxes. Omit for no limit. |
+| Option           | Type              | Required | Description                                                   |
+| ---------------- | ----------------- | -------- | ------------------------------------------------------------- |
+| `baseUrl`        | `string`          | Yes      | OpenSandbox server URL, e.g. `"http://localhost:8080"`        |
+| `apiKey`         | `string`          | No       | OpenSandbox API key. Empty string for local dev with no auth. |
+| `adapter`        | `IStorageAdapter` | Yes      | Storage adapter for the run ledger                            |
+| `maxConcurrency` | `number`          | No       | Max simultaneous active sandboxes. Omit for no limit.         |
 
 ```ts
 const client = new Drej({
@@ -93,7 +93,7 @@ Throws `DrejError` (404) if the session is not found or has no checkpoint.
 const sbResume = await client.resume(originalSandboxId);
 try {
   await sbResume.exec("pip install -q requests").pipe(process.stdout); // replayed
-  await sbResume.exec("python3 script.py").pipe(process.stdout);       // live
+  await sbResume.exec("python3 script.py").pipe(process.stdout); // live
 } finally {
   await sbResume.close();
 }
@@ -131,11 +131,11 @@ await client.sandboxes.delete("my-job", sandboxId);
 
 ### ListSandboxOptions
 
-| Option | Type | Description |
-|---|---|---|
+| Option   | Type            | Description                                                             |
+| -------- | --------------- | ----------------------------------------------------------------------- |
 | `status` | `SandboxStatus` | Filter by status: `"running"`, `"completed"`, `"failed"`, `"cancelled"` |
-| `limit` | `number` | Max results to return |
-| `before` | `number` | Return only sessions started before this Unix timestamp (ms) |
+| `limit`  | `number`        | Max results to return                                                   |
+| `before` | `number`        | Return only sessions started before this Unix timestamp (ms)            |
 
 ## Sandbox class
 
@@ -143,31 +143,31 @@ See [Sandbox](#sandbox) below for the object returned by `sandbox()` and `resume
 
 ### Sandbox methods
 
-| Method | Returns | Description |
-|---|---|---|
-| `sb.exec(cmd, opts?)` | `ExecHandle` | Run a shell command |
-| `sb.execCode(code, opts?)` | `ExecHandle` | Run code via the interpreter |
-| `sb.proxy(port)` | `Promise<{ url, headers }>` | Get a proxied URL for an in-sandbox port |
-| `sb.metrics()` | `Promise<{ cpu, memory, timestamp }>` | Current CPU and memory usage |
-| `sb.writeFile(path, content)` | `Promise<void>` | Write a UTF-8 file into the container |
-| `sb.readFile(path)` | `Promise<string>` | Read a file from the container as a string |
-| `sb.moveFile(from, to)` | `Promise<void>` | Move or rename a file |
-| `sb.deleteFile(path)` | `Promise<void>` | Delete a file |
-| `sb.createDirectory(path)` | `Promise<void>` | Create a directory (and parents) |
-| `sb.deleteDirectory(path)` | `Promise<void>` | Delete a directory |
-| `sb.getFileInfo(path)` | `Promise<FileInfo>` | File metadata: size, type, mode, timestamps |
-| `sb.replaceInFiles(replacements)` | `Promise<void>` | In-place substring replacement across files |
-| `sb.transfer(path, target)` | `Promise<void>` | Copy a file to another `Sandbox` instance |
-| `sb.searchFiles(pattern, path?)` | `Promise<string[]>` | Search for files matching a glob |
-| `sb.listDirectory(path, opts?)` | `Promise<FileInfo[]>` | List directory entries with metadata |
-| `sb.checkpoint(name?)` | `Promise<void>` | Snapshot the container state |
-| `sb.listCheckpoints()` | `Promise<CheckpointInfo[]>` | All checkpoints for this sandbox |
-| `sb.fork(tag?)` | `Promise<Sandbox>` | Snapshot and return an independent copy |
-| `sb.close()` | `Promise<void>` | Delete the container and release resources |
+| Method                            | Returns                               | Description                                 |
+| --------------------------------- | ------------------------------------- | ------------------------------------------- |
+| `sb.exec(cmd, opts?)`             | `ExecHandle`                          | Run a shell command                         |
+| `sb.execCode(code, opts?)`        | `ExecHandle`                          | Run code via the interpreter                |
+| `sb.proxy(port)`                  | `Promise<{ url, headers }>`           | Get a proxied URL for an in-sandbox port    |
+| `sb.metrics()`                    | `Promise<{ cpu, memory, timestamp }>` | Current CPU and memory usage                |
+| `sb.writeFile(path, content)`     | `Promise<void>`                       | Write a UTF-8 file into the container       |
+| `sb.readFile(path)`               | `Promise<string>`                     | Read a file from the container as a string  |
+| `sb.moveFile(from, to)`           | `Promise<void>`                       | Move or rename a file                       |
+| `sb.deleteFile(path)`             | `Promise<void>`                       | Delete a file                               |
+| `sb.createDirectory(path)`        | `Promise<void>`                       | Create a directory (and parents)            |
+| `sb.deleteDirectory(path)`        | `Promise<void>`                       | Delete a directory                          |
+| `sb.getFileInfo(path)`            | `Promise<FileInfo>`                   | File metadata: size, type, mode, timestamps |
+| `sb.replaceInFiles(replacements)` | `Promise<void>`                       | In-place substring replacement across files |
+| `sb.transfer(path, target)`       | `Promise<void>`                       | Copy a file to another `Sandbox` instance   |
+| `sb.searchFiles(pattern, path?)`  | `Promise<string[]>`                   | Search for files matching a glob            |
+| `sb.listDirectory(path, opts?)`   | `Promise<FileInfo[]>`                 | List directory entries with metadata        |
+| `sb.checkpoint(name?)`            | `Promise<void>`                       | Snapshot the container state                |
+| `sb.listCheckpoints()`            | `Promise<CheckpointInfo[]>`           | All checkpoints for this sandbox            |
+| `sb.fork(tag?)`                   | `Promise<Sandbox>`                    | Snapshot and return an independent copy     |
+| `sb.close()`                      | `Promise<void>`                       | Delete the container and release resources  |
 
 ### Sandbox properties
 
-| Property | Type | Description |
-|---|---|---|
-| `sb.sandboxId` | `string` | OpenSandbox container ID |
-| `sb.name` | `string` | User-provided name or auto-generated |
+| Property       | Type     | Description                          |
+| -------------- | -------- | ------------------------------------ |
+| `sb.sandboxId` | `string` | OpenSandbox container ID             |
+| `sb.name`      | `string` | User-provided name or auto-generated |

--- a/apps/docs/content/docs/core/api-reference/errors.mdx
+++ b/apps/docs/content/docs/core/api-reference/errors.mdx
@@ -48,8 +48,8 @@ try {
   await sb.exec("exit 42");
 } catch (e) {
   if (e instanceof CommandError) {
-    console.error(`exit ${e.exitCode}`);      // 42
-    console.error(`command: ${e.command}`);   // "exit 42"
+    console.error(`exit ${e.exitCode}`); // 42
+    console.error(`command: ${e.command}`); // "exit 42"
     console.error(`sandbox: ${e.sandboxId}`);
   }
 }
@@ -57,13 +57,13 @@ try {
 
 ### Properties
 
-| Property | Type | Description |
-|---|---|---|
-| `exitCode` | `number` | The process exit code |
-| `command` | `string` | The command string that was run |
-| `sandboxId` | `string` | The sandbox ID where it ran |
-| `message` | `string` | `"Command exited with code N: <cmd>"` |
-| `name` | `string` | `"CommandError"` |
+| Property    | Type     | Description                           |
+| ----------- | -------- | ------------------------------------- |
+| `exitCode`  | `number` | The process exit code                 |
+| `command`   | `string` | The command string that was run       |
+| `sandboxId` | `string` | The sandbox ID where it ran           |
+| `message`   | `string` | `"Command exited with code N: <cmd>"` |
+| `name`      | `string` | `"CommandError"`                      |
 
 ### Avoiding CommandError
 
@@ -81,22 +81,25 @@ Thrown when a sandbox fails to create, boot, or reach `Running` state. Also thro
 import { SandboxError } from "drej";
 
 try {
-  const sb = await client.sandbox({ image: "nonexistent:image", resources: { cpu: "500m", memory: "256Mi" } });
+  const sb = await client.sandbox({
+    image: "nonexistent:image",
+    resources: { cpu: "500m", memory: "256Mi" },
+  });
 } catch (e) {
   if (e instanceof SandboxError) {
-    console.error(e.message);           // "Sandbox <id> entered state Failed: ..."
-    console.error(e.sandboxId ?? "");   // sandbox ID if assigned before failure
+    console.error(e.message); // "Sandbox <id> entered state Failed: ..."
+    console.error(e.sandboxId ?? ""); // sandbox ID if assigned before failure
   }
 }
 ```
 
 ### Properties
 
-| Property | Type | Description |
-|---|---|---|
+| Property    | Type                  | Description                                         |
+| ----------- | --------------------- | --------------------------------------------------- |
 | `sandboxId` | `string \| undefined` | Container ID if one was assigned before the failure |
-| `message` | `string` | Describes what failed |
-| `name` | `string` | `"SandboxError"` |
+| `message`   | `string`              | Describes what failed                               |
+| `name`      | `string`              | `"SandboxError"`                                    |
 
 ## ExecConnectionError
 
@@ -109,19 +112,19 @@ try {
   await sb.exec("echo test");
 } catch (e) {
   if (e instanceof ExecConnectionError) {
-    console.error(e.message);        // "execd not ready for sandbox <id>"
-    console.error(e.sandboxId);      // the sandbox ID
+    console.error(e.message); // "execd not ready for sandbox <id>"
+    console.error(e.sandboxId); // the sandbox ID
   }
 }
 ```
 
 ### Properties
 
-| Property | Type | Description |
-|---|---|---|
-| `sandboxId` | `string` | The sandbox ID |
-| `message` | `string` | `"execd not ready for sandbox <id>"` |
-| `name` | `string` | `"ExecConnectionError"` |
+| Property    | Type     | Description                          |
+| ----------- | -------- | ------------------------------------ |
+| `sandboxId` | `string` | The sandbox ID                       |
+| `message`   | `string` | `"execd not ready for sandbox <id>"` |
+| `name`      | `string` | `"ExecConnectionError"`              |
 
 This usually means the container image doesn't include execd, or the container started but the execd process crashed.
 
@@ -137,7 +140,7 @@ try {
 } catch (e) {
   if (e instanceof DrejError) {
     console.error(e.message); // "Session nonexistent-id not found"
-    console.error(e.status);  // 404
+    console.error(e.status); // 404
   }
 }
 ```

--- a/apps/docs/content/docs/core/api-reference/index.mdx
+++ b/apps/docs/content/docs/core/api-reference/index.mdx
@@ -4,8 +4,24 @@ description: Complete reference for every public symbol exported from drej.
 ---
 
 <Cards>
-  <Card href="/docs/api-reference/drej-client" title="Drej" description="The main client — sandbox(), resume(), connect(), close(), and sandboxes management." />
-  <Card href="/docs/api-reference/workflow-run" title="ExecHandle" description="The PromiseLike returned by sb.exec() — pipe(), stdout() generator, result(), and await." />
-  <Card href="/docs/api-reference/builder" title="Builder API" description="workflow(), WorkflowBuilder, and SandboxBuilder from @drej/workflow." />
-  <Card href="/docs/api-reference/errors" title="Errors" description="CommandError, SandboxError, ExecConnectionError, WorkflowError, DrejError." />
+  <Card
+    href="/docs/api-reference/drej-client"
+    title="Drej"
+    description="The main client — sandbox(), resume(), connect(), close(), and sandboxes management."
+  />
+  <Card
+    href="/docs/api-reference/workflow-run"
+    title="ExecHandle"
+    description="The PromiseLike returned by sb.exec() — pipe(), stdout() generator, result(), and await."
+  />
+  <Card
+    href="/docs/api-reference/builder"
+    title="Builder API"
+    description="workflow(), WorkflowBuilder, and SandboxBuilder from @drej/workflow."
+  />
+  <Card
+    href="/docs/api-reference/errors"
+    title="Errors"
+    description="CommandError, SandboxError, ExecConnectionError, WorkflowError, DrejError."
+  />
 </Cards>

--- a/apps/docs/content/docs/core/api-reference/workflow-run.mdx
+++ b/apps/docs/content/docs/core/api-reference/workflow-run.mdx
@@ -51,8 +51,8 @@ Explicit promise form. Equivalent to `await handle`.
 
 ```ts
 interface ExecResult {
-  stdout: string;   // full stdout as a string
-  stderr: string;   // full stderr as a string
+  stdout: string; // full stdout as a string
+  stderr: string; // full stderr as a string
   exitCode: number; // process exit code (0 = success)
 }
 ```
@@ -75,8 +75,8 @@ An `ExecHandle` can only be consumed once — the underlying stream is driven by
 const handle = sb.exec("long-running-command");
 
 // These share the same stream — start them before any awaiting
-void handle.pipe(process.stdout);                      // stream as it runs
-const { exitCode } = await handle.result();            // get result when done
+void handle.pipe(process.stdout); // stream as it runs
+const { exitCode } = await handle.result(); // get result when done
 ```
 
 ## In the workflow builder

--- a/apps/docs/content/docs/core/building/control-flow.mdx
+++ b/apps/docs/content/docs/core/building/control-flow.mdx
@@ -33,9 +33,9 @@ await workflow(client)
 
 ### RetryOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `delayMs` | `number` | `1000` | Delay between retries in milliseconds |
+| Option    | Type                       | Default   | Description                                    |
+| --------- | -------------------------- | --------- | ---------------------------------------------- |
+| `delayMs` | `number`                   | `1000`    | Delay between retries in milliseconds          |
 | `backoff` | `"fixed" \| "exponential"` | `"fixed"` | `"exponential"` doubles the delay each attempt |
 
 With exponential backoff, attempt delays are: `delayMs`, `delayMs * 2`, `delayMs * 4`, etc.
@@ -50,8 +50,12 @@ await workflow(client)
     sb.exec("test -f /etc/hostname", { strict: false });
     sb.when(
       (ctx) => ctx.exitCode === 0,
-      (sb) => { sb.exec('echo "/etc/hostname exists"'); },
-      (sb) => { sb.exec('echo "/etc/hostname missing"'); },
+      (sb) => {
+        sb.exec('echo "/etc/hostname exists"');
+      },
+      (sb) => {
+        sb.exec('echo "/etc/hostname missing"');
+      },
     );
   })
   .pipe(process.stdout);
@@ -76,9 +80,9 @@ await workflow(client)
 
 ### ForEachOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `concurrency` | `number` | `1` | Number of items to process simultaneously (within the same sandbox) |
+| Option        | Type     | Default | Description                                                         |
+| ------------- | -------- | ------- | ------------------------------------------------------------------- |
+| `concurrency` | `number` | `1`     | Number of items to process simultaneously (within the same sandbox) |
 
 ## parallel
 
@@ -137,9 +141,13 @@ await workflow(client)
 
 ```ts
 sb.forEach(["a", "b", "c"], (sb, item) => {
-  sb.retry(3, (sb) => {
-    sb.exec(`process ${item}`);
-  }, { backoff: "exponential" });
+  sb.retry(
+    3,
+    (sb) => {
+      sb.exec(`process ${item}`);
+    },
+    { backoff: "exponential" },
+  );
 
   sb.when(
     (ctx) => ctx.exitCode === 0,

--- a/apps/docs/content/docs/core/building/exec.mdx
+++ b/apps/docs/content/docs/core/building/exec.mdx
@@ -39,12 +39,12 @@ await sb.exec(script).pipe(process.stdout);
 
 ### ExecOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `strict` | `boolean` | `true` | Throw `CommandError` on non-zero exit. Set to `false` to get the exit code instead. |
-| `cwd` | `string` | — | Working directory inside the sandbox |
-| `env` | `Record<string, string>` | — | Extra environment variables for this exec only |
-| `timeoutMs` | `number` | — | Abort the command after this many milliseconds |
+| Option      | Type                     | Default | Description                                                                         |
+| ----------- | ------------------------ | ------- | ----------------------------------------------------------------------------------- |
+| `strict`    | `boolean`                | `true`  | Throw `CommandError` on non-zero exit. Set to `false` to get the exit code instead. |
+| `cwd`       | `string`                 | —       | Working directory inside the sandbox                                                |
+| `env`       | `Record<string, string>` | —       | Extra environment variables for this exec only                                      |
+| `timeoutMs` | `number`                 | —       | Abort the command after this many milliseconds                                      |
 
 ### Exec timeout
 
@@ -82,9 +82,7 @@ if (exitCode === 0) {
 ### Using captured output in subsequent commands
 
 ```ts
-const { stdout: nodeVersion } = await sb.exec(
-  "node -e \"process.stdout.write(process.version)\"",
-);
+const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
 
 await sb.exec(`echo "Building with ${nodeVersion.trim()}"`).pipe(process.stdout);
 ```
@@ -109,11 +107,15 @@ const sb = await client.sandbox({
 Each call without a context runs in an isolated interpreter session:
 
 ```ts
-await sb.execCode(`
+await sb
+  .execCode(
+    `
 import sys, math
 print(f"Python {sys.version.split()[0]}")
 print(f"pi = {math.pi:.6f}")
-`.trim()).pipe(process.stdout);
+`.trim(),
+  )
+  .pipe(process.stdout);
 ```
 
 ### Stateful execution
@@ -130,8 +132,8 @@ await sb.execCode(`print(f"sum = {sum(data)}")`, { context: ctx }).pipe(process.
 
 ### ExecCodeOptions
 
-| Option | Type | Description |
-|---|---|---|
+| Option    | Type                                     | Description                                                                            |
+| --------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
 | `context` | `{ id: string, language: CodeLanguage }` | Stateful interpreter session. Variables defined in one call are available in the next. |
 
 ### CodeLanguage
@@ -139,9 +141,9 @@ await sb.execCode(`print(f"sum = {sum(data)}")`, { context: ctx }).pipe(process.
 ```ts
 import { CodeLanguage } from "drej";
 
-CodeLanguage.Python     // "python"
-CodeLanguage.JavaScript // "javascript"
-CodeLanguage.TypeScript // "typescript"
+CodeLanguage.Python; // "python"
+CodeLanguage.JavaScript; // "javascript"
+CodeLanguage.TypeScript; // "typescript"
 ```
 
 ## proxy()

--- a/apps/docs/content/docs/core/building/file-ops.mdx
+++ b/apps/docs/content/docs/core/building/file-ops.mdx
@@ -91,9 +91,9 @@ Return metadata for a file or directory — size, type, mode, owner, and timesta
 
 ```ts
 const info = await sb.getFileInfo("/workspace/src/index.ts");
-console.log(info.size);        // bytes
-console.log(info.type);        // "file" | "directory" | "symlink"
-console.log(info.mode);        // unix permission bits
+console.log(info.size); // bytes
+console.log(info.type); // "file" | "directory" | "symlink"
+console.log(info.mode); // unix permission bits
 console.log(info.modified_at); // ISO timestamp
 ```
 

--- a/apps/docs/content/docs/core/building/index.mdx
+++ b/apps/docs/content/docs/core/building/index.mdx
@@ -4,8 +4,24 @@ description: Practical guides for each step type and capability in the builder A
 ---
 
 <Cards>
-  <Card href="/docs/building/exec" title="exec & execCode" description="Run shell commands and code in the sandbox interpreter." />
-  <Card href="/docs/building/file-ops" title="File operations" description="Write, read, search, and manage files inside the container." />
-  <Card href="/docs/building/control-flow" title="Control flow" description="retry, when, forEach, and parallel — composable within a sandbox." />
-  <Card href="/docs/building/snapshots" title="Snapshots & replay" description="Checkpoint the container state and replay from it." />
+  <Card
+    href="/docs/building/exec"
+    title="exec & execCode"
+    description="Run shell commands and code in the sandbox interpreter."
+  />
+  <Card
+    href="/docs/building/file-ops"
+    title="File operations"
+    description="Write, read, search, and manage files inside the container."
+  />
+  <Card
+    href="/docs/building/control-flow"
+    title="Control flow"
+    description="retry, when, forEach, and parallel — composable within a sandbox."
+  />
+  <Card
+    href="/docs/building/snapshots"
+    title="Snapshots & replay"
+    description="Checkpoint the container state and replay from it."
+  />
 </Cards>

--- a/apps/docs/content/docs/core/concepts/environments.mdx
+++ b/apps/docs/content/docs/core/concepts/environments.mdx
@@ -16,18 +16,20 @@ const env = client.environment("python-data-science", {
   image: "debian:bookworm-slim",
   resources: { cpu: "500m", memory: "512Mi" },
   setup: async (sb) => {
-    await sb.exec("apt-get update -qq && apt-get install -y python3-pip --no-install-recommends -q");
+    await sb.exec(
+      "apt-get update -qq && apt-get install -y python3-pip --no-install-recommends -q",
+    );
     await sb.exec("pip install --quiet numpy pandas matplotlib");
   },
 });
 ```
 
-| Option | Type | Description |
-|---|---|---|
-| `image` | `string \| { uri, auth? }` | Container image. Same format as `SandboxOptions.image`. |
-| `resources` | `{ cpu: string; memory: string; gpu?: string }` | Applied to both the build sandbox and each spawned sandbox. |
-| `setup` | `(sb: Sandbox) => Promise<void>` | Runs once to configure the environment. |
-| `shell` | `string` | Shell binary for all `exec()` calls in this environment. Defaults to `"/bin/sh"`. |
+| Option      | Type                                            | Description                                                                       |
+| ----------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| `image`     | `string \| { uri, auth? }`                      | Container image. Same format as `SandboxOptions.image`.                           |
+| `resources` | `{ cpu: string; memory: string; gpu?: string }` | Applied to both the build sandbox and each spawned sandbox.                       |
+| `setup`     | `(sb: Sandbox) => Promise<void>`                | Runs once to configure the environment.                                           |
+| `shell`     | `string`                                        | Shell binary for all `exec()` calls in this environment. Defaults to `"/bin/sh"`. |
 
 ## Spawning a sandbox
 
@@ -52,11 +54,11 @@ const sb = await env.sandbox({
 });
 ```
 
-| Option | Type | Description |
-|---|---|---|
-| `env` | `Record<string, string>` | Environment variables set at container startup. |
-| `hooks` | `SandboxHooks` | Observability hooks (e.g. `otelHooks(tracer)` from `@drej/otel`). |
-| `shell` | `string` | Shell override for this sandbox only. Falls back to `EnvironmentOptions.shell`. |
+| Option  | Type                     | Description                                                                     |
+| ------- | ------------------------ | ------------------------------------------------------------------------------- |
+| `env`   | `Record<string, string>` | Environment variables set at container startup.                                 |
+| `hooks` | `SandboxHooks`           | Observability hooks (e.g. `otelHooks(tracer)` from `@drej/otel`).               |
+| `shell` | `string`                 | Shell override for this sandbox only. Falls back to `EnvironmentOptions.shell`. |
 
 ## Rebuilding after setup changes
 

--- a/apps/docs/content/docs/core/concepts/event-stream.mdx
+++ b/apps/docs/content/docs/core/concepts/event-stream.mdx
@@ -55,8 +55,8 @@ const { exitCode } = await handle.result();
 
 ```ts
 interface ExecResult {
-  stdout: string;   // full stdout as a string
-  stderr: string;   // full stderr as a string
+  stdout: string; // full stdout as a string
+  stderr: string; // full stderr as a string
   exitCode: number; // process exit code
 }
 ```

--- a/apps/docs/content/docs/core/concepts/index.mdx
+++ b/apps/docs/content/docs/core/concepts/index.mdx
@@ -4,11 +4,39 @@ description: The core ideas behind drej — what things are and how they relate.
 ---
 
 <Cards>
-  <Card href="/docs/concepts/workflows" title="Workflows" description="What a workflow is, how it's defined, and how it runs." />
-  <Card href="/docs/concepts/sandboxes" title="Sandboxes" description="Isolated Docker containers managed by OpenSandbox." />
-  <Card href="/docs/concepts/environments" title="Environments" description="Define a setup recipe once, snapshot it, and spawn isolated sandboxes from it on demand." />
-  <Card href="/docs/concepts/steps" title="Steps" description="The unit of work — leaf steps and control-flow steps." />
-  <Card href="/docs/concepts/refs-and-state" title="Refs & state" description="How to capture step output and thread values through a workflow." />
-  <Card href="/docs/concepts/event-stream" title="Event stream" description="The AsyncIterable that streams events as steps execute." />
-  <Card href="/docs/concepts/storage-adapters" title="Storage adapters" description="How the ledger persists every event for durability and replay." />
+  <Card
+    href="/docs/concepts/workflows"
+    title="Workflows"
+    description="What a workflow is, how it's defined, and how it runs."
+  />
+  <Card
+    href="/docs/concepts/sandboxes"
+    title="Sandboxes"
+    description="Isolated Docker containers managed by OpenSandbox."
+  />
+  <Card
+    href="/docs/concepts/environments"
+    title="Environments"
+    description="Define a setup recipe once, snapshot it, and spawn isolated sandboxes from it on demand."
+  />
+  <Card
+    href="/docs/concepts/steps"
+    title="Steps"
+    description="The unit of work — leaf steps and control-flow steps."
+  />
+  <Card
+    href="/docs/concepts/refs-and-state"
+    title="Refs & state"
+    description="How to capture step output and thread values through a workflow."
+  />
+  <Card
+    href="/docs/concepts/event-stream"
+    title="Event stream"
+    description="The AsyncIterable that streams events as steps execute."
+  />
+  <Card
+    href="/docs/concepts/storage-adapters"
+    title="Storage adapters"
+    description="How the ledger persists every event for durability and replay."
+  />
 </Cards>

--- a/apps/docs/content/docs/core/concepts/meta.json
+++ b/apps/docs/content/docs/core/concepts/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "Concepts",
-  "pages": ["workflows", "sandboxes", "environments", "steps", "refs-and-state", "event-stream", "storage-adapters"]
+  "pages": [
+    "workflows",
+    "sandboxes",
+    "environments",
+    "steps",
+    "refs-and-state",
+    "event-stream",
+    "storage-adapters"
+  ]
 }

--- a/apps/docs/content/docs/core/concepts/refs-and-state.mdx
+++ b/apps/docs/content/docs/core/concepts/refs-and-state.mdx
@@ -15,9 +15,7 @@ const sb = await client.sandbox({
   resources: { cpu: "500m", memory: "256Mi" },
 });
 try {
-  const { stdout: nodeVersion } = await sb.exec(
-    "node -e \"process.stdout.write(process.version)\"",
-  );
+  const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
 
   // Use the captured value in the next exec
   await sb.exec(`echo "Running on Node ${nodeVersion.trim()}"`).pipe(process.stdout);
@@ -64,7 +62,7 @@ The `when` predicate also receives runtime state:
 ```ts
 sb.exec("test -f /etc/hostname", { strict: false });
 sb.when(
-  (ctx) => ctx.exitCode === 0,     // ctx.exitCode, ctx.stdout, ctx.vars
+  (ctx) => ctx.exitCode === 0, // ctx.exitCode, ctx.stdout, ctx.vars
   (sb) => sb.exec("echo exists"),
   (sb) => sb.exec("echo missing"),
 );

--- a/apps/docs/content/docs/core/concepts/sandboxes.mdx
+++ b/apps/docs/content/docs/core/concepts/sandboxes.mdx
@@ -16,21 +16,22 @@ const sb = await client.sandbox({
 ```
 
 `client.sandbox()` does three things:
+
 1. Calls the OpenSandbox control API to create the container
 2. Waits until the container reaches `Running` state
 3. Returns the `Sandbox` object
 
 ## SandboxOptions
 
-| Option | Type | Description |
-|---|---|---|
-| `image` | `string \| { uri, auth? }` | Container image. String form: `"ubuntu:22.04"`. Object form for private registries: `{ uri: "ghcr.io/org/image", auth: { username, password } }` |
-| `resources` | `{ cpu?, memory?, gpu? }` | Resource limits. `cpu` is a Kubernetes-style string like `"500m"` or `"2"`. `memory` is `"256Mi"`, `"1Gi"`, etc. |
-| `env` | `Record<string, string>` | Environment variables set in the container at startup |
-| `metadata` | `Record<string, string>` | Arbitrary key-value labels attached to the sandbox (e.g. `{ runId: "ci-42" }`) |
-| `name` | `string` | User-provided name for the run — used as the ledger key. Auto-generated if omitted. |
-| `timeout` | `number` | Sandbox lifetime in seconds. Defaults to the OpenSandbox server's default. |
-| `hooks` | `SandboxHooks` | Lifecycle callbacks for observability. See [Observability](/docs/core/patterns/observability). |
+| Option      | Type                       | Description                                                                                                                                      |
+| ----------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `image`     | `string \| { uri, auth? }` | Container image. String form: `"ubuntu:22.04"`. Object form for private registries: `{ uri: "ghcr.io/org/image", auth: { username, password } }` |
+| `resources` | `{ cpu?, memory?, gpu? }`  | Resource limits. `cpu` is a Kubernetes-style string like `"500m"` or `"2"`. `memory` is `"256Mi"`, `"1Gi"`, etc.                                 |
+| `env`       | `Record<string, string>`   | Environment variables set in the container at startup                                                                                            |
+| `metadata`  | `Record<string, string>`   | Arbitrary key-value labels attached to the sandbox (e.g. `{ runId: "ci-42" }`)                                                                   |
+| `name`      | `string`                   | User-provided name for the run — used as the ledger key. Auto-generated if omitted.                                                              |
+| `timeout`   | `number`                   | Sandbox lifetime in seconds. Defaults to the OpenSandbox server's default.                                                                       |
+| `hooks`     | `SandboxHooks`             | Lifecycle callbacks for observability. See [Observability](/docs/core/patterns/observability).                                                   |
 
 ## Sandbox lifecycle
 
@@ -55,8 +56,8 @@ try {
 ## Sandbox properties
 
 ```ts
-sb.sandboxId  // OpenSandbox container ID — also the unique ledger key
-sb.name       // User-provided name, or "sandbox-<short-id>" if omitted
+sb.sandboxId; // OpenSandbox container ID — also the unique ledger key
+sb.name; // User-provided name, or "sandbox-<short-id>" if omitted
 ```
 
 ## Multiple sandboxes
@@ -65,7 +66,10 @@ Each `client.sandbox()` call creates an independent container. Hold them as sepa
 
 ```ts
 const sbA = await client.sandbox({ image: "node:22", resources: { cpu: "500m", memory: "512Mi" } });
-const sbB = await client.sandbox({ image: "python:3.11", resources: { cpu: "500m", memory: "512Mi" } });
+const sbB = await client.sandbox({
+  image: "python:3.11",
+  resources: { cpu: "500m", memory: "512Mi" },
+});
 
 try {
   await sbA.exec("node --version").pipe(process.stdout);

--- a/apps/docs/content/docs/core/concepts/steps.mdx
+++ b/apps/docs/content/docs/core/concepts/steps.mdx
@@ -47,14 +47,14 @@ Requires a code-interpreter image (e.g. `opensandbox/code-interpreter`).
 
 ## File operations
 
-| Method | Description |
-|---|---|
-| `sb.writeFile(path, content)` | Write a UTF-8 string into the container |
-| `sb.readFile(path)` | Read a file as a UTF-8 string |
-| `sb.moveFile(from, to)` | Move or rename a file inside the container |
-| `sb.deleteFile(path)` | Delete a file from the container |
+| Method                           | Description                                                   |
+| -------------------------------- | ------------------------------------------------------------- |
+| `sb.writeFile(path, content)`    | Write a UTF-8 string into the container                       |
+| `sb.readFile(path)`              | Read a file as a UTF-8 string                                 |
+| `sb.moveFile(from, to)`          | Move or rename a file inside the container                    |
+| `sb.deleteFile(path)`            | Delete a file from the container                              |
 | `sb.searchFiles(pattern, path?)` | Search for files matching a glob; returns an array of matches |
-| `sb.listDirectory(path, opts?)` | List directory entries; `opts.depth` controls recursion depth |
+| `sb.listDirectory(path, opts?)`  | List directory entries; `opts.depth` controls recursion depth |
 
 See [File operations](/docs/core/building/file-ops) for full examples.
 

--- a/apps/docs/content/docs/core/concepts/storage-adapters.mdx
+++ b/apps/docs/content/docs/core/concepts/storage-adapters.mdx
@@ -8,15 +8,16 @@ Every exec, checkpoint, and sandbox lifecycle event is written to a storage adap
 ## Why persistence matters
 
 The ledger enables:
+
 - **Audit** — see which commands ran, when, and what they output
 - **Resume** — `client.resume(sandboxId)` reads the ledger to rebuild replay cache and restore the container
 - **Observability** — `client.sandboxes.list()` returns run history across all sessions
 
 ## Choosing an adapter
 
-| Adapter | Package | When to use |
-|---|---|---|
-| `SQLiteAdapter` | `@drej/sqlite` | Local dev, single-process apps, scripts |
+| Adapter           | Package          | When to use                              |
+| ----------------- | ---------------- | ---------------------------------------- |
+| `SQLiteAdapter`   | `@drej/sqlite`   | Local dev, single-process apps, scripts  |
 | `PostgresAdapter` | `@drej/postgres` | Production, multi-process, shared ledger |
 
 ## SQLite
@@ -56,21 +57,21 @@ Always call `await client.connect()` before first use and `await client.close()`
 ```ts
 await client.connect(); // opens connection, runs migrations
 // ... use client ...
-await client.close();   // releases connections
+await client.close(); // releases connections
 ```
 
 `connect()` is where migrations run — `CREATE TABLE IF NOT EXISTS` so it's safe to call on every startup.
 
 ## Events written to the ledger
 
-| Event | When |
-|---|---|
-| `sandbox_created` | Container created and reached Running state |
-| `exec_start` | `sb.exec()` or `sb.execCode()` called |
-| `exec_event` | Stdout/stderr chunk received from execd |
-| `exec_complete` | exec finished; payload has `{ seq, exitCode }` |
+| Event                | When                                                      |
+| -------------------- | --------------------------------------------------------- |
+| `sandbox_created`    | Container created and reached Running state               |
+| `exec_start`         | `sb.exec()` or `sb.execCode()` called                     |
+| `exec_event`         | Stdout/stderr chunk received from execd                   |
+| `exec_complete`      | exec finished; payload has `{ seq, exitCode }`            |
 | `checkpoint_created` | `sb.checkpoint()` completed; payload has `{ snapshotId }` |
-| `sandbox_closed` | `sb.close()` called |
+| `sandbox_closed`     | `sb.close()` called                                       |
 
 ## Custom adapter
 

--- a/apps/docs/content/docs/core/concepts/workflows.mdx
+++ b/apps/docs/content/docs/core/concepts/workflows.mdx
@@ -37,6 +37,7 @@ try {
 ```
 
 Use the direct API when:
+
 - You need to branch on output values mid-workflow
 - You want to run different commands based on external state
 - Your workflow is straightforward (a few steps, no retry logic)
@@ -49,18 +50,16 @@ Use the direct API when:
 import { workflow } from "@drej/workflow";
 
 await workflow(client)
-  .sandbox(
-    { image: "node:22", resources: { cpu: "500m", memory: "512Mi" } },
-    (sb) => {
-      sb.exec("npm ci");
-      sb.checkpoint("after-install");
-      sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
-    },
-  )
+  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "512Mi" } }, (sb) => {
+    sb.exec("npm ci");
+    sb.checkpoint("after-install");
+    sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
+  })
   .pipe(process.stdout);
 ```
 
 Use the workflow builder when:
+
 - You need `retry`, `when`, `forEach`, or `parallel`
 - You want lifecycle managed automatically (no try/finally)
 - You're building multi-sandbox pipelines with `.parallel()` or `.sequence()`
@@ -72,14 +71,22 @@ Use the workflow builder when:
 ```ts
 // Sequential: stage 2 starts after stage 1 finishes
 await workflow(client)
-  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => { sb.exec("npm run build"); })
-  .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => { sb.exec("./deploy.sh"); })
+  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => {
+    sb.exec("npm run build");
+  })
+  .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => {
+    sb.exec("./deploy.sh");
+  })
   .pipe(process.stdout);
 
 // Parallel: all run simultaneously, results merged
 await workflow(client)
   .parallel(
-    [{ image: "node:20", resources: { cpu: "500m", memory: "256Mi" } }, { image: "node:22", resources: { cpu: "500m", memory: "256Mi" } }, { image: "node:24", resources: { cpu: "500m", memory: "256Mi" } }],
+    [
+      { image: "node:20", resources: { cpu: "500m", memory: "256Mi" } },
+      { image: "node:22", resources: { cpu: "500m", memory: "256Mi" } },
+      { image: "node:24", resources: { cpu: "500m", memory: "256Mi" } },
+    ],
     (sb) => sb.exec("npm test"),
   )
   .pipe(process.stdout);
@@ -87,8 +94,18 @@ await workflow(client)
 // Sequence: each step receives the previous step's result
 await workflow(client)
   .sequence([
-    { image: "node:22", name: "build", resources: { cpu: "500m", memory: "256Mi" }, run: (sb) => sb.exec("npm run build") },
-    { image: "ubuntu:22.04", name: "deploy", resources: { cpu: "500m", memory: "256Mi" }, run: (sb, prev) => sb.exec("./deploy.sh") },
+    {
+      image: "node:22",
+      name: "build",
+      resources: { cpu: "500m", memory: "256Mi" },
+      run: (sb) => sb.exec("npm run build"),
+    },
+    {
+      image: "ubuntu:22.04",
+      name: "deploy",
+      resources: { cpu: "500m", memory: "256Mi" },
+      run: (sb, prev) => sb.exec("./deploy.sh"),
+    },
   ])
   .pipe(process.stdout);
 ```

--- a/apps/docs/content/docs/core/getting-started/how-it-works.mdx
+++ b/apps/docs/content/docs/core/getting-started/how-it-works.mdx
@@ -22,7 +22,10 @@ client.sandbox(opts)
 Always wrap sandbox usage in `try/finally` so the container is cleaned up even if an exec throws:
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   await sb.exec("npm ci");
   await sb.exec("npm test").pipe(process.stdout);
@@ -35,11 +38,11 @@ try {
 
 `sb.exec()` returns an `ExecHandle` — a `PromiseLike<ExecResult>` with three consumption modes:
 
-| Mode | How | When to use |
-|---|---|---|
-| Await | `const { stdout, exitCode } = await sb.exec(...)` | You need the full result before continuing |
-| Pipe | `await sb.exec(...).pipe(process.stdout)` | Real-time output to a writable |
-| Generator | `for await (const chunk of sb.exec(...).stdout())` | Process chunks individually |
+| Mode      | How                                                | When to use                                |
+| --------- | -------------------------------------------------- | ------------------------------------------ |
+| Await     | `const { stdout, exitCode } = await sb.exec(...)`  | You need the full result before continuing |
+| Pipe      | `await sb.exec(...).pipe(process.stdout)`          | Real-time output to a writable             |
+| Generator | `for await (const chunk of sb.exec(...).stdout())` | Process chunks individually                |
 
 All three modes drive the same underlying SSE stream from execd. `.result()` resolves to `{ stdout, stderr, exitCode }` once the stream is fully consumed.
 

--- a/apps/docs/content/docs/core/getting-started/installation.mdx
+++ b/apps/docs/content/docs/core/getting-started/installation.mdx
@@ -36,12 +36,12 @@ await client.close();
 
 ## Options
 
-| Option | Type | Description |
-|---|---|---|
-| `baseUrl` | `string` | OpenSandbox server URL |
-| `apiKey` | `string` | OpenSandbox API key (empty string for local dev) |
-| `adapter` | `IStorageAdapter` | Storage adapter for the run ledger |
-| `maxConcurrency` | `number` | Max simultaneous workflow runs (default: unlimited) |
+| Option           | Type              | Description                                         |
+| ---------------- | ----------------- | --------------------------------------------------- |
+| `baseUrl`        | `string`          | OpenSandbox server URL                              |
+| `apiKey`         | `string`          | OpenSandbox API key (empty string for local dev)    |
+| `adapter`        | `IStorageAdapter` | Storage adapter for the run ledger                  |
+| `maxConcurrency` | `number`          | Max simultaneous workflow runs (default: unlimited) |
 
 ## Local OpenSandbox
 

--- a/apps/docs/content/docs/core/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/core/getting-started/quickstart.mdx
@@ -50,11 +50,12 @@ bun hello.ts
 Await the `ExecHandle` directly to get `{ stdout, stderr, exitCode }`:
 
 ```ts
-const sb = await client.sandbox({ image: "node:20-slim", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "node:20-slim",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
-  const { stdout: nodeVersion } = await sb.exec(
-    "node -e \"process.stdout.write(process.version)\"",
-  );
+  const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
   await sb.exec(`echo "Running on Node ${nodeVersion.trim()}"`).pipe(process.stdout);
 } finally {
   await sb.close();
@@ -64,7 +65,10 @@ try {
 ## Write and read files
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   await sb.writeFile("/tmp/hello.txt", "hello from drej\n");
   const content = await sb.readFile("/tmp/hello.txt");
@@ -86,13 +90,10 @@ bun add @drej/workflow
 import { workflow } from "@drej/workflow";
 
 await workflow(client)
-  .sandbox(
-    { image: "ubuntu:22.04", resources: { cpu: "500m", memory: "512Mi" } },
-    (sb) => {
-      sb.exec("echo 'step 1'");
-      sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
-    },
-  )
+  .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "512Mi" } }, (sb) => {
+    sb.exec("echo 'step 1'");
+    sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
+  })
   .pipe(process.stdout);
 ```
 

--- a/apps/docs/content/docs/core/patterns/error-handling.mdx
+++ b/apps/docs/content/docs/core/patterns/error-handling.mdx
@@ -10,7 +10,10 @@ By default, `sb.exec()` throws `CommandError` if the command exits with a non-ze
 ```ts
 import { CommandError } from "drej";
 
-const sb = await client.sandbox({ image: "debian:bookworm-slim", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "debian:bookworm-slim",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   await sb.exec("echo 'about to fail'").pipe(process.stdout);
   await sb.exec("exit 42"); // throws CommandError
@@ -26,6 +29,7 @@ try {
 ```
 
 `CommandError` properties:
+
 - `exitCode: number` — the process exit code
 - `command: string` — the command string
 - `sandboxId: string` — which sandbox it ran in
@@ -50,7 +54,10 @@ This is useful for commands where a non-zero exit is a valid outcome (like `test
 Combine non-strict exec with conditional logic:
 
 ```ts
-const sb = await client.sandbox({ image: "debian:bookworm-slim", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "debian:bookworm-slim",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   const { exitCode } = await sb.exec("exit 1", { strict: false });
   if (exitCode === 0) {
@@ -84,7 +91,10 @@ Thrown when a sandbox fails to create, boot, or reach `Running` state:
 import { SandboxError } from "drej";
 
 try {
-  const sb = await client.sandbox({ image: "nonexistent:latest", resources: { cpu: "500m", memory: "256Mi" } });
+  const sb = await client.sandbox({
+    image: "nonexistent:latest",
+    resources: { cpu: "500m", memory: "256Mi" },
+  });
 } catch (e) {
   if (e instanceof SandboxError) {
     console.error(`SandboxError: ${e.message}`, e.sandboxId ?? "");

--- a/apps/docs/content/docs/core/patterns/flue.mdx
+++ b/apps/docs/content/docs/core/patterns/flue.mdx
@@ -49,30 +49,30 @@ export default defineAgent({
 ## API
 
 ```ts
-function drej(sandbox: Sandbox, opts?: { cwd?: string }): SandboxFactory
+function drej(sandbox: Sandbox, opts?: { cwd?: string }): SandboxFactory;
 ```
 
-| Parameter | Type | Description |
-|---|---|---|
-| `sandbox` | `Sandbox` | An already-created drej sandbox. Lifecycle is the caller's responsibility — the adapter never calls `sb.close()`. |
-| `opts.cwd` | `string` | Working directory passed to `createSandboxSessionEnv`. Defaults to `"/"`. |
+| Parameter  | Type      | Description                                                                                                       |
+| ---------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `sandbox`  | `Sandbox` | An already-created drej sandbox. Lifecycle is the caller's responsibility — the adapter never calls `sb.close()`. |
+| `opts.cwd` | `string`  | Working directory passed to `createSandboxSessionEnv`. Defaults to `"/"`.                                         |
 
 ## SandboxApi coverage
 
 The adapter implements all nine `SandboxApi` methods:
 
-| Method | Backed by |
-|---|---|
-| `exec(cmd, opts?)` | `sb.exec()` with `strict: false`. Timeout via `Promise.race` + `Math.ceil`. |
-| `readFile(path)` | `sb.readFile()` |
-| `readFileBuffer(path)` | `sb.exec("base64 -w0 <path>")` → decoded `Uint8Array` |
-| `writeFile(path, string)` | `sb.writeFile()` |
-| `writeFile(path, Uint8Array)` | Base64-encoded, piped through `base64 -d` in the container |
-| `stat(path)` | `sb.exec("stat -c '%F\|%s\|%Y' <path>")` → parsed `FileStat` |
-| `readdir(path)` | `sb.listDirectory(path, { depth: 1 })` → entry names |
-| `exists(path)` | `sb.exec("test -e <path>")` → exit code check |
-| `mkdir(path, opts?)` | `sb.exec("mkdir [-p] <path>")` |
-| `rm(path, opts?)` | `sb.exec("rm [-r] [-f] <path>")` |
+| Method                        | Backed by                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `exec(cmd, opts?)`            | `sb.exec()` with `strict: false`. Timeout via `Promise.race` + `Math.ceil`. |
+| `readFile(path)`              | `sb.readFile()`                                                             |
+| `readFileBuffer(path)`        | `sb.exec("base64 -w0 <path>")` → decoded `Uint8Array`                       |
+| `writeFile(path, string)`     | `sb.writeFile()`                                                            |
+| `writeFile(path, Uint8Array)` | Base64-encoded, piped through `base64 -d` in the container                  |
+| `stat(path)`                  | `sb.exec("stat -c '%F\|%s\|%Y' <path>")` → parsed `FileStat`                |
+| `readdir(path)`               | `sb.listDirectory(path, { depth: 1 })` → entry names                        |
+| `exists(path)`                | `sb.exec("test -e <path>")` → exit code check                               |
+| `mkdir(path, opts?)`          | `sb.exec("mkdir [-p] <path>")`                                              |
+| `rm(path, opts?)`             | `sb.exec("rm [-r] [-f] <path>")`                                            |
 
 ## Known limits
 

--- a/apps/docs/content/docs/core/patterns/fork.mdx
+++ b/apps/docs/content/docs/core/patterns/fork.mdx
@@ -60,19 +60,22 @@ const env = client.environment("python-base", {
 const sb = await env.sandbox();
 try {
   // Fork into two independent experiment tracks
-  const [forkA, forkB] = await Promise.all([
-    sb.fork("track-a"),
-    sb.fork("track-b"),
-  ]);
+  const [forkA, forkB] = await Promise.all([sb.fork("track-a"), sb.fork("track-b")]);
 
   await Promise.all([
-    forkA.exec("pip install -q pandas").then(() =>
-      forkA.exec("python3 -c 'import pandas; print(pandas.__version__)'").pipe(process.stdout)
-    ).finally(() => forkA.close()),
+    forkA
+      .exec("pip install -q pandas")
+      .then(() =>
+        forkA.exec("python3 -c 'import pandas; print(pandas.__version__)'").pipe(process.stdout),
+      )
+      .finally(() => forkA.close()),
 
-    forkB.exec("pip install -q torch --index-url https://download.pytorch.org/whl/cpu").then(() =>
-      forkB.exec("python3 -c 'import torch; print(torch.__version__)'").pipe(process.stdout)
-    ).finally(() => forkB.close()),
+    forkB
+      .exec("pip install -q torch --index-url https://download.pytorch.org/whl/cpu")
+      .then(() =>
+        forkB.exec("python3 -c 'import torch; print(torch.__version__)'").pipe(process.stdout),
+      )
+      .finally(() => forkB.close()),
   ]);
 } finally {
   await sb.close();
@@ -85,12 +88,12 @@ Each forked sandbox acquires a concurrency slot (counts against `DrejOptions.max
 
 ## Relationship to checkpoint and resume
 
-| | `sb.checkpoint()` | `sb.fork()` |
-|---|---|---|
-| Snapshots the container | Yes | Yes |
-| Writes `checkpoint_created` to ledger | Yes | Yes |
-| Original sandbox keeps running | Yes | Yes |
-| Returns a new live sandbox | No | Yes |
-| Use with `client.resume()` | Yes | Yes (snapshot is in ledger) |
+|                                       | `sb.checkpoint()` | `sb.fork()`                 |
+| ------------------------------------- | ----------------- | --------------------------- |
+| Snapshots the container               | Yes               | Yes                         |
+| Writes `checkpoint_created` to ledger | Yes               | Yes                         |
+| Original sandbox keeps running        | Yes               | Yes                         |
+| Returns a new live sandbox            | No                | Yes                         |
+| Use with `client.resume()`            | Yes               | Yes (snapshot is in ledger) |
 
 Because `fork()` writes a `checkpoint_created` event, the resulting snapshot is visible in `sb.listCheckpoints()` and can also be used with `client.resume()`.

--- a/apps/docs/content/docs/core/patterns/index.mdx
+++ b/apps/docs/content/docs/core/patterns/index.mdx
@@ -4,9 +4,29 @@ description: Cross-cutting concerns — how to handle failure, time, and observa
 ---
 
 <Cards>
-  <Card href="/docs/patterns/timeouts-and-cancellation" title="Timeouts & cancellation" description="Sandbox lifetime, bash timeout command, and try/finally cleanup." />
-  <Card href="/docs/patterns/error-handling" title="Error handling" description="Strict vs non-strict exec, CommandError, SandboxError, and ExecConnectionError." />
-  <Card href="/docs/patterns/run-management" title="Run management" description="List, resume, and delete runs from the ledger." />
-  <Card href="/docs/patterns/observability" title="Observability" description="WorkflowHooks and OpenTelemetry tracing with @drej/otel." />
-  <Card href="/docs/patterns/flue" title="Flue integration" description="Use drej sandboxes as Flue session environments with @drej/flue." />
+  <Card
+    href="/docs/patterns/timeouts-and-cancellation"
+    title="Timeouts & cancellation"
+    description="Sandbox lifetime, bash timeout command, and try/finally cleanup."
+  />
+  <Card
+    href="/docs/patterns/error-handling"
+    title="Error handling"
+    description="Strict vs non-strict exec, CommandError, SandboxError, and ExecConnectionError."
+  />
+  <Card
+    href="/docs/patterns/run-management"
+    title="Run management"
+    description="List, resume, and delete runs from the ledger."
+  />
+  <Card
+    href="/docs/patterns/observability"
+    title="Observability"
+    description="WorkflowHooks and OpenTelemetry tracing with @drej/otel."
+  />
+  <Card
+    href="/docs/patterns/flue"
+    title="Flue integration"
+    description="Use drej sandboxes as Flue session environments with @drej/flue."
+  />
 </Cards>

--- a/apps/docs/content/docs/core/patterns/meta.json
+++ b/apps/docs/content/docs/core/patterns/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "Patterns",
-  "pages": ["timeouts-and-cancellation", "error-handling", "run-management", "named-checkpoints", "fork", "observability", "flue"]
+  "pages": [
+    "timeouts-and-cancellation",
+    "error-handling",
+    "run-management",
+    "named-checkpoints",
+    "fork",
+    "observability",
+    "flue"
+  ]
 }

--- a/apps/docs/content/docs/core/patterns/named-checkpoints.mdx
+++ b/apps/docs/content/docs/core/patterns/named-checkpoints.mdx
@@ -37,11 +37,11 @@ for (const cp of checkpoints) {
 
 Each `CheckpointInfo` has:
 
-| Field | Type | Description |
-|---|---|---|
-| `snapshotId` | `string` | OpenSandbox snapshot ID |
-| `tag` | `string?` | Tag passed to `sb.checkpoint()`, if any |
-| `createdAt` | `number` | Unix timestamp (ms) when the checkpoint was created |
+| Field        | Type      | Description                                         |
+| ------------ | --------- | --------------------------------------------------- |
+| `snapshotId` | `string`  | OpenSandbox snapshot ID                             |
+| `tag`        | `string?` | Tag passed to `sb.checkpoint()`, if any             |
+| `createdAt`  | `number`  | Unix timestamp (ms) when the checkpoint was created |
 
 ## Resuming from a named checkpoint
 

--- a/apps/docs/content/docs/core/patterns/observability.mdx
+++ b/apps/docs/content/docs/core/patterns/observability.mdx
@@ -40,14 +40,14 @@ const sb = await client.sandbox({
 
 ## Hook signatures
 
-| Hook | When | Arguments |
-|---|---|---|
-| `onSandboxCreated` | Container created and running | `(sandboxId, name)` |
-| `onExecStart` | `sb.exec()` called | `(sandboxId, seq, cmd)` |
-| `onExecComplete` | exec finished | `(sandboxId, seq, ExecResult)` |
-| `onCheckpoint` | `sb.checkpoint()` completed | `(sandboxId, snapshotId, name?)` |
-| `onSandboxClosed` | `sb.close()` completed | `(sandboxId)` |
-| `onSandboxFailed` | sandbox creation or boot failed | `(sandboxId, error)` |
+| Hook               | When                            | Arguments                        |
+| ------------------ | ------------------------------- | -------------------------------- |
+| `onSandboxCreated` | Container created and running   | `(sandboxId, name)`              |
+| `onExecStart`      | `sb.exec()` called              | `(sandboxId, seq, cmd)`          |
+| `onExecComplete`   | exec finished                   | `(sandboxId, seq, ExecResult)`   |
+| `onCheckpoint`     | `sb.checkpoint()` completed     | `(sandboxId, snapshotId, name?)` |
+| `onSandboxClosed`  | `sb.close()` completed          | `(sandboxId)`                    |
+| `onSandboxFailed`  | sandbox creation or boot failed | `(sandboxId, error)`             |
 
 ## OpenTelemetry with @drej/otel
 
@@ -80,9 +80,9 @@ sandbox.run            ← root span (drej.sandbox.id, drej.sandbox.name)
 
 ### OtelHooksOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `recordExitCode` | `boolean` | `true` | Add `process.exit_code` attribute to exec spans |
+| Option           | Type      | Default | Description                                     |
+| ---------------- | --------- | ------- | ----------------------------------------------- |
+| `recordExitCode` | `boolean` | `true`  | Add `process.exit_code` attribute to exec spans |
 
 ```ts
 const hooks = otelHooks(tracer, { recordExitCode: false });

--- a/apps/docs/content/docs/core/patterns/run-management.mdx
+++ b/apps/docs/content/docs/core/patterns/run-management.mdx
@@ -21,15 +21,15 @@ Sessions are returned newest first.
 
 Each session has:
 
-| Field | Type | Description |
-|---|---|---|
-| `sandboxId` | `string` | OpenSandbox container ID |
-| `name` | `string` | User-provided name (or auto-generated) |
-| `status` | `SandboxStatus` | `"running"`, `"completed"`, `"failed"`, or `"cancelled"` |
-| `startedAt` | `number` | Unix timestamp (ms) of `sandbox_created` event |
-| `completedAt` | `number?` | Unix timestamp (ms) of `sandbox_closed` event |
-| `execCount` | `number` | Number of completed execs |
-| `error` | `string?` | Error message if status is `failed` |
+| Field         | Type            | Description                                              |
+| ------------- | --------------- | -------------------------------------------------------- |
+| `sandboxId`   | `string`        | OpenSandbox container ID                                 |
+| `name`        | `string`        | User-provided name (or auto-generated)                   |
+| `status`      | `SandboxStatus` | `"running"`, `"completed"`, `"failed"`, or `"cancelled"` |
+| `startedAt`   | `number`        | Unix timestamp (ms) of `sandbox_created` event           |
+| `completedAt` | `number?`       | Unix timestamp (ms) of `sandbox_closed` event            |
+| `execCount`   | `number`        | Number of completed execs                                |
+| `error`       | `string?`       | Error message if status is `failed`                      |
 
 ## Filter by name
 
@@ -99,7 +99,8 @@ const completed = await client.sandboxes.list({ status: SandboxStatus.Completed 
 
 for (const session of completed) {
   const ageMs = Date.now() - session.startedAt;
-  if (ageMs > 7 * 24 * 60 * 60 * 1000) { // older than 7 days
+  if (ageMs > 7 * 24 * 60 * 60 * 1000) {
+    // older than 7 days
     await client.sandboxes.delete(session.name, session.sandboxId);
   }
 }

--- a/apps/docs/content/docs/core/patterns/timeouts-and-cancellation.mdx
+++ b/apps/docs/content/docs/core/patterns/timeouts-and-cancellation.mdx
@@ -22,7 +22,10 @@ This is a hard limit on the container — not on individual commands.
 Use the bash `timeout` command to limit how long a single command can run. The `timeout` utility exits with code `124` if the limit is reached:
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   // Times out after 1 second, exits with 124
   const { exitCode } = await sb.exec("timeout 1 sleep 30 || echo 'timed out'", { strict: false });
@@ -69,7 +72,10 @@ try {
 For commands that might run indefinitely, combine `timeout` with error handling:
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   const result = await sb.exec("timeout 60 ./run-tests.sh", { strict: false });
   if (result.exitCode === 124) {
@@ -92,11 +98,10 @@ import { workflow } from "@drej/workflow";
 
 await workflow(client)
   .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => {
-    sb.retry(
-      5,
-      (sb) => sb.exec("curl --retry 0 --max-time 10 https://example.com"),
-      { delayMs: 1000, backoff: "exponential" },
-    );
+    sb.retry(5, (sb) => sb.exec("curl --retry 0 --max-time 10 https://example.com"), {
+      delayMs: 1000,
+      backoff: "exponential",
+    });
   })
   .pipe(process.stdout);
 ```

--- a/apps/docs/content/docs/drejx/commands/add.mdx
+++ b/apps/docs/content/docs/drejx/commands/add.mdx
@@ -9,15 +9,15 @@ bunx drejx add <url> [options]
 
 ## Arguments
 
-| Argument | Description |
-|---|---|
-| `url` | URL or local file path to a registry item JSON. Required. |
+| Argument | Description                                               |
+| -------- | --------------------------------------------------------- |
+| `url`    | URL or local file path to a registry item JSON. Required. |
 
 ## Options
 
-| Option | Description |
-|---|---|
-| `--name <name>` | Override the sandbox name. Defaults to the `name` field in the registry item. |
+| Option           | Description                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| `--name <name>`  | Override the sandbox name. Defaults to the `name` field in the registry item.       |
 | `--server <url>` | Use a different OpenSandbox server. Defaults to `serverUrl` in `.drej/config.json`. |
 
 ## What it does

--- a/apps/docs/content/docs/drejx/commands/index.mdx
+++ b/apps/docs/content/docs/drejx/commands/index.mdx
@@ -4,8 +4,24 @@ description: All drejx commands and their options.
 ---
 
 <Cards>
-  <Card href="/docs/drejx/commands/init" title="init" description="Start a local OpenSandbox server via Docker." />
-  <Card href="/docs/drejx/commands/add" title="add" description="Fetch a registry item and provision a sandbox from it." />
-  <Card href="/docs/drejx/commands/list" title="list" description="List all sandboxes provisioned in this project." />
-  <Card href="/docs/drejx/commands/remove" title="remove" description="Remove a sandbox entry from the project." />
+  <Card
+    href="/docs/drejx/commands/init"
+    title="init"
+    description="Start a local OpenSandbox server via Docker."
+  />
+  <Card
+    href="/docs/drejx/commands/add"
+    title="add"
+    description="Fetch a registry item and provision a sandbox from it."
+  />
+  <Card
+    href="/docs/drejx/commands/list"
+    title="list"
+    description="List all sandboxes provisioned in this project."
+  />
+  <Card
+    href="/docs/drejx/commands/remove"
+    title="remove"
+    description="Remove a sandbox entry from the project."
+  />
 </Cards>

--- a/apps/docs/content/docs/drejx/commands/init.mdx
+++ b/apps/docs/content/docs/drejx/commands/init.mdx
@@ -31,12 +31,12 @@ Written once. Contains the connection details for your project.
 }
 ```
 
-| Field | Description |
-|---|---|
-| `serverUrl` | The OpenSandbox server URL. |
+| Field            | Description                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| `serverUrl`      | The OpenSandbox server URL.                                                              |
 | `useServerProxy` | Always `true` when started via `drejx init`. Pass this to the `Drej` client constructor. |
-| `apiKey` | Empty for local dev. Set this if your server requires authentication. |
-| `adapterPath` | Path to the SQLite ledger database for this project. |
+| `apiKey`         | Empty for local dev. Set this if your server requires authentication.                    |
+| `adapterPath`    | Path to the SQLite ledger database for this project.                                     |
 
 ## Idempotency
 

--- a/apps/docs/content/docs/drejx/commands/list.mdx
+++ b/apps/docs/content/docs/drejx/commands/list.mdx
@@ -17,12 +17,12 @@ node-toolchain        sb_a1b2c3d4e5f6g7    2m      https://registry.drej.dev/nod
 python-data-sci       sb_h8i9j0k1l2m3n4    1h      https://registry.drej.dev/python-ds.json
 ```
 
-| Column | Description |
-|---|---|
-| `NAME` | The name given to the sandbox (from the registry item or `--name`). |
+| Column       | Description                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `NAME`       | The name given to the sandbox (from the registry item or `--name`).                                            |
 | `SANDBOX ID` | The first 16 characters of the sandbox ID. Use `client.resume()` with the full ID from `.drej/sandboxes.json`. |
-| `AGE` | How long ago the sandbox was provisioned. |
-| `URL` | The registry item URL used to provision it. |
+| `AGE`        | How long ago the sandbox was provisioned.                                                                      |
+| `URL`        | The registry item URL used to provision it.                                                                    |
 
 ## Notes
 

--- a/apps/docs/content/docs/drejx/commands/remove.mdx
+++ b/apps/docs/content/docs/drejx/commands/remove.mdx
@@ -9,9 +9,9 @@ bunx drejx remove <name>
 
 ## Arguments
 
-| Argument | Description |
-|---|---|
-| `name` | The sandbox name as shown by `drejx list`. Required. |
+| Argument | Description                                          |
+| -------- | ---------------------------------------------------- |
+| `name`   | The sandbox name as shown by `drejx list`. Required. |
 
 ## What it does
 

--- a/apps/docs/content/docs/drejx/registry/index.mdx
+++ b/apps/docs/content/docs/drejx/registry/index.mdx
@@ -34,10 +34,7 @@ bunx drejx add https://raw.githubusercontent.com/your-org/your-repo/main/sandbox
   "name": "node-toolchain",
   "image": "node:22",
   "resources": { "cpu": "500m", "memory": "512Mi" },
-  "setup": [
-    "npm install -g typescript eslint prettier",
-    "mkdir -p /workspace"
-  ]
+  "setup": ["npm install -g typescript eslint prettier", "mkdir -p /workspace"]
 }
 ```
 
@@ -50,11 +47,7 @@ A registry item can declare dependencies on other items. `drejx add` provisions 
   "name": "ts-reviewer",
   "image": "node:22",
   "resources": { "cpu": "500m", "memory": "512Mi" },
-  "registryDependencies": [
-    "https://registry.drej.dev/node-toolchain.json"
-  ],
-  "setup": [
-    "npm install -g @typescript-eslint/parser"
-  ]
+  "registryDependencies": ["https://registry.drej.dev/node-toolchain.json"],
+  "setup": ["npm install -g @typescript-eslint/parser"]
 }
 ```

--- a/apps/docs/content/docs/drejx/registry/schema.mdx
+++ b/apps/docs/content/docs/drejx/registry/schema.mdx
@@ -19,18 +19,13 @@ A registry item is a JSON object. Only `name`, `image`, and `resources` are requ
   "resources": { "cpu": "500m", "memory": "512Mi" },
   "env": { "NODE_ENV": "production" },
 
-  "setup": [
-    "npm install -g typescript eslint",
-    "mkdir -p /workspace"
-  ],
+  "setup": ["npm install -g typescript eslint", "mkdir -p /workspace"],
 
   "ports": [3000],
 
   "metadata": { "version": "1.0.0" },
 
-  "registryDependencies": [
-    "https://registry.drej.dev/base-node.json"
-  ]
+  "registryDependencies": ["https://registry.drej.dev/base-node.json"]
 }
 ```
 
@@ -38,11 +33,11 @@ A registry item is a JSON object. Only `name`, `image`, and `resources` are requ
 
 ### Required
 
-| Field | Type | Description |
-|---|---|---|
-| `name` | `string` | Unique identifier for the sandbox. Used as the entry name in `drejx list`. |
-| `image` | `string \| ImageSpec` | Container image. A plain string (`"node:22"`) or an object `{ uri, auth? }` for private registries. |
-| `resources` | `ResourceSpec` | CPU and memory limits. Required by the OpenSandbox server. |
+| Field       | Type                  | Description                                                                                         |
+| ----------- | --------------------- | --------------------------------------------------------------------------------------------------- |
+| `name`      | `string`              | Unique identifier for the sandbox. Used as the entry name in `drejx list`.                          |
+| `image`     | `string \| ImageSpec` | Container image. A plain string (`"node:22"`) or an object `{ uri, auth? }` for private registries. |
+| `resources` | `ResourceSpec`        | CPU and memory limits. Required by the OpenSandbox server.                                          |
 
 **`ResourceSpec`**
 
@@ -50,11 +45,11 @@ A registry item is a JSON object. Only `name`, `image`, and `resources` are requ
 { "cpu": "500m", "memory": "512Mi" }
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| `cpu` | `string` | CPU limit in Kubernetes resource notation (`"500m"`, `"1"`, `"2"`). |
-| `memory` | `string` | Memory limit (`"256Mi"`, `"1Gi"`). |
-| `gpu` | `string` | Optional GPU limit. |
+| Field    | Type     | Description                                                         |
+| -------- | -------- | ------------------------------------------------------------------- |
+| `cpu`    | `string` | CPU limit in Kubernetes resource notation (`"500m"`, `"1"`, `"2"`). |
+| `memory` | `string` | Memory limit (`"256Mi"`, `"1Gi"`).                                  |
+| `gpu`    | `string` | Optional GPU limit.                                                 |
 
 **`ImageSpec`** (for private registries)
 
@@ -64,17 +59,17 @@ A registry item is a JSON object. Only `name`, `image`, and `resources` are requ
 
 ### Optional
 
-| Field | Type | Description |
-|---|---|---|
-| `title` | `string` | Human-readable display name. |
-| `description` | `string` | Short description shown in tooling. |
-| `author` | `string` | Author name and optional URL. |
-| `categories` | `string[]` | Tags for discovery (e.g. `["agent", "python"]`). |
-| `env` | `Record<string, string>` | Environment variables injected at sandbox startup. |
-| `setup` | `string[]` | Shell commands run in order after the sandbox starts. The result is checkpointed so future resumes skip setup. |
-| `ports` | `number[]` | Informational. Documents which ports the sandbox exposes. Call `sb.proxy(port)` to reach them from your code. |
-| `metadata` | `Record<string, string>` | Arbitrary key-value labels attached to the sandbox. |
-| `registryDependencies` | `string[]` | URLs of other registry items to provision first. Resolved depth-first before this item's setup runs. |
+| Field                  | Type                     | Description                                                                                                    |
+| ---------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `title`                | `string`                 | Human-readable display name.                                                                                   |
+| `description`          | `string`                 | Short description shown in tooling.                                                                            |
+| `author`               | `string`                 | Author name and optional URL.                                                                                  |
+| `categories`           | `string[]`               | Tags for discovery (e.g. `["agent", "python"]`).                                                               |
+| `env`                  | `Record<string, string>` | Environment variables injected at sandbox startup.                                                             |
+| `setup`                | `string[]`               | Shell commands run in order after the sandbox starts. The result is checkpointed so future resumes skip setup. |
+| `ports`                | `number[]`               | Informational. Documents which ports the sandbox exposes. Call `sb.proxy(port)` to reach them from your code.  |
+| `metadata`             | `Record<string, string>` | Arbitrary key-value labels attached to the sandbox.                                                            |
+| `registryDependencies` | `string[]`               | URLs of other registry items to provision first. Resolved depth-first before this item's setup runs.           |
 
 ## Validation
 

--- a/apps/docs/content/docs/drejx/using-sandboxes.mdx
+++ b/apps/docs/content/docs/drejx/using-sandboxes.mdx
@@ -83,10 +83,7 @@ try {
 Every `client.resume()` call creates a fresh container restored from the same checkpoint. Each resume is independent — running commands on one does not affect another.
 
 ```ts
-const [sb1, sb2] = await Promise.all([
-  client.resume("sb_a1b2c3d4"),
-  client.resume("sb_a1b2c3d4"),
-]);
+const [sb1, sb2] = await Promise.all([client.resume("sb_a1b2c3d4"), client.resume("sb_a1b2c3d4")]);
 
 // sb1 and sb2 are separate containers, both starting from the same state
 await Promise.all([

--- a/apps/docs/content/docs/getting-started/how-it-works.mdx
+++ b/apps/docs/content/docs/getting-started/how-it-works.mdx
@@ -22,7 +22,10 @@ client.sandbox(opts)
 Always wrap sandbox usage in `try/finally` so the container is cleaned up even if an exec throws:
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   await sb.exec("npm ci");
   await sb.exec("npm test").pipe(process.stdout);
@@ -35,11 +38,11 @@ try {
 
 `sb.exec()` returns an `ExecHandle` — a `PromiseLike<ExecResult>` with three consumption modes:
 
-| Mode | How | When to use |
-|---|---|---|
-| Await | `const { stdout, exitCode } = await sb.exec(...)` | You need the full result before continuing |
-| Pipe | `await sb.exec(...).pipe(process.stdout)` | Real-time output to a writable |
-| Generator | `for await (const chunk of sb.exec(...).stdout())` | Process chunks individually |
+| Mode      | How                                                | When to use                                |
+| --------- | -------------------------------------------------- | ------------------------------------------ |
+| Await     | `const { stdout, exitCode } = await sb.exec(...)`  | You need the full result before continuing |
+| Pipe      | `await sb.exec(...).pipe(process.stdout)`          | Real-time output to a writable             |
+| Generator | `for await (const chunk of sb.exec(...).stdout())` | Process chunks individually                |
 
 All three modes drive the same underlying SSE stream from execd. `.result()` resolves to `{ stdout, stderr, exitCode }` once the stream is fully consumed.
 

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -36,12 +36,12 @@ await client.close();
 
 ## Options
 
-| Option | Type | Description |
-|---|---|---|
-| `baseUrl` | `string` | OpenSandbox server URL |
-| `apiKey` | `string` | OpenSandbox API key (empty string for local dev) |
-| `adapter` | `IStorageAdapter` | Storage adapter for the run ledger |
-| `maxConcurrency` | `number` | Max simultaneous workflow runs (default: unlimited) |
+| Option           | Type              | Description                                         |
+| ---------------- | ----------------- | --------------------------------------------------- |
+| `baseUrl`        | `string`          | OpenSandbox server URL                              |
+| `apiKey`         | `string`          | OpenSandbox API key (empty string for local dev)    |
+| `adapter`        | `IStorageAdapter` | Storage adapter for the run ledger                  |
+| `maxConcurrency` | `number`          | Max simultaneous workflow runs (default: unlimited) |
 
 ## Local OpenSandbox
 

--- a/apps/docs/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/getting-started/quickstart.mdx
@@ -50,11 +50,12 @@ bun hello.ts
 Await the `ExecHandle` directly to get `{ stdout, stderr, exitCode }`:
 
 ```ts
-const sb = await client.sandbox({ image: "node:20-slim", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "node:20-slim",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
-  const { stdout: nodeVersion } = await sb.exec(
-    "node -e \"process.stdout.write(process.version)\"",
-  );
+  const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
   await sb.exec(`echo "Running on Node ${nodeVersion.trim()}"`).pipe(process.stdout);
 } finally {
   await sb.close();
@@ -64,7 +65,10 @@ try {
 ## Write and read files
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   await sb.writeFile("/tmp/hello.txt", "hello from drej\n");
   const content = await sb.readFile("/tmp/hello.txt");
@@ -86,13 +90,10 @@ bun add @drej/workflow
 import { workflow } from "@drej/workflow";
 
 await workflow(client)
-  .sandbox(
-    { image: "ubuntu:22.04", resources: { cpu: "500m", memory: "512Mi" } },
-    (sb) => {
-      sb.exec("echo 'step 1'");
-      sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
-    },
-  )
+  .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "512Mi" } }, (sb) => {
+    sb.exec("echo 'step 1'");
+    sb.retry(3, (sb) => sb.exec("npm test"), { backoff: "exponential" });
+  })
   .pipe(process.stdout);
 ```
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "drej",
-  "pages": ["index", "getting-started", "concepts", "building", "patterns", "adapters", "api-reference"]
+  "pages": [
+    "index",
+    "getting-started",
+    "concepts",
+    "building",
+    "patterns",
+    "adapters",
+    "api-reference"
+  ]
 }

--- a/apps/docs/content/docs/patterns/error-handling.mdx
+++ b/apps/docs/content/docs/patterns/error-handling.mdx
@@ -10,7 +10,10 @@ By default, `sb.exec()` throws `CommandError` if the command exits with a non-ze
 ```ts
 import { CommandError } from "drej";
 
-const sb = await client.sandbox({ image: "debian:bookworm-slim", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "debian:bookworm-slim",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   await sb.exec("echo 'about to fail'").pipe(process.stdout);
   await sb.exec("exit 42"); // throws CommandError
@@ -26,6 +29,7 @@ try {
 ```
 
 `CommandError` properties:
+
 - `exitCode: number` — the process exit code
 - `command: string` — the command string
 - `sandboxId: string` — which sandbox it ran in
@@ -50,7 +54,10 @@ This is useful for commands where a non-zero exit is a valid outcome (like `test
 Combine non-strict exec with conditional logic:
 
 ```ts
-const sb = await client.sandbox({ image: "debian:bookworm-slim", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "debian:bookworm-slim",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   const { exitCode } = await sb.exec("exit 1", { strict: false });
   if (exitCode === 0) {
@@ -84,7 +91,10 @@ Thrown when a sandbox fails to create, boot, or reach `Running` state:
 import { SandboxError } from "drej";
 
 try {
-  const sb = await client.sandbox({ image: "nonexistent:latest", resources: { cpu: "500m", memory: "256Mi" } });
+  const sb = await client.sandbox({
+    image: "nonexistent:latest",
+    resources: { cpu: "500m", memory: "256Mi" },
+  });
 } catch (e) {
   if (e instanceof SandboxError) {
     console.error(`SandboxError: ${e.message}`, e.sandboxId ?? "");

--- a/apps/docs/content/docs/patterns/index.mdx
+++ b/apps/docs/content/docs/patterns/index.mdx
@@ -4,8 +4,24 @@ description: Cross-cutting concerns — how to handle failure, time, and observa
 ---
 
 <Cards>
-  <Card href="/docs/patterns/timeouts-and-cancellation" title="Timeouts & cancellation" description="Sandbox lifetime, bash timeout command, and try/finally cleanup." />
-  <Card href="/docs/patterns/error-handling" title="Error handling" description="Strict vs non-strict exec, CommandError, SandboxError, and ExecConnectionError." />
-  <Card href="/docs/patterns/run-management" title="Run management" description="List, resume, and delete runs from the ledger." />
-  <Card href="/docs/patterns/observability" title="Observability" description="WorkflowHooks and OpenTelemetry tracing with @drej/otel." />
+  <Card
+    href="/docs/patterns/timeouts-and-cancellation"
+    title="Timeouts & cancellation"
+    description="Sandbox lifetime, bash timeout command, and try/finally cleanup."
+  />
+  <Card
+    href="/docs/patterns/error-handling"
+    title="Error handling"
+    description="Strict vs non-strict exec, CommandError, SandboxError, and ExecConnectionError."
+  />
+  <Card
+    href="/docs/patterns/run-management"
+    title="Run management"
+    description="List, resume, and delete runs from the ledger."
+  />
+  <Card
+    href="/docs/patterns/observability"
+    title="Observability"
+    description="WorkflowHooks and OpenTelemetry tracing with @drej/otel."
+  />
 </Cards>

--- a/apps/docs/content/docs/patterns/observability.mdx
+++ b/apps/docs/content/docs/patterns/observability.mdx
@@ -40,14 +40,14 @@ const sb = await client.sandbox({
 
 ## Hook signatures
 
-| Hook | When | Arguments |
-|---|---|---|
-| `onSandboxCreated` | Container created and running | `(sandboxId, name)` |
-| `onExecStart` | `sb.exec()` called | `(sandboxId, seq, cmd)` |
-| `onExecComplete` | exec finished | `(sandboxId, seq, ExecResult)` |
-| `onCheckpoint` | `sb.checkpoint()` completed | `(sandboxId, snapshotId, name?)` |
-| `onSandboxClosed` | `sb.close()` completed | `(sandboxId)` |
-| `onSandboxFailed` | sandbox creation or boot failed | `(sandboxId, error)` |
+| Hook               | When                            | Arguments                        |
+| ------------------ | ------------------------------- | -------------------------------- |
+| `onSandboxCreated` | Container created and running   | `(sandboxId, name)`              |
+| `onExecStart`      | `sb.exec()` called              | `(sandboxId, seq, cmd)`          |
+| `onExecComplete`   | exec finished                   | `(sandboxId, seq, ExecResult)`   |
+| `onCheckpoint`     | `sb.checkpoint()` completed     | `(sandboxId, snapshotId, name?)` |
+| `onSandboxClosed`  | `sb.close()` completed          | `(sandboxId)`                    |
+| `onSandboxFailed`  | sandbox creation or boot failed | `(sandboxId, error)`             |
 
 ## OpenTelemetry with @drej/otel
 
@@ -80,9 +80,9 @@ sandbox.run            ← root span (drej.sandbox.id, drej.sandbox.name)
 
 ### OtelHooksOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `recordExitCode` | `boolean` | `true` | Add `process.exit_code` attribute to exec spans |
+| Option           | Type      | Default | Description                                     |
+| ---------------- | --------- | ------- | ----------------------------------------------- |
+| `recordExitCode` | `boolean` | `true`  | Add `process.exit_code` attribute to exec spans |
 
 ```ts
 const hooks = otelHooks(tracer, { recordExitCode: false });

--- a/apps/docs/content/docs/patterns/run-management.mdx
+++ b/apps/docs/content/docs/patterns/run-management.mdx
@@ -21,15 +21,15 @@ Sessions are returned newest first.
 
 Each session has:
 
-| Field | Type | Description |
-|---|---|---|
-| `sandboxId` | `string` | OpenSandbox container ID |
-| `name` | `string` | User-provided name (or auto-generated) |
-| `status` | `SandboxStatus` | `"running"`, `"completed"`, `"failed"`, or `"cancelled"` |
-| `startedAt` | `number` | Unix timestamp (ms) of `sandbox_created` event |
-| `completedAt` | `number?` | Unix timestamp (ms) of `sandbox_closed` event |
-| `execCount` | `number` | Number of completed execs |
-| `error` | `string?` | Error message if status is `failed` |
+| Field         | Type            | Description                                              |
+| ------------- | --------------- | -------------------------------------------------------- |
+| `sandboxId`   | `string`        | OpenSandbox container ID                                 |
+| `name`        | `string`        | User-provided name (or auto-generated)                   |
+| `status`      | `SandboxStatus` | `"running"`, `"completed"`, `"failed"`, or `"cancelled"` |
+| `startedAt`   | `number`        | Unix timestamp (ms) of `sandbox_created` event           |
+| `completedAt` | `number?`       | Unix timestamp (ms) of `sandbox_closed` event            |
+| `execCount`   | `number`        | Number of completed execs                                |
+| `error`       | `string?`       | Error message if status is `failed`                      |
 
 ## Filter by name
 
@@ -99,7 +99,8 @@ const completed = await client.sandboxes.list({ status: SandboxStatus.Completed 
 
 for (const session of completed) {
   const ageMs = Date.now() - session.startedAt;
-  if (ageMs > 7 * 24 * 60 * 60 * 1000) { // older than 7 days
+  if (ageMs > 7 * 24 * 60 * 60 * 1000) {
+    // older than 7 days
     await client.sandboxes.delete(session.name, session.sandboxId);
   }
 }

--- a/apps/docs/content/docs/patterns/timeouts-and-cancellation.mdx
+++ b/apps/docs/content/docs/patterns/timeouts-and-cancellation.mdx
@@ -22,7 +22,10 @@ This is a hard limit on the container — not on individual commands.
 Use the bash `timeout` command to limit how long a single command can run. The `timeout` utility exits with code `124` if the limit is reached:
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   // Times out after 1 second, exits with 124
   const { exitCode } = await sb.exec("timeout 1 sleep 30 || echo 'timed out'", { strict: false });
@@ -69,7 +72,10 @@ try {
 For commands that might run indefinitely, combine `timeout` with error handling:
 
 ```ts
-const sb = await client.sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } });
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+});
 try {
   const result = await sb.exec("timeout 60 ./run-tests.sh", { strict: false });
   if (result.exitCode === 124) {
@@ -92,11 +98,10 @@ import { workflow } from "@drej/workflow";
 
 await workflow(client)
   .sandbox({ image: "ubuntu:22.04", resources: { cpu: "500m", memory: "256Mi" } }, (sb) => {
-    sb.retry(
-      5,
-      (sb) => sb.exec("curl --retry 0 --max-time 10 https://example.com"),
-      { delayMs: 1000, backoff: "exponential" },
-    );
+    sb.retry(5, (sb) => sb.exec("curl --retry 0 --max-time 10 https://example.com"), {
+      delayMs: 1000,
+      backoff: "exponential",
+    });
   })
   .pipe(process.stdout);
 ```

--- a/apps/docs/content/docs/workflow/api-reference/builder.mdx
+++ b/apps/docs/content/docs/workflow/api-reference/builder.mdx
@@ -48,9 +48,8 @@ Run the same operation across multiple containers simultaneously. All configs re
 
 ```ts
 await workflow(client)
-  .parallel(
-    [{ image: "node:20" }, { image: "node:22" }, { image: "node:24" }],
-    (sb) => sb.exec("npm test"),
+  .parallel([{ image: "node:20" }, { image: "node:22" }, { image: "node:24" }], (sb) =>
+    sb.exec("npm test"),
   )
   .pipe(process.stdout);
 ```
@@ -66,8 +65,18 @@ Run sandboxes one after another. Each step's callback receives the previous step
 ```ts
 await workflow(client)
   .sequence([
-    { image: "node:22", name: "build", resources: { cpu: "1", memory: "512Mi" }, run: (sb) => sb.exec("npm run build") },
-    { image: "ubuntu:22.04", name: "deploy", resources: { cpu: "500m", memory: "256Mi" }, run: (sb, prev) => sb.exec("./deploy.sh") },
+    {
+      image: "node:22",
+      name: "build",
+      resources: { cpu: "1", memory: "512Mi" },
+      run: (sb) => sb.exec("npm run build"),
+    },
+    {
+      image: "ubuntu:22.04",
+      name: "deploy",
+      resources: { cpu: "500m", memory: "256Mi" },
+      run: (sb, prev) => sb.exec("./deploy.sh"),
+    },
   ])
   .pipe(process.stdout);
 ```
@@ -90,8 +99,8 @@ Execute the workflow and return the combined result:
 
 ```ts
 interface WorkflowResult {
-  stdout: string;                    // concatenated stdout from all sandboxes
-  vars: Record<string, unknown>;     // values captured by readFile(path, as)
+  stdout: string; // concatenated stdout from all sandboxes
+  vars: Record<string, unknown>; // values captured by readFile(path, as)
 }
 ```
 
@@ -169,8 +178,8 @@ Queue a retry block. On failure, waits `delayMs` and retries up to `maxAttempts`
 
 ```ts
 interface RetryOptions {
-  delayMs?: number;                    // default: 1000
-  backoff?: "fixed" | "exponential";   // default: "fixed"
+  delayMs?: number; // default: 1000
+  backoff?: "fixed" | "exponential"; // default: "fixed"
 }
 ```
 

--- a/apps/docs/content/docs/workflow/building/control-flow.mdx
+++ b/apps/docs/content/docs/workflow/building/control-flow.mdx
@@ -10,17 +10,21 @@ Control flow primitives let you express branching and looping inside the `Sandbo
 Retry a block of operations up to `maxAttempts` times on failure.
 
 ```ts
-sb.retry(3, (sb) => {
-  sb.exec("curl -f https://api.example.com/health");
-}, { delayMs: 2000, backoff: "exponential" });
+sb.retry(
+  3,
+  (sb) => {
+    sb.exec("curl -f https://api.example.com/health");
+  },
+  { delayMs: 2000, backoff: "exponential" },
+);
 ```
 
 ### RetryOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `delayMs` | `number` | `1000` | Wait between attempts (ms) |
-| `backoff` | `"fixed" \| "exponential"` | `"fixed"` | Delay growth strategy |
+| Option    | Type                       | Default   | Description                |
+| --------- | -------------------------- | --------- | -------------------------- |
+| `delayMs` | `number`                   | `1000`    | Wait between attempts (ms) |
+| `backoff` | `"fixed" \| "exponential"` | `"fixed"` | Delay growth strategy      |
 
 With `backoff: "exponential"`, each retry multiplies `delayMs` by the attempt number: 1s, 2s, 4s, ...
 
@@ -42,8 +46,8 @@ sb.when(
 
 ```ts
 interface FlushContext {
-  stdout: string;          // accumulated stdout so far
-  exitCode: number;        // exit code of the last exec
+  stdout: string; // accumulated stdout so far
+  exitCode: number; // exit code of the last exec
   vars: Record<string, unknown>; // values captured by readFile(path, as)
 }
 ```
@@ -65,18 +69,14 @@ sb.forEach(packages, (sb, pkg) => {
 Run iterations in parallel with `concurrency`:
 
 ```ts
-sb.forEach(
-  packages,
-  (sb, pkg) => sb.exec(`npm install ${pkg}`),
-  { concurrency: 3 },
-);
+sb.forEach(packages, (sb, pkg) => sb.exec(`npm install ${pkg}`), { concurrency: 3 });
 ```
 
 ### ForEachOptions
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `concurrency` | `number` | `1` | Max parallel iterations |
+| Option        | Type     | Default | Description             |
+| ------------- | -------- | ------- | ----------------------- |
+| `concurrency` | `number` | `1`     | Max parallel iterations |
 
 ## Composing
 

--- a/apps/docs/content/docs/workflow/building/parallel-sequence.mdx
+++ b/apps/docs/content/docs/workflow/building/parallel-sequence.mdx
@@ -91,8 +91,8 @@ interface SequenceStep {
 
 ```ts
 await workflow(client)
-  .sandbox(opts, (sb) => sb.exec("npm ci"))        // setup
-  .parallel(matrix, (sb) => sb.exec("npm test"))   // test across versions
+  .sandbox(opts, (sb) => sb.exec("npm ci")) // setup
+  .parallel(matrix, (sb) => sb.exec("npm test")) // test across versions
   .pipe(process.stdout);
 ```
 

--- a/apps/docs/content/docs/workflow/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/workflow/getting-started/quickstart.mdx
@@ -28,13 +28,10 @@ await client.connect();
 
 ```ts
 await workflow(client)
-  .sandbox(
-    { image: "node:22", resources: { cpu: "500m", memory: "512Mi" } },
-    (sb) => {
-      sb.exec("node --version");
-      sb.exec("npm --version");
-    },
-  )
+  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "512Mi" } }, (sb) => {
+    sb.exec("node --version");
+    sb.exec("npm --version");
+  })
   .pipe(process.stdout);
 
 await client.close();
@@ -48,13 +45,10 @@ Use `.result()` instead of `.pipe()` to get the combined stdout and any captured
 
 ```ts
 const { stdout, vars } = await workflow(client)
-  .sandbox(
-    { image: "node:22", resources: { cpu: "500m", memory: "512Mi" } },
-    (sb) => {
-      sb.exec("node --version > /tmp/ver.txt");
-      sb.readFile("/tmp/ver.txt", "nodeVersion");
-    },
-  )
+  .sandbox({ image: "node:22", resources: { cpu: "500m", memory: "512Mi" } }, (sb) => {
+    sb.exec("node --version > /tmp/ver.txt");
+    sb.readFile("/tmp/ver.txt", "nodeVersion");
+  })
   .result();
 
 console.log(vars.nodeVersion); // "v22.x.x\n"

--- a/apps/docs/content/docs/workflow/getting-started/what-is-workflow.mdx
+++ b/apps/docs/content/docs/workflow/getting-started/what-is-workflow.mdx
@@ -18,14 +18,14 @@ await workflow(client)
 
 ## Core SDK vs Workflow Builder
 
-| | Core SDK (`drej`) | Workflow Builder (`@drej/workflow`) |
-|---|---|---|
-| Style | Imperative — hold objects, call methods | Declarative — describe ops, flush once |
-| Await | Per-operation | Once at the end |
-| Lifecycle | Manual `try/finally sb.close()` | Managed automatically |
-| Multi-sandbox | Multiple variables | `.parallel()`, `.sequence()` |
-| Streaming | `ExecHandle.pipe()` | `.pipe(writable)` on the workflow |
-| Values | `await sb.exec(...)` | `readFile(path, as)` → `vars` |
+|               | Core SDK (`drej`)                       | Workflow Builder (`@drej/workflow`)    |
+| ------------- | --------------------------------------- | -------------------------------------- |
+| Style         | Imperative — hold objects, call methods | Declarative — describe ops, flush once |
+| Await         | Per-operation                           | Once at the end                        |
+| Lifecycle     | Manual `try/finally sb.close()`         | Managed automatically                  |
+| Multi-sandbox | Multiple variables                      | `.parallel()`, `.sequence()`           |
+| Streaming     | `ExecHandle.pipe()`                     | `.pipe(writable)` on the workflow      |
+| Values        | `await sb.exec(...)`                    | `readFile(path, as)` → `vars`          |
 
 ## When to use the Workflow Builder
 

--- a/apps/docs/src/app/docs/core/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/core/[[...slug]]/page.tsx
@@ -25,9 +25,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
       <DocsTitle>{page.data.title}</DocsTitle>
-      {page.data.description && (
-        <DocsDescription>{page.data.description}</DocsDescription>
-      )}
+      {page.data.description && <DocsDescription>{page.data.description}</DocsDescription>}
       <DocsBody>
         <MDX components={{ ...defaultMdxComponents }} />
       </DocsBody>

--- a/apps/docs/src/app/docs/drejx/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/drejx/[[...slug]]/page.tsx
@@ -3,12 +3,7 @@ import { drejxSource } from "@/lib/source";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 
-const OVERVIEW_SLUGS = new Set([
-  "",
-  "getting-started",
-  "commands",
-  "registry",
-]);
+const OVERVIEW_SLUGS = new Set(["", "getting-started", "commands", "registry"]);
 
 export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
   const { slug } = await params;
@@ -22,9 +17,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
       <DocsTitle>{page.data.title}</DocsTitle>
-      {page.data.description && (
-        <DocsDescription>{page.data.description}</DocsDescription>
-      )}
+      {page.data.description && <DocsDescription>{page.data.description}</DocsDescription>}
       <DocsBody>
         <MDX components={{ ...defaultMdxComponents }} />
       </DocsBody>

--- a/apps/docs/src/app/docs/workflow/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/workflow/[[...slug]]/page.tsx
@@ -3,12 +3,7 @@ import { workflowSource } from "@/lib/source";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 
-const OVERVIEW_SLUGS = new Set([
-  "",
-  "getting-started",
-  "building",
-  "api-reference",
-]);
+const OVERVIEW_SLUGS = new Set(["", "getting-started", "building", "api-reference"]);
 
 export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
   const { slug } = await params;
@@ -22,9 +17,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
       <DocsTitle>{page.data.title}</DocsTitle>
-      {page.data.description && (
-        <DocsDescription>{page.data.description}</DocsDescription>
-      )}
+      {page.data.description && <DocsDescription>{page.data.description}</DocsDescription>}
       <DocsBody>
         <MDX components={{ ...defaultMdxComponents }} />
       </DocsBody>

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -14,22 +14,22 @@ html {
   --font-mono: var(--font-geist-mono);
 
   /* drej palette — fumadocs token overrides */
-  --color-fd-background:           #FFFFFF;
-  --color-fd-foreground:           #111318;
-  --color-fd-muted:                #EDF4F6;
-  --color-fd-muted-foreground:     #687680;
-  --color-fd-popover:              #FFFFFF;
-  --color-fd-popover-foreground:   #111318;
-  --color-fd-card:                 #F5FAFB;
-  --color-fd-card-foreground:      #111318;
-  --color-fd-border:               #DDE6E9;
-  --color-fd-primary:              #0C5164;
-  --color-fd-primary-foreground:   #FFFFFF;
-  --color-fd-secondary:            #EDF4F6;
+  --color-fd-background: #ffffff;
+  --color-fd-foreground: #111318;
+  --color-fd-muted: #edf4f6;
+  --color-fd-muted-foreground: #687680;
+  --color-fd-popover: #ffffff;
+  --color-fd-popover-foreground: #111318;
+  --color-fd-card: #f5fafb;
+  --color-fd-card-foreground: #111318;
+  --color-fd-border: #dde6e9;
+  --color-fd-primary: #0c5164;
+  --color-fd-primary-foreground: #ffffff;
+  --color-fd-secondary: #edf4f6;
   --color-fd-secondary-foreground: #111318;
-  --color-fd-accent:               #E0EDF0;
-  --color-fd-accent-foreground:    #111318;
-  --color-fd-ring:                 #0C5164;
+  --color-fd-accent: #e0edf0;
+  --color-fd-accent-foreground: #111318;
+  --color-fd-ring: #0c5164;
 }
 
 @layer base {

--- a/apps/docs/src/components/package-switcher.tsx
+++ b/apps/docs/src/components/package-switcher.tsx
@@ -21,8 +21,8 @@ export function PackageSwitcher() {
   const current: PackageValue = pathname.startsWith("/docs/workflow")
     ? "workflow"
     : pathname.startsWith("/docs/drejx")
-    ? "drejx"
-    : "core";
+      ? "drejx"
+      : "core";
   const selected = packages.find((p) => p.value === current)!;
 
   useEffect(() => {

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "drej",
       "devDependencies": {
         "@changesets/cli": "2.31.0",
+        "oxfmt": "^0.56.0",
+        "oxlint": "^1.71.0",
       },
     },
     "apps/docs": {
@@ -650,6 +652,82 @@
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
+
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.56.0", "", { "os": "android", "cpu": "arm64" }, "sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.56.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sftR/bEOr+t1gs+evwsHi/Xbq2FAPA2uU3VMr8n6ZU9PoK/IMSfnfu7+OEe/uy1+knhrFl4Wvy7Vkm3uo9mJ7g=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.56.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-z66SdjLqa3MUPKvTp3Mbb5nSjKSbnYxJGeB+Wx987s8T5hPcIRiBMfnJ6zcPgYtQn3x5xjvdzNVkXrSeYH6ZFg=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.56.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-t2tkrV1vtZyaItSQ71dTi2ZVKZEI39b/LqLT12V5KMfIeXK6N32TUC1jhOXKVQmhECq9j2ZXMQV3JeT1kh9Vmg=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.56.0", "", { "os": "linux", "cpu": "arm" }, "sha512-+gCy+Tp3RHeXQ9y/QrS76lXIpZkbziTyp6hIgjB2MssCwfMph3vG/GEfkhO34Rai1vhYIaUkvv8UT1BcDorJPw=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.56.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0kKkVvQ2I+FJ2sxQyUu1zJ0yWP5kcWse/yVFnGQSFCXMwSSkfEaUGu0dW774O7nyy3jrcBGap7OSc8dZmU/CdA=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.56.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-npkA2siMbyWRh+wEhi1aTAx4RirukGcGNt8V4Ch86pG+xU9aurqS1MZOnKYMu03ISwat3rB6zkQx51SsB9obNw=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.56.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.56.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.56.0", "", { "os": "linux", "cpu": "none" }, "sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.56.0", "", { "os": "linux", "cpu": "none" }, "sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.56.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.56.0", "", { "os": "linux", "cpu": "x64" }, "sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.56.0", "", { "os": "linux", "cpu": "x64" }, "sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.56.0", "", { "os": "none", "cpu": "arm64" }, "sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.56.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-6qLNXfXmtAs8jXDvYMkxk6Wec5SUJoew+ZX1uOZmqaR7ks0EJFbAohuOCELDyJMWyVlxotVG8Xf8m74Bfq0O2w=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.56.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UXEXuKphAe15bsob4AswNMArCw38XSmUIs3wk1s6e6MX9OWGW/IRWU95s1hZDiVg09STy1jHgyN2qkqbu1FT0w=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-HPyNDjky+NIOuaMvHZflR+kst3YWdUOH2JUQYkf99grqZ5mEBTQM6h9iGy501Z8Xt5xMScrwHOuVCOlqDrktRw=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.71.0", "", { "os": "android", "cpu": "arm" }, "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.71.0", "", { "os": "android", "cpu": "arm64" }, "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.71.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.71.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.71.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.71.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.71.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.71.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.71.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.71.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.71.0", "", { "os": "win32", "cpu": "x64" }, "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1881,6 +1959,10 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
+    "oxfmt": ["oxfmt@0.56.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.56.0", "@oxfmt/binding-android-arm64": "0.56.0", "@oxfmt/binding-darwin-arm64": "0.56.0", "@oxfmt/binding-darwin-x64": "0.56.0", "@oxfmt/binding-freebsd-x64": "0.56.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.56.0", "@oxfmt/binding-linux-arm-musleabihf": "0.56.0", "@oxfmt/binding-linux-arm64-gnu": "0.56.0", "@oxfmt/binding-linux-arm64-musl": "0.56.0", "@oxfmt/binding-linux-ppc64-gnu": "0.56.0", "@oxfmt/binding-linux-riscv64-gnu": "0.56.0", "@oxfmt/binding-linux-riscv64-musl": "0.56.0", "@oxfmt/binding-linux-s390x-gnu": "0.56.0", "@oxfmt/binding-linux-x64-gnu": "0.56.0", "@oxfmt/binding-linux-x64-musl": "0.56.0", "@oxfmt/binding-openharmony-arm64": "0.56.0", "@oxfmt/binding-win32-arm64-msvc": "0.56.0", "@oxfmt/binding-win32-ia32-msvc": "0.56.0", "@oxfmt/binding-win32-x64-msvc": "0.56.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw=="],
+
+    "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -2176,6 +2258,8 @@
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 

--- a/examples/cancellation/README.md
+++ b/examples/cancellation/README.md
@@ -17,10 +17,10 @@ bun start
 
 ## What it shows
 
-| Pattern | Description |
-|---------|-------------|
-| `try/finally` | Guarantees `sb.close()` runs even when an exec throws |
+| Pattern        | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `try/finally`  | Guarantees `sb.close()` runs even when an exec throws |
 | Bash `timeout` | Limits a command's wall-clock time at the shell level |
-| `CommandError` | Catching the error thrown by a non-zero exit code |
+| `CommandError` | Catching the error thrown by a non-zero exit code     |
 
 Three sandboxes run sequentially, each demonstrating one pattern.

--- a/examples/cancellation/index.ts
+++ b/examples/cancellation/index.ts
@@ -50,7 +50,7 @@ console.log("\n=== Pattern C: CommandError ===");
 const sbC = await client.sandbox({ image, resources, name: "cancellation-c" });
 try {
   await sbC.exec("echo 'step 1'").pipe(process.stdout);
-  await sbC.exec("exit 1");  // throws CommandError
+  await sbC.exec("exit 1"); // throws CommandError
 } catch (e) {
   if (e instanceof CommandError) {
     console.log(`caught CommandError: exit ${e.exitCode}`);
@@ -58,4 +58,3 @@ try {
 } finally {
   await sbC.close();
 }
-

--- a/examples/cancellation/package.json
+++ b/examples/cancellation/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-cancellation",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/capture/index.ts
+++ b/examples/capture/index.ts
@@ -20,9 +20,7 @@ const sb = await client.sandbox({
 console.log(`Sandbox ID: ${sb.sandboxId}`);
 
 try {
-  const { stdout: nodeVersion } = await sb.exec(
-    "node -e \"process.stdout.write(process.version)\"",
-  );
+  const { stdout: nodeVersion } = await sb.exec('node -e "process.stdout.write(process.version)"');
 
   await sb.exec(`echo "Running on Node ${nodeVersion.trim()}"`, { strict: false });
 
@@ -40,4 +38,3 @@ try {
 } finally {
   await sb.close();
 }
-

--- a/examples/capture/package.json
+++ b/examples/capture/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-capture",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/control-flow/README.md
+++ b/examples/control-flow/README.md
@@ -17,8 +17,8 @@ bun start
 
 ## What it shows
 
-| Primitive | Description |
-|-----------|-------------|
+| Primitive | Description                                                    |
+| --------- | -------------------------------------------------------------- |
 | `retry`   | Retries a flaky command up to 5 times with exponential backoff |
-| `when`    | Branches conditionally based on the previous exec's exit code |
-| `forEach` | Iterates over a list, running a command per item |
+| `when`    | Branches conditionally based on the previous exec's exit code  |
+| `forEach` | Iterates over a list, running a command per item               |

--- a/examples/control-flow/index.ts
+++ b/examples/control-flow/index.ts
@@ -36,8 +36,12 @@ await workflow(client)
       sb.exec("test -f /etc/hostname", { strict: false });
       sb.when(
         (ctx) => ctx.exitCode === 0,
-        (sb) => { sb.exec('echo "[when] /etc/hostname exists"'); },
-        (sb) => { sb.exec('echo "[when] /etc/hostname missing"'); },
+        (sb) => {
+          sb.exec('echo "[when] /etc/hostname exists"');
+        },
+        (sb) => {
+          sb.exec('echo "[when] /etc/hostname missing"');
+        },
       );
 
       // forEach — run a command for each item in a list

--- a/examples/control-flow/package.json
+++ b/examples/control-flow/package.json
@@ -1,13 +1,13 @@
 {
   "name": "drej-example-control-flow",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
+    "@drej/sqlite": "workspace:*",
     "@drej/workflow": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "drej": "workspace:*"
   }
 }

--- a/examples/environments/README.md
+++ b/examples/environments/README.md
@@ -19,11 +19,13 @@ bun start        # ~2–3s on subsequent runs (restores from snapshot)
 ## What it does
 
 **First run** — environment not yet cached:
+
 1. Installs Python 3 and pip into a `debian:bookworm-slim` container
 2. Installs `numpy` and `pandas` via pip
 3. Snapshots the container and saves the snapshot ID to the ledger
 
 **Subsequent runs** — environment cached:
+
 1. Finds the existing snapshot in the ledger
 2. Boots directly from the snapshot — no apt-get or pip install
 3. Runs `import numpy, pandas` to prove packages are already present

--- a/examples/environments/index.ts
+++ b/examples/environments/index.ts
@@ -31,7 +31,9 @@ const env = client.environment("python-data-science", {
 
 const existing = await env.info();
 if (existing) {
-  console.log(`Environment cached (built ${new Date(existing.builtAt).toISOString()}, snapshot ${existing.snapshotId})`);
+  console.log(
+    `Environment cached (built ${new Date(existing.builtAt).toISOString()}, snapshot ${existing.snapshotId})`,
+  );
 } else {
   console.log("No cached environment — will build on first sandbox() call.");
 }
@@ -42,10 +44,12 @@ const sb = await env.sandbox();
 console.log(`Ready in ${Date.now() - t0}ms  (sandbox ${sb.sandboxId})`);
 
 try {
-  console.log('\n$ python3 -c "import numpy, pandas; print(numpy.__version__, pandas.__version__)"');
-  await sb.exec(
-    'python3 -c "import numpy, pandas; print(numpy.__version__, pandas.__version__)"',
-  ).pipe(process.stdout);
+  console.log(
+    '\n$ python3 -c "import numpy, pandas; print(numpy.__version__, pandas.__version__)"',
+  );
+  await sb
+    .exec('python3 -c "import numpy, pandas; print(numpy.__version__, pandas.__version__)"')
+    .pipe(process.stdout);
 } finally {
   await sb.close();
 }

--- a/examples/environments/package.json
+++ b/examples/environments/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-environments",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/error-handling/README.md
+++ b/examples/error-handling/README.md
@@ -17,10 +17,10 @@ bun start
 
 ## What it shows
 
-| Pattern | Description |
-|---------|-------------|
-| Non-strict exec | `exec("...", { strict: false })` returns the result; you inspect `exitCode` yourself |
-| Strict exec (default) | Non-zero exit throws `CommandError` — catch it to handle the failure |
-| Error types | `CommandError`, `SandboxError`, `ExecConnectionError` — when each is thrown |
+| Pattern               | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| Non-strict exec       | `exec("...", { strict: false })` returns the result; you inspect `exitCode` yourself |
+| Strict exec (default) | Non-zero exit throws `CommandError` — catch it to handle the failure                 |
+| Error types           | `CommandError`, `SandboxError`, `ExecConnectionError` — when each is thrown          |
 
 Two sandboxes run sequentially, one per pattern.

--- a/examples/error-handling/index.ts
+++ b/examples/error-handling/index.ts
@@ -42,7 +42,7 @@ console.log("\n=== Pattern B: strict exec (default) — catch CommandError ===")
 
 try {
   await sbB.exec("echo 'about to fail'").pipe(process.stdout);
-  await sbB.exec("exit 42");  // throws CommandError (strict: true is the default)
+  await sbB.exec("exit 42"); // throws CommandError (strict: true is the default)
   await sbB.exec("echo 'this line never runs'");
 } catch (e) {
   if (e instanceof CommandError) {
@@ -57,4 +57,3 @@ try {
 } finally {
   await sbB.close();
 }
-

--- a/examples/error-handling/package.json
+++ b/examples/error-handling/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-error-handling",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/exec-code/README.md
+++ b/examples/exec-code/README.md
@@ -17,9 +17,9 @@ bun start
 
 ## What it shows
 
-| Mode | Description |
-|------|-------------|
+| Mode      | Description                                                         |
+| --------- | ------------------------------------------------------------------- |
 | Stateless | Each `execCode()` call runs in an isolated context; no shared state |
-| Stateful | Calls sharing the same `context` object see each other's variables |
+| Stateful  | Calls sharing the same `context` object see each other's variables  |
 
 Uses the `opensandbox/code-interpreter` image, which ships a Python interpreter accessible via the execd `/code` endpoint.

--- a/examples/exec-code/index.ts
+++ b/examples/exec-code/index.ts
@@ -32,42 +32,43 @@ try {
   const ctxA = await sb.createCodeContext(CodeLanguage.Python);
   const ctxB = await sb.createCodeContext(CodeLanguage.Python);
 
-  await sb.execCode(
-    [
-      "import sys, math",
-      'print(f"[isolated-a] Python {sys.version.split()[0]}")',
-      'print(f"[isolated-a] pi = {math.pi:.6f}")',
-    ].join("\n"),
-    { context: ctxA },
-  ).pipe(process.stdout);
+  await sb
+    .execCode(
+      [
+        "import sys, math",
+        'print(f"[isolated-a] Python {sys.version.split()[0]}")',
+        'print(f"[isolated-a] pi = {math.pi:.6f}")',
+      ].join("\n"),
+      { context: ctxA },
+    )
+    .pipe(process.stdout);
 
-  await sb.execCode(
-    [
-      "import sys",
-      'print(f"[isolated-b] Python {sys.version.split()[0]}")',
-    ].join("\n"),
-    { context: ctxB },
-  ).pipe(process.stdout);
+  await sb
+    .execCode(["import sys", 'print(f"[isolated-b] Python {sys.version.split()[0]}")'].join("\n"), {
+      context: ctxB,
+    })
+    .pipe(process.stdout);
 
   // Stateful — variables persist across calls sharing the same context
   const ctx = await sb.createCodeContext(CodeLanguage.Python);
 
-  await sb.execCode(
-    [
-      "data = [2**i for i in range(8)]",
-      'print(f"[stateful 1] data = {data}")',
-    ].join("\n"),
-    { context: ctx },
-  ).pipe(process.stdout);
+  await sb
+    .execCode(
+      ["data = [2**i for i in range(8)]", 'print(f"[stateful 1] data = {data}")'].join("\n"),
+      { context: ctx },
+    )
+    .pipe(process.stdout);
 
-  await sb.execCode(
-    [
-      "total = sum(data)",
-      'print(f"[stateful 2] sum = {total}")',
-      'print(f"[stateful 2] max = {max(data)}")',
-    ].join("\n"),
-    { context: ctx },
-  ).pipe(process.stdout);
+  await sb
+    .execCode(
+      [
+        "total = sum(data)",
+        'print(f"[stateful 2] sum = {total}")',
+        'print(f"[stateful 2] max = {max(data)}")',
+      ].join("\n"),
+      { context: ctx },
+    )
+    .pipe(process.stdout);
 } finally {
   await sb.close();
 }

--- a/examples/exec-code/package.json
+++ b/examples/exec-code/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-exec-code",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/file-ops/README.md
+++ b/examples/file-ops/README.md
@@ -17,15 +17,15 @@ bun start
 
 ## What it covers
 
-| Method | Description |
-|--------|-------------|
-| `writeFile` / `readFile` | Write and read UTF-8 files |
-| `moveFile` / `deleteFile` | Move or remove a file |
-| `createDirectory` / `deleteDirectory` | Create or remove directories |
-| `listDirectory` | List directory contents |
-| `searchFiles` | Find files matching a glob pattern |
-| `getFileInfo` | Stat a file (size, type, mode, timestamps) |
-| `replaceInFiles` | In-place string substitution across one or more files |
-| `transfer` | Copy a file from one sandbox to another |
+| Method                                | Description                                           |
+| ------------------------------------- | ----------------------------------------------------- |
+| `writeFile` / `readFile`              | Write and read UTF-8 files                            |
+| `moveFile` / `deleteFile`             | Move or remove a file                                 |
+| `createDirectory` / `deleteDirectory` | Create or remove directories                          |
+| `listDirectory`                       | List directory contents                               |
+| `searchFiles`                         | Find files matching a glob pattern                    |
+| `getFileInfo`                         | Stat a file (size, type, mode, timestamps)            |
+| `replaceInFiles`                      | In-place string substitution across one or more files |
+| `transfer`                            | Copy a file from one sandbox to another               |
 
 Two sandboxes are used to demonstrate `transfer()`.

--- a/examples/file-ops/index.ts
+++ b/examples/file-ops/index.ts
@@ -29,7 +29,10 @@ try {
   // Write files
   await sb.writeFile("/workspace/src/index.ts", 'export const VERSION = "0.0.0";\n');
   await sb.writeFile("/workspace/src/util.ts", 'export const helper = () => "ok";\n');
-  await sb.writeFile("/workspace/src/config.json", JSON.stringify({ host: "localhost", port: 3000 }, null, 2));
+  await sb.writeFile(
+    "/workspace/src/config.json",
+    JSON.stringify({ host: "localhost", port: 3000 }, null, 2),
+  );
 
   // File metadata
   const info = await sb.getFileInfo("/workspace/src/index.ts");
@@ -56,7 +59,10 @@ try {
 
   // List directory
   const distEntries = await sb.listDirectory("/workspace/dist");
-  console.log("Dist entries:", distEntries.map((e: { path: string }) => e.path));
+  console.log(
+    "Dist entries:",
+    distEntries.map((e: { path: string }) => e.path),
+  );
 
   // Transfer a file to a second sandbox
   const sb2 = await client.sandbox({
@@ -76,7 +82,10 @@ try {
   await sb.deleteFile("/workspace/src/util.ts");
   await sb.deleteDirectory("/workspace/src");
   const remaining = await sb.listDirectory("/workspace");
-  console.log("Remaining:", remaining.map((e: { path: string }) => e.path));
+  console.log(
+    "Remaining:",
+    remaining.map((e: { path: string }) => e.path),
+  );
 } finally {
   await sb.close();
 }

--- a/examples/file-ops/package.json
+++ b/examples/file-ops/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-file-ops",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/hello-world/index.ts
+++ b/examples/hello-world/index.ts
@@ -21,4 +21,3 @@ try {
 } finally {
   await sb.close();
 }
-

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-hello-world",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/ports/package.json
+++ b/examples/ports/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-ports",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/read-file/index.ts
+++ b/examples/read-file/index.ts
@@ -33,4 +33,3 @@ try {
 } finally {
   await sb.close();
 }
-

--- a/examples/read-file/package.json
+++ b/examples/read-file/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-read-file",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/run-bash-script/index.ts
+++ b/examples/run-bash-script/index.ts
@@ -41,4 +41,3 @@ try {
 } finally {
   await sb.close();
 }
-

--- a/examples/run-bash-script/package.json
+++ b/examples/run-bash-script/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-run-bash-script",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/sandbox-fork/index.ts
+++ b/examples/sandbox-fork/index.ts
@@ -49,10 +49,7 @@ try {
 
   console.log("\n=== Forking into two tracks ===\n");
 
-  [forkA, forkB] = await Promise.all([
-    sb.fork("track-a"),
-    sb.fork("track-b"),
-  ]);
+  [forkA, forkB] = await Promise.all([sb.fork("track-a"), sb.fork("track-b")]);
 
   console.log(`fork-a id: ${forkA.sandboxId}`);
   console.log(`fork-b id: ${forkB.sandboxId}`);
@@ -62,12 +59,12 @@ try {
   console.log("\n=== Running in parallel ===\n");
 
   await Promise.all([
-    forkA.writeFile("/tmp/run.py", scriptA).then(() =>
-      forkA!.exec("python3 /tmp/run.py").pipe(process.stdout)
-    ),
-    forkB.writeFile("/tmp/run.py", scriptB).then(() =>
-      forkB!.exec("python3 /tmp/run.py").pipe(process.stdout)
-    ),
+    forkA
+      .writeFile("/tmp/run.py", scriptA)
+      .then(() => forkA!.exec("python3 /tmp/run.py").pipe(process.stdout)),
+    forkB
+      .writeFile("/tmp/run.py", scriptB)
+      .then(() => forkB!.exec("python3 /tmp/run.py").pipe(process.stdout)),
   ]);
 
   // ── Checkpoints are recorded in the original sandbox's ledger ─────────────
@@ -78,9 +75,5 @@ try {
     console.log(`  ${cp.tag} → ${cp.snapshotId}`);
   }
 } finally {
-  await Promise.all([
-    forkA?.close(),
-    forkB?.close(),
-    sb.close(),
-  ]);
+  await Promise.all([forkA?.close(), forkB?.close(), sb.close()]);
 }

--- a/examples/sandbox-fork/package.json
+++ b/examples/sandbox-fork/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-sandbox-fork",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/examples/snapshot-replay/README.md
+++ b/examples/snapshot-replay/README.md
@@ -18,12 +18,14 @@ bun start
 ## What it does
 
 **Initial run**
+
 1. Creates a Python 3.11 sandbox
 2. Installs `requests` via pip
 3. Captures a checkpoint (`after-install`)
 4. Runs a script and closes the sandbox
 
 **Resumed run**
+
 1. Calls `client.resume(sandboxId)` — boots from the snapshot
 2. The `pip install` call returns cached output instantly (never re-runs)
 3. Runs an updated script on the restored container

--- a/examples/snapshot-replay/index.ts
+++ b/examples/snapshot-replay/index.ts
@@ -72,4 +72,3 @@ try {
 } finally {
   await sbResume.close();
 }
-

--- a/examples/snapshot-replay/package.json
+++ b/examples/snapshot-replay/package.json
@@ -1,12 +1,12 @@
 {
   "name": "drej-example-snapshot-replay",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "start": "bun index.ts"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,15 @@
     "build": "bun run --cwd packages/opensandbox build && bun run --cwd packages/core build && bun run --cwd packages/sdks/typescript build && bun run --cwd packages/workflow build && bun run --cwd packages/adapters/sqlite build && bun run --cwd packages/adapters/postgres build && bun run --cwd packages/adapters/otel build && bun run --cwd packages/adapters/flue build",
     "typecheck": "bunx tsc --noEmit --strict --project packages/opensandbox/tsconfig.json && bunx tsc --noEmit --strict --project packages/core/tsconfig.json && bunx tsc --noEmit --strict --project packages/sdks/typescript/tsconfig.json && bunx tsc --noEmit --strict --project packages/workflow/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/postgres/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/sqlite/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/otel/tsconfig.json && bunx tsc --noEmit --strict --project packages/adapters/flue/tsconfig.json",
     "test": "bun run --cwd packages/core test && bun run --cwd packages/sdks/typescript test && bun run --cwd packages/workflow test && bun run --cwd packages/adapters/sqlite test && bun run --cwd packages/adapters/flue test",
-    "test:integration": "bun run --cwd tests/integration test"
+    "test:integration": "bun run --cwd tests/integration test",
+    "lint": "oxlint packages examples",
+    "lint:fix": "oxlint --fix packages examples",
+    "format": "oxfmt packages examples apps",
+    "format:check": "oxfmt --check packages examples apps"
   },
   "devDependencies": {
-    "@changesets/cli": "2.31.0"
+    "@changesets/cli": "2.31.0",
+    "oxfmt": "^0.56.0",
+    "oxlint": "^1.71.0"
   }
 }

--- a/packages/adapters/flue/package.json
+++ b/packages/adapters/flue/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/flue",
   "version": "0.1.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,9 +13,6 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },
@@ -20,15 +20,15 @@
     "build": "tsdown",
     "test": "bun test"
   },
-  "peerDependencies": {
-    "@flue/runtime": ">=1.0.0-beta",
-    "drej": ">=0.4.0"
-  },
   "devDependencies": {
     "@flue/runtime": "1.0.0-beta.3",
     "bun-types": "1.3.14",
     "drej": "workspace:*",
     "tsdown": "0.22.3",
     "typescript": "6.0.3"
+  },
+  "peerDependencies": {
+    "@flue/runtime": ">=1.0.0-beta",
+    "drej": ">=0.4.0"
   }
 }

--- a/packages/adapters/flue/src/index.ts
+++ b/packages/adapters/flue/src/index.ts
@@ -75,10 +75,9 @@ class DrejSandboxApi implements SandboxApi {
   }
 
   async stat(path: string): Promise<FileStat> {
-    const { stdout, exitCode } = await this.sb.exec(
-      `stat -c '%F|%s|%Y' ${esc(path)}`,
-      { strict: false },
-    );
+    const { stdout, exitCode } = await this.sb.exec(`stat -c '%F|%s|%Y' ${esc(path)}`, {
+      strict: false,
+    });
     if (exitCode !== 0) throw new Error(`stat: cannot stat '${path}': No such file or directory`);
     const [typeStr, sizeStr, mtimeStr] = stdout.trim().split("|");
     return {

--- a/packages/adapters/flue/test/adapter.test.ts
+++ b/packages/adapters/flue/test/adapter.test.ts
@@ -17,7 +17,16 @@ import { drej } from "../src/index.ts";
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 type ExecResult = { stdout: string; stderr: string; exitCode: number };
-type FileInfoStub = { path: string; type: string; size: number; mode: number; modified_at: string; created_at: string; owner: string; group: string };
+type FileInfoStub = {
+  path: string;
+  type: string;
+  size: number;
+  mode: number;
+  modified_at: string;
+  created_at: string;
+  owner: string;
+  group: string;
+};
 
 type SandboxStub = {
   exec: (cmd: string, opts?: any) => PromiseLike<ExecResult>;
@@ -28,7 +37,8 @@ type SandboxStub = {
 
 function makeStub(overrides: Partial<SandboxStub> = {}): Sandbox {
   return {
-    exec: overrides.exec ?? ((_cmd, _opts) => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 })),
+    exec:
+      overrides.exec ?? ((_cmd, _opts) => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 })),
     readFile: overrides.readFile ?? ((_path) => Promise.resolve("")),
     writeFile: overrides.writeFile ?? ((_path, _content) => Promise.resolve()),
     listDirectory: overrides.listDirectory ?? ((_path, _opts) => Promise.resolve([])),
@@ -67,7 +77,9 @@ describe("exec", () => {
   });
 
   it("returns non-zero exitCode without throwing", async () => {
-    const sb = makeStub({ exec: () => Promise.resolve({ stdout: "", stderr: "err", exitCode: 1 }) });
+    const sb = makeStub({
+      exec: () => Promise.resolve({ stdout: "", stderr: "err", exitCode: 1 }),
+    });
     const api = await getApi(sb);
     const { exitCode } = await api.exec("false");
     expect(exitCode).toBe(1);
@@ -83,7 +95,9 @@ describe("exec", () => {
     let rejectMsg = "";
     const sb = makeStub({ exec: () => new Promise(() => {}) });
     const api = await getApi(sb);
-    await api.exec("x", { timeoutMs: 1.3 }).catch((e: Error) => { rejectMsg = e.message; });
+    await api.exec("x", { timeoutMs: 1.3 }).catch((e: Error) => {
+      rejectMsg = e.message;
+    });
     expect(rejectMsg).toBe("exec timed out after 2ms"); // ceil(1.3) = 2
   });
 
@@ -142,7 +156,12 @@ describe("readFileBuffer", () => {
 describe("writeFile", () => {
   it("delegates string content to sb.writeFile", async () => {
     let wrote: any;
-    const sb = makeStub({ writeFile: (p, c) => { wrote = { p, c }; return Promise.resolve(); } });
+    const sb = makeStub({
+      writeFile: (p, c) => {
+        wrote = { p, c };
+        return Promise.resolve();
+      },
+    });
     const api = await getApi(sb);
     await api.writeFile("/out.txt", "hello");
     expect(wrote).toEqual({ p: "/out.txt", c: "hello" });
@@ -151,7 +170,10 @@ describe("writeFile", () => {
   it("base64-encodes Uint8Array content and pipes through base64 -d", async () => {
     let execCmd = "";
     const sb = makeStub({
-      exec: (cmd) => { execCmd = cmd; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); },
+      exec: (cmd) => {
+        execCmd = cmd;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
     });
     const api = await getApi(sb);
     const data = new Uint8Array([0x01, 0x02, 0x03]);
@@ -215,8 +237,26 @@ describe("readdir", () => {
     const sb = makeStub({
       listDirectory: () =>
         Promise.resolve([
-          { path: "/base/a", type: "file", size: 0, mode: 0o644, modified_at: "", created_at: "", owner: "", group: "" },
-          { path: "/base/b", type: "directory", size: 0, mode: 0o755, modified_at: "", created_at: "", owner: "", group: "" },
+          {
+            path: "/base/a",
+            type: "file",
+            size: 0,
+            mode: 0o644,
+            modified_at: "",
+            created_at: "",
+            owner: "",
+            group: "",
+          },
+          {
+            path: "/base/b",
+            type: "directory",
+            size: 0,
+            mode: 0o755,
+            modified_at: "",
+            created_at: "",
+            owner: "",
+            group: "",
+          },
         ]),
     });
     const api = await getApi(sb);
@@ -227,8 +267,26 @@ describe("readdir", () => {
     const sb = makeStub({
       listDirectory: () =>
         Promise.resolve([
-          { path: "/d/child", type: "file", size: 0, mode: 0, modified_at: "", created_at: "", owner: "", group: "" },
-          { path: "/d/child/grandchild", type: "file", size: 0, mode: 0, modified_at: "", created_at: "", owner: "", group: "" },
+          {
+            path: "/d/child",
+            type: "file",
+            size: 0,
+            mode: 0,
+            modified_at: "",
+            created_at: "",
+            owner: "",
+            group: "",
+          },
+          {
+            path: "/d/child/grandchild",
+            type: "file",
+            size: 0,
+            mode: 0,
+            modified_at: "",
+            created_at: "",
+            owner: "",
+            group: "",
+          },
         ]),
     });
     const api = await getApi(sb);
@@ -239,7 +297,16 @@ describe("readdir", () => {
     const sb = makeStub({
       listDirectory: () =>
         Promise.resolve([
-          { path: "/base/x", type: "file", size: 0, mode: 0, modified_at: "", created_at: "", owner: "", group: "" },
+          {
+            path: "/base/x",
+            type: "file",
+            size: 0,
+            mode: 0,
+            modified_at: "",
+            created_at: "",
+            owner: "",
+            group: "",
+          },
         ]),
     });
     const api = await getApi(sb);
@@ -268,7 +335,12 @@ describe("exists", () => {
 describe("mkdir", () => {
   it("calls mkdir without -p by default", async () => {
     let cmd = "";
-    const sb = makeStub({ exec: (c) => { cmd = c; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } });
+    const sb = makeStub({
+      exec: (c) => {
+        cmd = c;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    });
     const api = await getApi(sb);
     await api.mkdir("/new/dir");
     expect(cmd).toMatch(/^mkdir '/);
@@ -277,7 +349,12 @@ describe("mkdir", () => {
 
   it("passes -p when recursive is true", async () => {
     let cmd = "";
-    const sb = makeStub({ exec: (c) => { cmd = c; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } });
+    const sb = makeStub({
+      exec: (c) => {
+        cmd = c;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    });
     const api = await getApi(sb);
     await api.mkdir("/deep/path", { recursive: true });
     expect(cmd).toContain("mkdir -p");
@@ -289,7 +366,12 @@ describe("mkdir", () => {
 describe("rm", () => {
   it("calls rm with no flags by default", async () => {
     let cmd = "";
-    const sb = makeStub({ exec: (c) => { cmd = c; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } });
+    const sb = makeStub({
+      exec: (c) => {
+        cmd = c;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    });
     const api = await getApi(sb);
     await api.rm("/tmp/file");
     expect(cmd).toMatch(/^rm '/);
@@ -297,7 +379,12 @@ describe("rm", () => {
 
   it("passes -r for recursive", async () => {
     let cmd = "";
-    const sb = makeStub({ exec: (c) => { cmd = c; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } });
+    const sb = makeStub({
+      exec: (c) => {
+        cmd = c;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    });
     const api = await getApi(sb);
     await api.rm("/dir", { recursive: true });
     expect(cmd).toContain("-r");
@@ -306,7 +393,12 @@ describe("rm", () => {
 
   it("passes -f for force", async () => {
     let cmd = "";
-    const sb = makeStub({ exec: (c) => { cmd = c; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } });
+    const sb = makeStub({
+      exec: (c) => {
+        cmd = c;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    });
     const api = await getApi(sb);
     await api.rm("/file", { force: true });
     expect(cmd).toContain("-f");
@@ -315,7 +407,12 @@ describe("rm", () => {
 
   it("passes both -r and -f", async () => {
     let cmd = "";
-    const sb = makeStub({ exec: (c) => { cmd = c; return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } });
+    const sb = makeStub({
+      exec: (c) => {
+        cmd = c;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    });
     const api = await getApi(sb);
     await api.rm("/dir", { recursive: true, force: true });
     expect(cmd).toContain("-r");
@@ -329,14 +426,14 @@ describe("drej factory", () => {
   it("passes cwd '/' by default to createSandboxSessionEnv", async () => {
     const sb = makeStub();
     const factory = drej(sb);
-    const env = await factory.createSessionEnv({ id: "x" }) as any;
+    const env = (await factory.createSessionEnv({ id: "x" })) as any;
     expect(env._cwd).toBe("/");
   });
 
   it("forwards custom cwd option", async () => {
     const sb = makeStub();
     const factory = drej(sb, { cwd: "/workspace" });
-    const env = await factory.createSessionEnv({ id: "x" }) as any;
+    const env = (await factory.createSessionEnv({ id: "x" })) as any;
     expect(env._cwd).toBe("/workspace");
   });
 });

--- a/packages/adapters/otel/package.json
+++ b/packages/adapters/otel/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/otel",
   "version": "0.1.1",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,17 +13,11 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "build": "tsdown"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@drej/core": "workspace:*"
@@ -30,5 +27,8 @@
     "bun-types": "1.3.14",
     "tsdown": "0.22.3",
     "typescript": "6.0.3"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0"
   }
 }

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/postgres",
   "version": "0.2.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,9 +13,6 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },
@@ -20,8 +20,8 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "postgres": "3.4.9",
-    "@drej/core": "workspace:*"
+    "@drej/core": "workspace:*",
+    "postgres": "3.4.9"
   },
   "devDependencies": {
     "bun-types": "1.3.14",

--- a/packages/adapters/postgres/src/adapter.ts
+++ b/packages/adapters/postgres/src/adapter.ts
@@ -1,5 +1,13 @@
 import postgres from "postgres";
-import type { IStorageAdapter, LedgerEntry, LedgerEvent, SandboxDetails, ListSandboxOptions, EnvironmentRecord, CheckpointInfo } from "@drej/core";
+import type {
+  IStorageAdapter,
+  LedgerEntry,
+  LedgerEvent,
+  SandboxDetails,
+  ListSandboxOptions,
+  EnvironmentRecord,
+  CheckpointInfo,
+} from "@drej/core";
 import { SandboxStatus } from "@drej/core";
 import { MIGRATION_SQL } from "./migrations";
 
@@ -159,7 +167,9 @@ export class PostgresAdapter implements IStorageAdapter {
   }
 
   async getEnvironment(name: string): Promise<EnvironmentRecord | null> {
-    const rows = await this.sql<{ name: string; snapshot_id: string; image: string; built_at: string }[]>`
+    const rows = await this.sql<
+      { name: string; snapshot_id: string; image: string; built_at: string }[]
+    >`
       SELECT name, snapshot_id, image, built_at FROM drej_environments WHERE name = ${name}
     `;
     if (!rows.length) return null;
@@ -183,9 +193,16 @@ export class PostgresAdapter implements IStorageAdapter {
   }
 
   async listEnvironments(): Promise<EnvironmentRecord[]> {
-    const rows = await this.sql<{ name: string; snapshot_id: string; image: string; built_at: string }[]>`
+    const rows = await this.sql<
+      { name: string; snapshot_id: string; image: string; built_at: string }[]
+    >`
       SELECT name, snapshot_id, image, built_at FROM drej_environments ORDER BY built_at DESC
     `;
-    return rows.map((r) => ({ name: r.name, snapshotId: r.snapshot_id, image: r.image, builtAt: Number(r.built_at) }));
+    return rows.map((r) => ({
+      name: r.name,
+      snapshotId: r.snapshot_id,
+      image: r.image,
+      builtAt: Number(r.built_at),
+    }));
   }
 }

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/sqlite",
   "version": "0.2.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,9 +13,6 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/adapters/sqlite/src/adapter.ts
+++ b/packages/adapters/sqlite/src/adapter.ts
@@ -1,5 +1,13 @@
 import { Database } from "bun:sqlite";
-import type { IStorageAdapter, LedgerEntry, LedgerEvent, SandboxDetails, ListSandboxOptions, EnvironmentRecord, CheckpointInfo } from "@drej/core";
+import type {
+  IStorageAdapter,
+  LedgerEntry,
+  LedgerEvent,
+  SandboxDetails,
+  ListSandboxOptions,
+  EnvironmentRecord,
+  CheckpointInfo,
+} from "@drej/core";
 import { SandboxStatus } from "@drej/core";
 import { MIGRATION_SQL } from "./migrations";
 
@@ -139,9 +147,7 @@ export class SQLiteAdapter implements IStorageAdapter {
   }
 
   async listSandboxDetails(name: string, opts?: ListSandboxOptions): Promise<SandboxDetails[]> {
-    const rows = this.db
-      .prepare<AggRow, [string]>(AGG_SQL("WHERE name = ?"))
-      .all(name);
+    const rows = this.db.prepare<AggRow, [string]>(AGG_SQL("WHERE name = ?")).all(name);
     return applyOpts(rows.map(aggRowToDetails), opts);
   }
 
@@ -173,18 +179,23 @@ export class SQLiteAdapter implements IStorageAdapter {
       )
       .all(name, sandboxId);
     return rows.map((r) => {
-      const p = r.payload !== null
-        ? (JSON.parse(r.payload) as { snapshotId: string; name?: string })
-        : { snapshotId: "" };
+      const p =
+        r.payload !== null
+          ? (JSON.parse(r.payload) as { snapshotId: string; name?: string })
+          : { snapshotId: "" };
       return { snapshotId: p.snapshotId, tag: p.name, createdAt: r.ts };
     });
   }
 
   async getEnvironment(name: string): Promise<EnvironmentRecord | null> {
     const row = this.db
-      .prepare<EnvRow, [string]>("SELECT name, snapshot_id, image, built_at FROM drej_environments WHERE name = ?")
+      .prepare<EnvRow, [string]>(
+        "SELECT name, snapshot_id, image, built_at FROM drej_environments WHERE name = ?",
+      )
       .get(name);
-    return row ? { name: row.name, snapshotId: row.snapshot_id, image: row.image, builtAt: row.built_at } : null;
+    return row
+      ? { name: row.name, snapshotId: row.snapshot_id, image: row.image, builtAt: row.built_at }
+      : null;
   }
 
   async saveEnvironment(record: EnvironmentRecord): Promise<void> {
@@ -202,8 +213,15 @@ export class SQLiteAdapter implements IStorageAdapter {
 
   async listEnvironments(): Promise<EnvironmentRecord[]> {
     const rows = this.db
-      .prepare<EnvRow, []>("SELECT name, snapshot_id, image, built_at FROM drej_environments ORDER BY built_at DESC")
+      .prepare<EnvRow, []>(
+        "SELECT name, snapshot_id, image, built_at FROM drej_environments ORDER BY built_at DESC",
+      )
       .all();
-    return rows.map((r) => ({ name: r.name, snapshotId: r.snapshot_id, image: r.image, builtAt: r.built_at }));
+    return rows.map((r) => ({
+      name: r.name,
+      snapshotId: r.snapshot_id,
+      image: r.image,
+      builtAt: r.built_at,
+    }));
   }
 }

--- a/packages/adapters/sqlite/test/adapter.test.ts
+++ b/packages/adapters/sqlite/test/adapter.test.ts
@@ -84,8 +84,20 @@ describe("SQLiteAdapter", () => {
     });
 
     it("returns the most recent checkpoint_created event", async () => {
-      await db.append(entry({ ts: 1000, event: LedgerEvent.CheckpointCreated, payload: { snapshotId: "snap-1" } }));
-      await db.append(entry({ ts: 2000, event: LedgerEvent.CheckpointCreated, payload: { snapshotId: "snap-2" } }));
+      await db.append(
+        entry({
+          ts: 1000,
+          event: LedgerEvent.CheckpointCreated,
+          payload: { snapshotId: "snap-1" },
+        }),
+      );
+      await db.append(
+        entry({
+          ts: 2000,
+          event: LedgerEvent.CheckpointCreated,
+          payload: { snapshotId: "snap-2" },
+        }),
+      );
       const cp = await db.lastCheckpoint("test-session", "session-1");
       expect((cp!.payload as any).snapshotId).toBe("snap-2");
     });
@@ -98,14 +110,24 @@ describe("SQLiteAdapter", () => {
 
   // ── session details ─────────────────────────────────────────────────────────
 
-  async function seedSession(name: string, sandboxId: string, opts: { close?: boolean; execCount?: number } = {}) {
+  async function seedSession(
+    name: string,
+    sandboxId: string,
+    opts: { close?: boolean; execCount?: number } = {},
+  ) {
     const ts = Date.now();
-    await db.append(entry({ name, sandboxId, ts, stepIndex: -1, event: LedgerEvent.SandboxCreated }));
+    await db.append(
+      entry({ name, sandboxId, ts, stepIndex: -1, event: LedgerEvent.SandboxCreated }),
+    );
     for (let i = 0; i < (opts.execCount ?? 1); i++) {
-      await db.append(entry({ name, sandboxId, ts: ts + i + 1, stepIndex: i, event: LedgerEvent.ExecComplete }));
+      await db.append(
+        entry({ name, sandboxId, ts: ts + i + 1, stepIndex: i, event: LedgerEvent.ExecComplete }),
+      );
     }
     if (opts.close) {
-      await db.append(entry({ name, sandboxId, ts: ts + 100, stepIndex: -1, event: LedgerEvent.SandboxClosed }));
+      await db.append(
+        entry({ name, sandboxId, ts: ts + 100, stepIndex: -1, event: LedgerEvent.SandboxClosed }),
+      );
     }
   }
 
@@ -201,21 +223,41 @@ describe("SQLiteAdapter", () => {
     });
 
     it("saveEnvironment + getEnvironment round-trips all fields", async () => {
-      await db.saveEnvironment({ name: "py", snapshotId: "snap-1", image: "debian:slim", builtAt: 1000 });
+      await db.saveEnvironment({
+        name: "py",
+        snapshotId: "snap-1",
+        image: "debian:slim",
+        builtAt: 1000,
+      });
       const r = await db.getEnvironment("py");
       expect(r).toEqual({ name: "py", snapshotId: "snap-1", image: "debian:slim", builtAt: 1000 });
     });
 
     it("saveEnvironment upserts: second write updates the record", async () => {
-      await db.saveEnvironment({ name: "py", snapshotId: "snap-1", image: "debian:slim", builtAt: 1000 });
-      await db.saveEnvironment({ name: "py", snapshotId: "snap-2", image: "debian:slim", builtAt: 2000 });
+      await db.saveEnvironment({
+        name: "py",
+        snapshotId: "snap-1",
+        image: "debian:slim",
+        builtAt: 1000,
+      });
+      await db.saveEnvironment({
+        name: "py",
+        snapshotId: "snap-2",
+        image: "debian:slim",
+        builtAt: 2000,
+      });
       const r = await db.getEnvironment("py");
       expect(r?.snapshotId).toBe("snap-2");
       expect(r?.builtAt).toBe(2000);
     });
 
     it("deleteEnvironment removes the record", async () => {
-      await db.saveEnvironment({ name: "py", snapshotId: "snap-1", image: "debian:slim", builtAt: 1000 });
+      await db.saveEnvironment({
+        name: "py",
+        snapshotId: "snap-1",
+        image: "debian:slim",
+        builtAt: 1000,
+      });
       await db.deleteEnvironment("py");
       expect(await db.getEnvironment("py")).toBeNull();
     });
@@ -225,8 +267,18 @@ describe("SQLiteAdapter", () => {
     });
 
     it("listEnvironments returns all records newest-first", async () => {
-      await db.saveEnvironment({ name: "py", snapshotId: "snap-1", image: "debian:slim", builtAt: 1000 });
-      await db.saveEnvironment({ name: "node", snapshotId: "snap-2", image: "node:22", builtAt: 2000 });
+      await db.saveEnvironment({
+        name: "py",
+        snapshotId: "snap-1",
+        image: "debian:slim",
+        builtAt: 1000,
+      });
+      await db.saveEnvironment({
+        name: "node",
+        snapshotId: "snap-2",
+        image: "node:22",
+        builtAt: 2000,
+      });
       const list = await db.listEnvironments();
       expect(list).toHaveLength(2);
       expect(list[0].name).toBe("node");
@@ -238,8 +290,18 @@ describe("SQLiteAdapter", () => {
     });
 
     it("deleteEnvironment does not affect other records", async () => {
-      await db.saveEnvironment({ name: "py", snapshotId: "snap-1", image: "debian:slim", builtAt: 1000 });
-      await db.saveEnvironment({ name: "node", snapshotId: "snap-2", image: "node:22", builtAt: 2000 });
+      await db.saveEnvironment({
+        name: "py",
+        snapshotId: "snap-1",
+        image: "debian:slim",
+        builtAt: 1000,
+      });
+      await db.saveEnvironment({
+        name: "node",
+        snapshotId: "snap-2",
+        image: "node:22",
+        builtAt: 2000,
+      });
       await db.deleteEnvironment("py");
       expect(await db.getEnvironment("node")).not.toBeNull();
     });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,18 +1,28 @@
 {
   "name": "drejx",
   "version": "0.1.0",
+  "bin": {
+    "drejx": "./dist/index.mjs"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
-  "bin": { "drejx": "./dist/index.mjs" },
-  "exports": { ".": { "import": "./dist/index.mjs" } },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsdown",
     "test": "bun test"
   },
   "dependencies": {
-    "drej": "workspace:*",
-    "@drej/sqlite": "workspace:*"
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
   },
   "devDependencies": {
     "bun-types": "1.3.14",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -4,7 +4,10 @@ import { readConfig } from "../config.js";
 import { readSandboxes, writeSandboxes } from "../sandboxes.js";
 import { validateRegistryItem, type RegistryItem } from "../schema.js";
 
-export async function add(url: string, opts: { name?: string; server?: string } = {}): Promise<void> {
+export async function add(
+  url: string,
+  opts: { name?: string; server?: string } = {},
+): Promise<void> {
   if (!url) throw new Error("Usage: drejx add <url>");
 
   const config = await readConfig();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,19 @@
 import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
-import { checkDocker, getContainerState, startContainer, runContainer, pollHealth } from "../docker.js";
-import { configPath, writeConfig, serverConfigDir, serverConfigPath, serverConfigContent } from "../config.js";
+import {
+  checkDocker,
+  getContainerState,
+  startContainer,
+  runContainer,
+  pollHealth,
+} from "../docker.js";
+import {
+  configPath,
+  writeConfig,
+  serverConfigDir,
+  serverConfigPath,
+  serverConfigContent,
+} from "../config.js";
 
 const CONTAINER_NAME = "drejx-opensandbox";
 const SERVER_URL = "http://localhost:8080";
@@ -26,12 +38,18 @@ export async function init(): Promise<void> {
     console.log("Starting OpenSandbox in Docker...");
     await runContainer([
       "-d",
-      "--name", CONTAINER_NAME,
-      "-p", "8080:8080",
-      "-v", "/var/run/docker.sock:/var/run/docker.sock",
-      "-v", `${serverConfigPath()}:/etc/opensandbox/config.toml:ro`,
-      "-e", "SANDBOX_CONFIG_PATH=/etc/opensandbox/config.toml",
-      "-e", "OPENSANDBOX_INSECURE_SERVER=YES",
+      "--name",
+      CONTAINER_NAME,
+      "-p",
+      "8080:8080",
+      "-v",
+      "/var/run/docker.sock:/var/run/docker.sock",
+      "-v",
+      `${serverConfigPath()}:/etc/opensandbox/config.toml:ro`,
+      "-e",
+      "SANDBOX_CONFIG_PATH=/etc/opensandbox/config.toml",
+      "-e",
+      "OPENSANDBOX_INSECURE_SERVER=YES",
       "opensandbox/server:latest",
     ]);
   }

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -16,9 +16,11 @@ export async function list(): Promise<void> {
   for (const e of entries) {
     const ageSec = Math.floor((now - new Date(e.createdAt).getTime()) / 1_000);
     const age =
-      ageSec < 60 ? `${ageSec}s` :
-      ageSec < 3_600 ? `${Math.floor(ageSec / 60)}m` :
-      `${Math.floor(ageSec / 3_600)}h`;
+      ageSec < 60
+        ? `${ageSec}s`
+        : ageSec < 3_600
+          ? `${Math.floor(ageSec / 60)}m`
+          : `${Math.floor(ageSec / 3_600)}h`;
     const row = [e.name, e.sandboxId.slice(0, 16), age, e.url];
     console.log(row.map((v, i) => (cols[i] ? v.padEnd(cols[i]) : v)).join("  "));
   }

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -6,7 +6,8 @@ export async function remove(name: string): Promise<void> {
 
   const [config, entries] = await Promise.all([readConfig(), readSandboxes()]);
   const idx = entries.findIndex((e) => e.name === name);
-  if (idx === -1) throw new Error(`No sandbox named '${name}'. Run 'drejx list' to see available sandboxes.`);
+  if (idx === -1)
+    throw new Error(`No sandbox named '${name}'. Run 'drejx list' to see available sandboxes.`);
 
   const entry = entries[idx]!;
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,7 +18,8 @@ export function configPath(): string {
 
 export async function readConfig(): Promise<DrejxConfig> {
   const file = Bun.file(configPath());
-  if (!(await file.exists())) throw new Error("No .drej/config.json found — run 'drejx init' first");
+  if (!(await file.exists()))
+    throw new Error("No .drej/config.json found — run 'drejx init' first");
   return file.json() as Promise<DrejxConfig>;
 }
 

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -18,7 +18,11 @@ async function spawn(cmd: string[]): Promise<{ ok: boolean; stdout: string; stde
 export async function checkDocker(): Promise<void> {
   const { ok, stderr } = await spawn(["docker", "info"]);
   if (!ok) {
-    if (stderr.includes("Cannot connect") || stderr.includes("daemon") || stderr.includes("socket")) {
+    if (
+      stderr.includes("Cannot connect") ||
+      stderr.includes("daemon") ||
+      stderr.includes("socket")
+    ) {
       throw new Error("Docker daemon is not running. Start Docker and try again.");
     }
     throw new Error("Docker is not available. Install Docker and try again.");
@@ -48,10 +52,12 @@ export async function pollHealth(url: string, timeoutMs = 60_000): Promise<void>
     try {
       const res = await fetch(url);
       if (res.ok) {
-        const body = await res.json() as { status?: string };
+        const body = (await res.json()) as { status?: string };
         if (body.status === "healthy") return;
       }
-    } catch { /* not ready yet */ }
+    } catch {
+      /* not ready yet */
+    }
     await new Promise<void>((r) => setTimeout(r, 1_000));
   }
   throw new Error(`OpenSandbox did not become healthy within ${timeoutMs / 1_000}s`);

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -17,11 +17,14 @@ export interface RegistryItem {
 export function validateRegistryItem(data: unknown): RegistryItem {
   if (!data || typeof data !== "object") throw new Error("Registry item must be an object");
   const item = data as Record<string, unknown>;
-  if (typeof item.name !== "string" || !item.name) throw new Error("Registry item must have a 'name' string");
-  if (item.image === undefined || item.image === null) throw new Error("Registry item must have an 'image'");
-  if (typeof item.image !== "string" && (typeof item.image !== "object"))
+  if (typeof item.name !== "string" || !item.name)
+    throw new Error("Registry item must have a 'name' string");
+  if (item.image === undefined || item.image === null)
+    throw new Error("Registry item must have an 'image'");
+  if (typeof item.image !== "string" && typeof item.image !== "object")
     throw new Error("'image' must be a string or { uri: string }");
-  if (!item.resources || typeof item.resources !== "object") throw new Error("Registry item must have 'resources'");
+  if (!item.resources || typeof item.resources !== "object")
+    throw new Error("Registry item must have 'resources'");
   const res = item.resources as Record<string, unknown>;
   if (typeof res.cpu !== "string") throw new Error("'resources.cpu' must be a string");
   if (typeof res.memory !== "string") throw new Error("'resources.memory' must be a string");

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -14,15 +14,15 @@ describe("serverConfigContent", () => {
     expect(serverConfigContent()).toContain("[docker]");
   });
 
-  it("contains eip = \"http://localhost:8080\"", () => {
+  it('contains eip = "http://localhost:8080"', () => {
     expect(serverConfigContent()).toContain(`eip = "http://localhost:8080"`);
   });
 
-  it("contains type = \"docker\"", () => {
+  it('contains type = "docker"', () => {
     expect(serverConfigContent()).toContain(`type = "docker"`);
   });
 
-  it("contains network_mode = \"bridge\"", () => {
+  it('contains network_mode = "bridge"', () => {
     expect(serverConfigContent()).toContain(`network_mode = "bridge"`);
   });
 

--- a/packages/cli/test/docker.test.ts
+++ b/packages/cli/test/docker.test.ts
@@ -25,7 +25,9 @@ describe("pollHealth", () => {
       return new Response(JSON.stringify({ status: "starting" }), { status: 200 });
     }) as unknown as typeof globalThis.fetch;
 
-    await expect(pollHealth("http://localhost:8080/health", 100)).rejects.toThrow(/did not become healthy/);
+    await expect(pollHealth("http://localhost:8080/health", 100)).rejects.toThrow(
+      /did not become healthy/,
+    );
   });
 
   it("throws after timeout if server is unreachable", async () => {
@@ -33,6 +35,8 @@ describe("pollHealth", () => {
       throw new Error("ECONNREFUSED");
     }) as unknown as typeof globalThis.fetch;
 
-    await expect(pollHealth("http://localhost:8080/health", 100)).rejects.toThrow(/did not become healthy/);
+    await expect(pollHealth("http://localhost:8080/health", 100)).rejects.toThrow(
+      /did not become healthy/,
+    );
   });
 });

--- a/packages/cli/test/schema.test.ts
+++ b/packages/cli/test/schema.test.ts
@@ -44,40 +44,50 @@ describe("validateRegistryItem", () => {
   });
 
   it("throws with 'name' in message when name is missing", () => {
-    expect(() => validateRegistryItem({
-      image: "node:22",
-      resources: { cpu: "500m", memory: "256Mi" },
-    })).toThrow(/name/);
+    expect(() =>
+      validateRegistryItem({
+        image: "node:22",
+        resources: { cpu: "500m", memory: "256Mi" },
+      }),
+    ).toThrow(/name/);
   });
 
   it("throws with 'image' in message when image is missing", () => {
-    expect(() => validateRegistryItem({
-      name: "my-sandbox",
-      resources: { cpu: "500m", memory: "256Mi" },
-    })).toThrow(/image/);
+    expect(() =>
+      validateRegistryItem({
+        name: "my-sandbox",
+        resources: { cpu: "500m", memory: "256Mi" },
+      }),
+    ).toThrow(/image/);
   });
 
   it("throws with 'resources' in message when resources is missing", () => {
-    expect(() => validateRegistryItem({
-      name: "my-sandbox",
-      image: "node:22",
-    })).toThrow(/resources/);
+    expect(() =>
+      validateRegistryItem({
+        name: "my-sandbox",
+        image: "node:22",
+      }),
+    ).toThrow(/resources/);
   });
 
   it("throws with 'cpu' in message when resources.cpu is missing", () => {
-    expect(() => validateRegistryItem({
-      name: "my-sandbox",
-      image: "node:22",
-      resources: { memory: "256Mi" },
-    })).toThrow(/cpu/);
+    expect(() =>
+      validateRegistryItem({
+        name: "my-sandbox",
+        image: "node:22",
+        resources: { memory: "256Mi" },
+      }),
+    ).toThrow(/cpu/);
   });
 
   it("throws with 'memory' in message when resources.memory is missing", () => {
-    expect(() => validateRegistryItem({
-      name: "my-sandbox",
-      image: "node:22",
-      resources: { cpu: "500m" },
-    })).toThrow(/memory/);
+    expect(() =>
+      validateRegistryItem({
+        name: "my-sandbox",
+        image: "node:22",
+        resources: { cpu: "500m" },
+      }),
+    ).toThrow(/memory/);
   });
 
   it("rejects null", () => {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -25,7 +25,7 @@
       .exec("git rev-parse HEAD", { capture: sha })
       .searchFiles("**/*.ts", { as: tsFiles })
       .forEach(tsFiles, (s, file) => s.exec(`tsc ${file}`))
-      .exec("deploy.sh", { envs: { GIT_SHA: sha } })
+      .exec("deploy.sh", { envs: { GIT_SHA: sha } }),
   );
   ```
 
@@ -77,9 +77,7 @@
 
   ```ts
   workflow("deploy").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
-    s
-      .exec("git rev-parse HEAD", { capture: "sha" })
-      .exec("echo deploying commit {{sha}}")
+    s.exec("git rev-parse HEAD", { capture: "sha" }).exec("echo deploying commit {{sha}}"),
   );
   ```
 
@@ -94,7 +92,7 @@
     s
       .exec('node -e "process.version" > /tmp/version.txt')
       .readFile("/tmp/version.txt", { as: "version" })
-      .exec("echo Node version: {{version}}")
+      .exec("echo Node version: {{version}}"),
   );
   ```
 
@@ -139,7 +137,7 @@
     s
       .exec("npm ci")
       .snapshot() // checkpoint: deps installed
-      .exec("npm test")
+      .exec("npm test"),
   );
   ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/core",
   "version": "0.3.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,9 +13,6 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,12 @@
 export { LedgerEvent, SandboxStatus } from "./ledger";
-export type { LedgerEntry, IStorageAdapter, SandboxDetails, ListSandboxOptions, EnvironmentRecord, CheckpointInfo } from "./ledger";
+export type {
+  LedgerEntry,
+  IStorageAdapter,
+  SandboxDetails,
+  ListSandboxOptions,
+  EnvironmentRecord,
+  CheckpointInfo,
+} from "./ledger";
 
 export { LogLevel, ConsoleLogger, noopLogger } from "./logger";
 export type { ILogger } from "./logger";
@@ -11,4 +18,10 @@ export type { FileInfo } from "@drej/opensandbox";
 export { ExecHandle } from "./exec-handle";
 export type { ExecResult } from "./exec-handle";
 
-export { WorkflowError, SandboxError, ExecConnectionError, CommandError, StepTimeoutError } from "./errors";
+export {
+  WorkflowError,
+  SandboxError,
+  ExecConnectionError,
+  CommandError,
+  StepTimeoutError,
+} from "./errors";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1,8 +1,8 @@
 /** Status of a sandbox session derived from its ledger events. */
 export enum SandboxStatus {
-  Running   = "running",
+  Running = "running",
   Completed = "completed",
-  Failed    = "failed",
+  Failed = "failed",
   Cancelled = "cancelled",
 }
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -23,10 +23,18 @@ export class ConsoleLogger implements ILogger {
     else console.log(out);
   }
 
-  debug(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Debug, "[DEBUG]", msg, meta); }
-  info(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Info, "[INFO]", msg, meta); }
-  warn(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Warn, "[WARN]", msg, meta); }
-  error(msg: string, meta?: Record<string, unknown>) { this.log(LogLevel.Error, "[ERROR]", msg, meta); }
+  debug(msg: string, meta?: Record<string, unknown>) {
+    this.log(LogLevel.Debug, "[DEBUG]", msg, meta);
+  }
+  info(msg: string, meta?: Record<string, unknown>) {
+    this.log(LogLevel.Info, "[INFO]", msg, meta);
+  }
+  warn(msg: string, meta?: Record<string, unknown>) {
+    this.log(LogLevel.Warn, "[WARN]", msg, meta);
+  }
+  error(msg: string, meta?: Record<string, unknown>) {
+    this.log(LogLevel.Error, "[ERROR]", msg, meta);
+  }
 }
 
 export const noopLogger: ILogger = {

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -126,7 +126,11 @@ export class Sandbox {
 
   private async _getExecClient(): Promise<ExecClient> {
     if (!this._execClient) {
-      this._execClient = await resolveExecClient(this._deps.control, this.sandboxId, this._deps.useServerProxy);
+      this._execClient = await resolveExecClient(
+        this._deps.control,
+        this.sandboxId,
+        this._deps.useServerProxy,
+      );
     }
     return this._execClient;
   }
@@ -171,7 +175,12 @@ export class Sandbox {
       // base64-encode so newlines/special chars survive the JSON boundary
       const sh = opts.shell ?? self._deps.shell ?? "/bin/sh";
       const command = `echo ${Buffer.from(cmd).toString("base64")} | base64 -d | ${sh}`;
-      for await (const ev of execClient.executeCommand({ command, cwd: opts.cwd, envs: opts.env, timeout: opts.timeoutMs })) {
+      for await (const ev of execClient.executeCommand({
+        command,
+        cwd: opts.cwd,
+        envs: opts.env,
+        timeout: opts.timeoutMs,
+      })) {
         await self._emit(LedgerEvent.ExecEvent, seq, { seq, ...ev });
         yield ev;
       }
@@ -205,7 +214,9 @@ export class Sandbox {
    * await sb.execCode('print(x)', { context: ctx }); // prints 42
    * ```
    */
-  async createCodeContext(language: import("@drej/opensandbox").CodeLanguage): Promise<import("@drej/opensandbox").CodeContext> {
+  async createCodeContext(
+    language: import("@drej/opensandbox").CodeLanguage,
+  ): Promise<import("@drej/opensandbox").CodeContext> {
     const ec = await this._getExecClient();
     return ec.createContext(language as string);
   }
@@ -322,7 +333,9 @@ export class Sandbox {
    * await sb.replaceInFiles([{ path: "/app/config.json", old: "localhost", new: "0.0.0.0" }]);
    * ```
    */
-  async replaceInFiles(replacements: Array<{ path: string; old: string; new: string }>): Promise<void> {
+  async replaceInFiles(
+    replacements: Array<{ path: string; old: string; new: string }>,
+  ): Promise<void> {
     const ec = await this._getExecClient();
     await ec.replaceInFiles(replacements);
   }
@@ -356,7 +369,11 @@ export class Sandbox {
    * ```
    */
   async proxy(port: number): Promise<{ url: string; headers: Record<string, string> }> {
-    const ep = await this._deps.control.getEndpoint(this.sandboxId, port, this._deps.useServerProxy);
+    const ep = await this._deps.control.getEndpoint(
+      this.sandboxId,
+      port,
+      this._deps.useServerProxy,
+    );
     const url = ep.endpoint.startsWith("http") ? ep.endpoint : `http://${ep.endpoint}`;
     return { url, headers: ep.headers ?? {} };
   }
@@ -389,7 +406,8 @@ export class Sandbox {
    * ```
    */
   async fork(tag?: string): Promise<Sandbox> {
-    if (!this._deps.fork) throw new SandboxError("fork() is not supported on this sandbox", this.sandboxId);
+    if (!this._deps.fork)
+      throw new SandboxError("fork() is not supported on this sandbox", this.sandboxId);
     const snap = await this._deps.control.createSnapshot(this.sandboxId);
     await this._waitForSnapshot(snap.id);
     await this._emit(LedgerEvent.CheckpointCreated, -1, { snapshotId: snap.id, name: tag });
@@ -420,7 +438,10 @@ export class Sandbox {
       }
       await new Promise<void>((r) => setTimeout(r, 2_000));
     }
-    throw new SandboxError(`Snapshot ${snapshotId} did not become ready within ${timeoutMs}ms`, this.sandboxId);
+    throw new SandboxError(
+      `Snapshot ${snapshotId} did not become ready within ${timeoutMs}ms`,
+      this.sandboxId,
+    );
   }
 
   /**

--- a/packages/core/test/exec-handle.test.ts
+++ b/packages/core/test/exec-handle.test.ts
@@ -18,7 +18,11 @@ function stderr(text: string): SSEEvent {
 }
 
 function error(exitCode: number): SSEEvent {
-  return { type: SSEEventType.Error, error: { message: "exit", evalue: String(exitCode) }, timestamp: 0 };
+  return {
+    type: SSEEventType.Error,
+    error: { message: "exit", evalue: String(exitCode) },
+    timestamp: 0,
+  };
 }
 
 describe("ExecHandle — streaming mode", () => {
@@ -81,7 +85,9 @@ describe("ExecHandle — streaming mode", () => {
     const handle = new ExecHandle({
       type: "stream",
       gen: makeStream([stdout("out"), error(42)]),
-      onDone: async (r) => { capturedResult = r; },
+      onDone: async (r) => {
+        capturedResult = r;
+      },
     });
     await handle;
     expect((capturedResult as { exitCode: number }).exitCode).toBe(42);
@@ -98,21 +104,30 @@ describe("ExecHandle — replay mode", () => {
   });
 
   it("yields stdout via stdout() generator", async () => {
-    const handle = new ExecHandle({ type: "replay", result: { stdout: "hello", stderr: "", exitCode: 0 } });
+    const handle = new ExecHandle({
+      type: "replay",
+      result: { stdout: "hello", stderr: "", exitCode: 0 },
+    });
     const chunks: string[] = [];
     for await (const chunk of handle.stdout()) chunks.push(chunk);
     expect(chunks.join("")).toBe("hello");
   });
 
   it("pipe() works in replay mode", async () => {
-    const handle = new ExecHandle({ type: "replay", result: { stdout: "piped", stderr: "", exitCode: 0 } });
+    const handle = new ExecHandle({
+      type: "replay",
+      result: { stdout: "piped", stderr: "", exitCode: 0 },
+    });
     const written: string[] = [];
     await handle.pipe({ write: (c) => written.push(c) });
     expect(written.join("")).toBe("piped");
   });
 
   it("result() works in replay mode", async () => {
-    const handle = new ExecHandle({ type: "replay", result: { stdout: "x", stderr: "", exitCode: 5 } });
+    const handle = new ExecHandle({
+      type: "replay",
+      result: { stdout: "x", stderr: "", exitCode: 5 },
+    });
     const result = await handle.result();
     expect(result.exitCode).toBe(5);
   });

--- a/packages/core/test/sandbox-fork.test.ts
+++ b/packages/core/test/sandbox-fork.test.ts
@@ -60,7 +60,9 @@ describe("Sandbox.fork()", () => {
     const events = appendCalls.map((c: [{ event: string }]) => c[0].event);
     expect(events).toContain(LedgerEvent.CheckpointCreated);
 
-    const cpEntry = appendCalls.find((c: [{ event: string }]) => c[0].event === LedgerEvent.CheckpointCreated);
+    const cpEntry = appendCalls.find(
+      (c: [{ event: string }]) => c[0].event === LedgerEvent.CheckpointCreated,
+    );
     expect((cpEntry![0] as any).payload.snapshotId).toBe("snap-xyz");
 
     expect(forkFn).toHaveBeenCalledWith("snap-xyz", undefined);
@@ -83,7 +85,9 @@ describe("Sandbox.fork()", () => {
     expect(forkFn).toHaveBeenCalledWith("snap-tagged", "after-install");
 
     const appendCalls = (adapter.append as ReturnType<typeof vi.fn>).mock.calls;
-    const cpEntry = appendCalls.find((c: [{ event: string }]) => c[0].event === LedgerEvent.CheckpointCreated);
+    const cpEntry = appendCalls.find(
+      (c: [{ event: string }]) => c[0].event === LedgerEvent.CheckpointCreated,
+    );
     expect((cpEntry![0] as any).payload.name).toBe("after-install");
   });
 

--- a/packages/core/test/sandbox-replay.test.ts
+++ b/packages/core/test/sandbox-replay.test.ts
@@ -22,7 +22,9 @@ function makeExecClient(events: SSEEvent[] = []) {
   return {
     listContexts: vi.fn().mockResolvedValue([]),
     executeCommand: vi.fn().mockImplementation(() =>
-      (async function* () { for (const ev of events) yield ev; })()
+      (async function* () {
+        for (const ev of events) yield ev;
+      })(),
     ),
   };
 }
@@ -83,8 +85,8 @@ describe("Sandbox replay mode", () => {
     const sb = new Sandbox("sb-1", "test", makeDeps(adapter), replayCache);
     (sb as any)._execClient = execClient;
 
-    const r1 = await sb.exec("npm ci");       // seq=1, cached
-    const r2 = await sb.exec("npm test");     // seq=2, live
+    const r1 = await sb.exec("npm ci"); // seq=1, cached
+    const r2 = await sb.exec("npm test"); // seq=2, live
 
     expect(r1.stdout).toBe("cached\n");
     expect(r2.stdout).toBe("live output\n");
@@ -106,9 +108,9 @@ describe("Sandbox replay mode", () => {
     (sb as any)._execClient = execClient;
 
     const results = await Promise.all([
-      sb.exec("cmd1"),  // seq=1, cached
-      sb.exec("cmd2"),  // seq=2, cached
-      sb.exec("cmd3"),  // seq=3, live
+      sb.exec("cmd1"), // seq=1, cached
+      sb.exec("cmd2"), // seq=2, cached
+      sb.exec("cmd3"), // seq=3, live
     ]);
 
     expect(results[0].stdout).toBe("a\n");

--- a/packages/opensandbox/package.json
+++ b/packages/opensandbox/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/opensandbox",
   "version": "0.1.3",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,9 +13,6 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/opensandbox/src/control.ts
+++ b/packages/opensandbox/src/control.ts
@@ -20,7 +20,12 @@ interface RawSnapshot {
 }
 
 function flattenSnapshot(raw: RawSnapshot): Snapshot {
-  return { id: raw.id, sandboxId: raw.sandboxId, state: raw.status.state, createdAt: raw.createdAt };
+  return {
+    id: raw.id,
+    sandboxId: raw.sandboxId,
+    state: raw.status.state,
+    createdAt: raw.createdAt,
+  };
 }
 
 export class OpenSandboxError extends Error {

--- a/packages/opensandbox/src/exec.ts
+++ b/packages/opensandbox/src/exec.ts
@@ -27,7 +27,11 @@ async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSE
         if (!trimmed) continue;
         if (trimmed.startsWith("{")) {
           // execd sends raw JSON lines, not data:-prefixed SSE
-          try { yield JSON.parse(trimmed) as SSEEvent; } catch { /* skip malformed */ }
+          try {
+            yield JSON.parse(trimmed) as SSEEvent;
+          } catch {
+            /* skip malformed */
+          }
         } else {
           let type: string | undefined;
           let data: string | undefined;
@@ -84,7 +88,11 @@ export class ExecClient {
     return res.json() as Promise<T>;
   }
 
-  private async *streamRequest(method: string, path: string, body?: unknown): AsyncGenerator<SSEEvent> {
+  private async *streamRequest(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): AsyncGenerator<SSEEvent> {
     const res = await fetch(`${this.baseUrl}${path}`, {
       method,
       headers: {
@@ -149,7 +157,10 @@ export class ExecClient {
   }
 
   async getFileInfo(path: string): Promise<FileInfo> {
-    const map = await this.request<Record<string, FileInfo>>("GET", `/files/info?path=${encodeURIComponent(path)}`);
+    const map = await this.request<Record<string, FileInfo>>(
+      "GET",
+      `/files/info?path=${encodeURIComponent(path)}`,
+    );
     const entry = map[path];
     if (!entry) throw new Error(`getFileInfo: no entry for path ${path}`);
     return entry;
@@ -182,8 +193,14 @@ export class ExecClient {
   async uploadFile(path: string, content: Blob | BufferSource | string): Promise<void> {
     // execd requires File objects (not Blob) so Content-Disposition includes a filename attribute.
     const formData = new FormData();
-    formData.append("metadata", new File([JSON.stringify({ path })], "metadata.json", { type: "application/json" }));
-    formData.append("file", new File([content], path.split("/").pop() ?? "file", { type: "application/octet-stream" }));
+    formData.append(
+      "metadata",
+      new File([JSON.stringify({ path })], "metadata.json", { type: "application/json" }),
+    );
+    formData.append(
+      "file",
+      new File([content], path.split("/").pop() ?? "file", { type: "application/octet-stream" }),
+    );
     const res = await fetch(`${this.baseUrl}/files/upload`, {
       method: "POST",
       headers: this.authHeader,

--- a/packages/sdks/typescript/CHANGELOG.md
+++ b/packages/sdks/typescript/CHANGELOG.md
@@ -25,7 +25,7 @@
       .exec("git rev-parse HEAD", { capture: sha })
       .searchFiles("**/*.ts", { as: tsFiles })
       .forEach(tsFiles, (s, file) => s.exec(`tsc ${file}`))
-      .exec("deploy.sh", { envs: { GIT_SHA: sha } })
+      .exec("deploy.sh", { envs: { GIT_SHA: sha } }),
   );
   ```
 
@@ -103,9 +103,7 @@
 
   ```ts
   workflow("deploy").sandbox({ image: { uri: "node:20-slim" } }, (s) =>
-    s
-      .exec("git rev-parse HEAD", { capture: "sha" })
-      .exec("echo deploying commit {{sha}}")
+    s.exec("git rev-parse HEAD", { capture: "sha" }).exec("echo deploying commit {{sha}}"),
   );
   ```
 
@@ -133,7 +131,7 @@
     s
       .exec('node -e "process.version" > /tmp/version.txt')
       .readFile("/tmp/version.txt", { as: "version" })
-      .exec("echo Node version: {{version}}")
+      .exec("echo Node version: {{version}}"),
   );
   ```
 
@@ -178,7 +176,7 @@
     s
       .exec("npm ci")
       .snapshot() // checkpoint: deps installed
-      .exec("npm test")
+      .exec("npm test"),
   );
   ```
 

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "drej",
   "version": "0.7.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -10,9 +13,6 @@
       "types": "./src/index.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -10,22 +10,40 @@ import {
   type EnvironmentRecord,
   type CheckpointInfo,
 } from "@drej/core";
-import {
-  ControlClient,
-  SandboxState,
-  SnapshotState,
-} from "@drej/opensandbox";
+import { ControlClient, SandboxState, SnapshotState } from "@drej/opensandbox";
 
 import { DrejError, type DrejOptions, type SandboxOptions, type ResumeOptions } from "./types";
-import { Environment, type EnvironmentOptions, type EnvironmentSandboxOptions } from "./environment";
+import {
+  Environment,
+  type EnvironmentOptions,
+  type EnvironmentSandboxOptions,
+} from "./environment";
 
 export { Sandbox } from "@drej/core";
 export type { ExecHandle, ExecResult, ExecOptions, ExecCodeOptions } from "@drej/core";
-export { LedgerEvent, SandboxStatus, SandboxError, ExecConnectionError, CommandError, StepTimeoutError } from "@drej/core";
-export type { IStorageAdapter, SandboxDetails, ListSandboxOptions, LedgerEntry, EnvironmentRecord, FileInfo } from "@drej/core";
+export {
+  LedgerEvent,
+  SandboxStatus,
+  SandboxError,
+  ExecConnectionError,
+  CommandError,
+  StepTimeoutError,
+} from "@drej/core";
+export type {
+  IStorageAdapter,
+  SandboxDetails,
+  ListSandboxOptions,
+  LedgerEntry,
+  EnvironmentRecord,
+  FileInfo,
+} from "@drej/core";
 export { DrejError, type DrejOptions, type SandboxOptions, type ResumeOptions } from "./types";
 export type { CheckpointInfo } from "@drej/core";
-export { Environment, type EnvironmentOptions, type EnvironmentSandboxOptions } from "./environment";
+export {
+  Environment,
+  type EnvironmentOptions,
+  type EnvironmentSandboxOptions,
+} from "./environment";
 
 /**
  * Main entry point for drej. Manages sandbox lifecycle and session history.
@@ -81,7 +99,7 @@ export class Drej {
 
   /** Lazily initialises the adapter on first use. Concurrent callers share the same promise. */
   private _ensureConnected(): Promise<void> {
-    this._connectPromise ??= (this._adapter.connect?.() ?? Promise.resolve());
+    this._connectPromise ??= this._adapter.connect?.() ?? Promise.resolve();
     return this._connectPromise;
   }
 
@@ -138,7 +156,8 @@ export class Drej {
         hooks: opts.hooks,
         onClose: () => this._releaseSlot(),
         shell: opts.shell,
-        fork: (snapshotId, tag) => this._forkFromSnapshot(snapshotId, name, opts.resources, opts.shell),
+        fork: (snapshotId, tag) =>
+          this._forkFromSnapshot(snapshotId, name, opts.resources, opts.shell),
         useServerProxy: this._useServerProxy,
       });
       opts.hooks?.onSandboxCreated?.(sandboxId, name);
@@ -187,18 +206,26 @@ export class Drej {
     let checkpointIdx: number;
     if (tag) {
       checkpointIdx = entries.findIndex(
-        (e) => e.event === LedgerEvent.CheckpointCreated && (e.payload as { name?: string } | undefined)?.name === tag,
+        (e) =>
+          e.event === LedgerEvent.CheckpointCreated &&
+          (e.payload as { name?: string } | undefined)?.name === tag,
       );
-      if (checkpointIdx === -1) throw new DrejError(`No checkpoint with tag '${tag}' found for session ${sandboxId}`, 404);
+      if (checkpointIdx === -1)
+        throw new DrejError(`No checkpoint with tag '${tag}' found for session ${sandboxId}`, 404);
     } else {
       checkpointIdx = entries.map((e) => e.event).lastIndexOf(LedgerEvent.CheckpointCreated);
-      if (checkpointIdx === -1) throw new DrejError(`No checkpoint found for session ${sandboxId}`, 404);
+      if (checkpointIdx === -1)
+        throw new DrejError(`No checkpoint found for session ${sandboxId}`, 404);
     }
 
     const { snapshotId } = entries[checkpointIdx].payload as { snapshotId: string };
 
     const createdEntry = entries.find((e) => e.event === LedgerEvent.SandboxCreated);
-    const resources = (createdEntry?.payload as { resources?: { cpu?: string; memory?: string; gpu?: string } } | undefined)?.resources;
+    const resources = (
+      createdEntry?.payload as
+        | { resources?: { cpu?: string; memory?: string; gpu?: string } }
+        | undefined
+    )?.resources;
 
     const replayCache = new Map<number, ExecResult>();
     const pendingStdout = new Map<number, string[]>();
@@ -240,15 +267,27 @@ export class Drej {
         payload: { sandboxId: newSessionId, resumedFrom: sandboxId, snapshotId },
       });
 
-      return new Sandbox(newSessionId, name, {
-        control: this._control,
-        adapter: this._adapter,
-        onClose: () => this._releaseSlot(),
-        fork: resources?.cpu && resources?.memory
-          ? (snapshotId, tag) => this._forkFromSnapshot(snapshotId, name, resources as { cpu: string; memory: string; gpu?: string }, undefined)
-          : undefined,
-        useServerProxy: this._useServerProxy,
-      }, replayCache);
+      return new Sandbox(
+        newSessionId,
+        name,
+        {
+          control: this._control,
+          adapter: this._adapter,
+          onClose: () => this._releaseSlot(),
+          fork:
+            resources?.cpu && resources?.memory
+              ? (snapshotId, tag) =>
+                  this._forkFromSnapshot(
+                    snapshotId,
+                    name,
+                    resources as { cpu: string; memory: string; gpu?: string },
+                    undefined,
+                  )
+              : undefined,
+          useServerProxy: this._useServerProxy,
+        },
+        replayCache,
+      );
     } catch (err) {
       this._releaseSlot();
       throw err;
@@ -357,7 +396,11 @@ export class Drej {
     await this._buildEnvironment(name, opts);
   }
 
-  async _envSandbox(name: string, opts: EnvironmentOptions, extra?: EnvironmentSandboxOptions): Promise<Sandbox> {
+  async _envSandbox(
+    name: string,
+    opts: EnvironmentOptions,
+    extra?: EnvironmentSandboxOptions,
+  ): Promise<Sandbox> {
     await this._ensureConnected();
 
     const record = await this._adapter.getEnvironment(name);
@@ -385,7 +428,12 @@ export class Drej {
     const image = typeof opts.image === "string" ? opts.image : opts.image.uri;
     const buildName = `env-${name}-build`;
 
-    const sb = await this.sandbox({ image: opts.image, resources: opts.resources, name: buildName, shell: opts.shell });
+    const sb = await this.sandbox({
+      image: opts.image,
+      resources: opts.resources,
+      name: buildName,
+      shell: opts.shell,
+    });
     try {
       await opts.setup(sb);
       await sb.checkpoint(`env:${name}`);
@@ -394,7 +442,8 @@ export class Drej {
     }
 
     const checkpoint = await this._adapter.lastCheckpoint(buildName, sb.sandboxId);
-    if (!checkpoint) throw new DrejError(`Environment build for '${name}' produced no checkpoint`, 500);
+    if (!checkpoint)
+      throw new DrejError(`Environment build for '${name}' produced no checkpoint`, 500);
     const { snapshotId } = checkpoint.payload as { snapshotId: string };
 
     await this._adapter.saveEnvironment({ name, snapshotId, image, builtAt: Date.now() });
@@ -434,7 +483,8 @@ export class Drej {
         hooks: extra?.hooks,
         onClose: () => this._releaseSlot(),
         shell: extra?.shell ?? envShell,
-        fork: (snapshotId, tag) => this._forkFromSnapshot(snapshotId, sessionName, resources, extra?.shell ?? envShell),
+        fork: (snapshotId, tag) =>
+          this._forkFromSnapshot(snapshotId, sessionName, resources, extra?.shell ?? envShell),
         useServerProxy: this._useServerProxy,
       });
       extra?.hooks?.onSandboxCreated?.(newId, sessionName);
@@ -487,7 +537,10 @@ export class Drej {
       const s = await this._control.getSandbox(sandboxId);
       if (s.status.state === SandboxState.Running) return;
       if (s.status.state === SandboxState.Failed || s.status.state === SandboxState.Terminated) {
-        throw new DrejError(`Sandbox ${sandboxId} entered state ${s.status.state}: ${s.status.message ?? ""}`, 500);
+        throw new DrejError(
+          `Sandbox ${sandboxId} entered state ${s.status.state}: ${s.status.message ?? ""}`,
+          500,
+        );
       }
       await new Promise<void>((r) => setTimeout(r, 1_000));
     }

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -3,10 +3,22 @@ export { Sandbox } from "@drej/core";
 export { ExecHandle } from "@drej/core";
 export type { ExecResult, ExecOptions, ExecCodeOptions } from "@drej/core";
 export { LedgerEvent, SandboxStatus } from "@drej/core";
-export { WorkflowError, SandboxError, ExecConnectionError, CommandError, StepTimeoutError } from "@drej/core";
+export {
+  WorkflowError,
+  SandboxError,
+  ExecConnectionError,
+  CommandError,
+  StepTimeoutError,
+} from "@drej/core";
 export { ConsoleLogger, LogLevel, noopLogger } from "@drej/core";
 export type { ILogger } from "@drej/core";
-export type { IStorageAdapter, LedgerEntry, SandboxDetails, ListSandboxOptions, SandboxHooks } from "@drej/core";
+export type {
+  IStorageAdapter,
+  LedgerEntry,
+  SandboxDetails,
+  ListSandboxOptions,
+  SandboxHooks,
+} from "@drej/core";
 export { DrejError } from "./types";
 export type { DrejOptions, SandboxOptions } from "./types";
 export { CodeLanguage } from "@drej/opensandbox";

--- a/packages/sdks/typescript/test/client.test.ts
+++ b/packages/sdks/typescript/test/client.test.ts
@@ -43,10 +43,7 @@ describe("Drej lazy connect", () => {
     const adapter = makeAdapter();
     const client = makeClient(adapter);
     // Trigger two concurrent first uses
-    await Promise.all([
-      client.sandboxes.list(),
-      client.sandboxes.list(),
-    ]);
+    await Promise.all([client.sandboxes.list(), client.sandboxes.list()]);
     expect(adapter.connect).toHaveBeenCalledOnce();
   });
 });
@@ -64,7 +61,13 @@ describe("Drej.sandboxes", () => {
 
   it("sessions.list() delegates to listAllSandboxDetails()", async () => {
     const details: SandboxDetails[] = [
-      { name: "ci", sandboxId: "s1", status: SandboxStatus.Completed, startedAt: 1000, execCount: 2 },
+      {
+        name: "ci",
+        sandboxId: "s1",
+        status: SandboxStatus.Completed,
+        startedAt: 1000,
+        execCount: 2,
+      },
     ];
     (adapter.listAllSandboxDetails as ReturnType<typeof vi.fn>).mockResolvedValue(details);
 
@@ -75,7 +78,10 @@ describe("Drej.sandboxes", () => {
 
   it("sessions.list(opts) forwards opts", async () => {
     await client.sandboxes.list({ limit: 5, status: SandboxStatus.Running });
-    expect(adapter.listAllSandboxDetails).toHaveBeenCalledWith({ limit: 5, status: SandboxStatus.Running });
+    expect(adapter.listAllSandboxDetails).toHaveBeenCalledWith({
+      limit: 5,
+      status: SandboxStatus.Running,
+    });
   });
 
   it("sessions.listByName(name) delegates to listSandboxDetails(name)", async () => {
@@ -90,7 +96,11 @@ describe("Drej.sandboxes", () => {
 
   it("sessions.get(name, sandboxId) delegates to getSandboxDetails()", async () => {
     const details: SandboxDetails = {
-      name: "ci", sandboxId: "s1", status: SandboxStatus.Completed, startedAt: 1000, execCount: 1,
+      name: "ci",
+      sandboxId: "s1",
+      status: SandboxStatus.Completed,
+      startedAt: 1000,
+      execCount: 1,
     };
     (adapter.getSandboxDetails as ReturnType<typeof vi.fn>).mockResolvedValue(details);
 
@@ -135,7 +145,9 @@ describe("Drej concurrency slot", () => {
     await (client as any)._acquireSlot();
 
     let resolved = false;
-    const pending = (client as any)._acquireSlot().then(() => { resolved = true; });
+    const pending = (client as any)._acquireSlot().then(() => {
+      resolved = true;
+    });
 
     // Not yet resolved — no free slot
     await Promise.resolve();
@@ -237,11 +249,17 @@ describe("Drej._getOrBuildEnvironment concurrency guard", () => {
     const client = makeClient(adapter);
 
     let resolveBuild!: (id: string) => void;
-    const buildPromise = new Promise<string>((r) => { resolveBuild = r; });
+    const buildPromise = new Promise<string>((r) => {
+      resolveBuild = r;
+    });
     const buildSpy = vi.fn().mockReturnValue(buildPromise);
     (client as any)._buildEnvironment = buildSpy;
 
-    const opts = { image: "debian:slim", resources: { cpu: "500m", memory: "256Mi" }, setup: async () => {} };
+    const opts = {
+      image: "debian:slim",
+      resources: { cpu: "500m", memory: "256Mi" },
+      setup: async () => {},
+    };
 
     const p1 = (client as any)._getOrBuildEnvironment("py", opts);
     const p2 = (client as any)._getOrBuildEnvironment("py", opts);
@@ -261,7 +279,11 @@ describe("Drej._getOrBuildEnvironment concurrency guard", () => {
     const buildSpy = vi.fn().mockResolvedValue("snap-1");
     (client as any)._buildEnvironment = buildSpy;
 
-    const opts = { image: "debian:slim", resources: { cpu: "500m", memory: "256Mi" }, setup: async () => {} };
+    const opts = {
+      image: "debian:slim",
+      resources: { cpu: "500m", memory: "256Mi" },
+      setup: async () => {},
+    };
 
     await (client as any)._getOrBuildEnvironment("py", opts);
     await (client as any)._getOrBuildEnvironment("py", opts);

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@drej/workflow",
   "version": "1.0.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -10,9 +13,6 @@
       "types": "./dist/index.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/src/sandbox-builder.ts
+++ b/packages/workflow/src/sandbox-builder.ts
@@ -10,15 +10,29 @@ export type SandboxOp =
   | { kind: "moveFile"; from: string; to: string }
   | { kind: "checkpoint"; name?: string }
   | { kind: "retry"; maxAttempts: number; fn: (sb: SandboxBuilder) => void; opts: RetryOptions }
-  | { kind: "when"; pred: WhenPredicate; then: (sb: SandboxBuilder) => void; else?: (sb: SandboxBuilder) => void }
-  | { kind: "forEach"; items: unknown[]; fn: (sb: SandboxBuilder, item: unknown, index: number) => void; opts: ForEachOptions };
+  | {
+      kind: "when";
+      pred: WhenPredicate;
+      then: (sb: SandboxBuilder) => void;
+      else?: (sb: SandboxBuilder) => void;
+    }
+  | {
+      kind: "forEach";
+      items: unknown[];
+      fn: (sb: SandboxBuilder, item: unknown, index: number) => void;
+      opts: ForEachOptions;
+    };
 
 export interface RetryOptions {
   backoff?: "fixed" | "exponential";
   delayMs?: number;
 }
 
-export type WhenPredicate = (ctx: { stdout: string; exitCode: number; vars: Record<string, unknown> }) => boolean;
+export type WhenPredicate = (ctx: {
+  stdout: string;
+  exitCode: number;
+  vars: Record<string, unknown>;
+}) => boolean;
 
 export interface ForEachOptions {
   concurrency?: number;
@@ -119,7 +133,7 @@ export class SandboxBuilder {
     then: (sb: SandboxBuilder) => void,
     otherwise?: (sb: SandboxBuilder) => void,
   ): this {
-    this._ops.push({ kind: "when", pred, then, "else": otherwise });
+    this._ops.push({ kind: "when", pred, then, else: otherwise });
     return this;
   }
 
@@ -154,7 +168,11 @@ export interface FlushContext {
 }
 
 /** Flush a SandboxBuilder's op queue against a live Sandbox. */
-export async function flushOps(sandbox: Sandbox, ops: SandboxOp[], ctx: FlushContext): Promise<void> {
+export async function flushOps(
+  sandbox: Sandbox,
+  ops: SandboxOp[],
+  ctx: FlushContext,
+): Promise<void> {
   for (const op of ops) {
     switch (op.kind) {
       case "exec": {

--- a/packages/workflow/src/workflow-builder.ts
+++ b/packages/workflow/src/workflow-builder.ts
@@ -106,7 +106,9 @@ export class WorkflowBuilder {
     return this._execute(undefined);
   }
 
-  private async _execute(sink: { write(chunk: string): unknown } | undefined): Promise<WorkflowResult> {
+  private async _execute(
+    sink: { write(chunk: string): unknown } | undefined,
+  ): Promise<WorkflowResult> {
     const combined: WorkflowResult = { stdout: "", vars: {} };
 
     for (const stage of this._stages) {

--- a/packages/workflow/test/sandbox-builder.test.ts
+++ b/packages/workflow/test/sandbox-builder.test.ts
@@ -10,11 +10,18 @@ function makeSandbox(execResults: Record<string, string> = {}) {
     exec: vi.fn().mockImplementation((cmd: string) => {
       const stdout = execResults[cmd] ?? `output of: ${cmd}`;
       return {
-        [Symbol.asyncIterator]: async function* () { yield stdout; },
-        stdout: async function* () { yield stdout; },
+        [Symbol.asyncIterator]: async function* () {
+          yield stdout;
+        },
+        stdout: async function* () {
+          yield stdout;
+        },
         result: async () => ({ stdout, stderr: "", exitCode: 0 }),
-        then: (ok: (r: unknown) => unknown) => Promise.resolve(ok({ stdout, stderr: "", exitCode: 0 })),
-        pipe: async (w: { write(s: string): unknown }) => { w.write(stdout); },
+        then: (ok: (r: unknown) => unknown) =>
+          Promise.resolve(ok({ stdout, stderr: "", exitCode: 0 })),
+        pipe: async (w: { write(s: string): unknown }) => {
+          w.write(stdout);
+        },
       };
     }),
     execCode: vi.fn(),
@@ -50,7 +57,10 @@ describe("SandboxBuilder — queue construction", () => {
 
   it("queues when op", () => {
     const sb = new SandboxBuilder();
-    sb.when((ctx) => ctx.exitCode === 0, (sb) => sb.exec("echo pass"));
+    sb.when(
+      (ctx) => ctx.exitCode === 0,
+      (sb) => sb.exec("echo pass"),
+    );
     expect(sb._ops[0]).toMatchObject({ kind: "when" });
   });
 
@@ -112,8 +122,12 @@ describe("flushOps — when primitive", () => {
     const sb = new SandboxBuilder();
     sb.when(
       (ctx) => ctx.exitCode === 0,
-      (sb) => { sb.exec("echo pass"); },
-      (sb) => { sb.exec("echo fail"); },
+      (sb) => {
+        sb.exec("echo pass");
+      },
+      (sb) => {
+        sb.exec("echo fail");
+      },
     );
 
     const sandbox = makeSandbox();
@@ -128,8 +142,12 @@ describe("flushOps — when primitive", () => {
     const sb = new SandboxBuilder();
     sb.when(
       (ctx) => ctx.exitCode === 0,
-      (sb) => { sb.exec("echo pass"); },
-      (sb) => { sb.exec("echo fail"); },
+      (sb) => {
+        sb.exec("echo pass");
+      },
+      (sb) => {
+        sb.exec("echo fail");
+      },
     );
 
     const sandbox = makeSandbox();
@@ -159,7 +177,9 @@ describe("flushOps — forEach primitive", () => {
 describe("flushOps — retry primitive", () => {
   it("succeeds on first attempt without retrying", async () => {
     const sb = new SandboxBuilder();
-    sb.retry(3, (sb) => { sb.exec("cmd"); });
+    sb.retry(3, (sb) => {
+      sb.exec("cmd");
+    });
 
     const sandbox = makeSandbox();
     await flushOps(sandbox as any, sb._ops, makeCtx());
@@ -175,22 +195,36 @@ describe("flushOps — retry primitive", () => {
         if (attempts < 3) {
           return {
             stdout: async function* () {},
-            result: async () => { throw new Error("failed"); },
-            then: (_ok: unknown, reject: (e: Error) => unknown) => Promise.resolve(reject!(new Error("failed"))),
-            pipe: async () => { throw new Error("failed"); },
+            result: async () => {
+              throw new Error("failed");
+            },
+            then: (_ok: unknown, reject: (e: Error) => unknown) =>
+              Promise.resolve(reject!(new Error("failed"))),
+            pipe: async () => {
+              throw new Error("failed");
+            },
           };
         }
         return {
-          stdout: async function* () { yield "success"; },
+          stdout: async function* () {
+            yield "success";
+          },
           result: async () => ({ stdout: "success", stderr: "", exitCode: 0 }),
-          then: (ok: (r: unknown) => unknown) => Promise.resolve(ok({ stdout: "success", stderr: "", exitCode: 0 })),
+          then: (ok: (r: unknown) => unknown) =>
+            Promise.resolve(ok({ stdout: "success", stderr: "", exitCode: 0 })),
           pipe: async () => {},
         };
       }),
     };
 
     const sb = new SandboxBuilder();
-    sb.retry(5, (sb) => { sb.exec("flaky-cmd"); }, { delayMs: 0 });
+    sb.retry(
+      5,
+      (sb) => {
+        sb.exec("flaky-cmd");
+      },
+      { delayMs: 0 },
+    );
 
     await flushOps(sandbox as any, sb._ops, makeCtx());
     expect(attempts).toBe(3);
@@ -200,14 +234,25 @@ describe("flushOps — retry primitive", () => {
     const sandbox = {
       exec: vi.fn().mockImplementation(() => ({
         stdout: async function* () {},
-        result: async () => { throw new Error("always fails"); },
-        then: (_ok: unknown, reject: (e: Error) => unknown) => Promise.resolve(reject!(new Error("always fails"))),
-        pipe: async () => { throw new Error("always fails"); },
+        result: async () => {
+          throw new Error("always fails");
+        },
+        then: (_ok: unknown, reject: (e: Error) => unknown) =>
+          Promise.resolve(reject!(new Error("always fails"))),
+        pipe: async () => {
+          throw new Error("always fails");
+        },
       })),
     };
 
     const sb = new SandboxBuilder();
-    sb.retry(3, (sb) => { sb.exec("broken"); }, { delayMs: 0 });
+    sb.retry(
+      3,
+      (sb) => {
+        sb.exec("broken");
+      },
+      { delayMs: 0 },
+    );
 
     await expect(flushOps(sandbox as any, sb._ops, makeCtx())).rejects.toThrow("always fails");
     expect(sandbox.exec).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
Adds oxlint (linter) and oxfmt (formatter) as root devDependencies. Configures both tools with monorepo-wide configs, adds lint/format scripts to the root package.json, extends CI to run lint and format:check in the check job, and applies oxfmt to the full codebase as the initial formatting baseline.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
