### PR TITLE
chore: remove dead SandboxStatus.Failed/Cancelled and SandboxDetails.…

### DIFF
--- a/.changeset/remove-dead-sandbox-status.md
+++ b/.changeset/remove-dead-sandbox-status.md
@@ -1,0 +1,6 @@
+---
+"@drej/core": patch
+"drej": patch
+---
+
+Remove `SandboxStatus.Failed` and `SandboxStatus.Cancelled` enum values and `SandboxDetails.error` field — these were never derivable from ledger events and could not be produced by any code path.

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2,8 +2,6 @@
 export enum SandboxStatus {
   Running = "running",
   Completed = "completed",
-  Failed = "failed",
-  Cancelled = "cancelled",
 }
 
 /** Derived metadata for a sandbox session, computed from its ledger events. */
@@ -18,8 +16,6 @@ export interface SandboxDetails {
   completedAt?: number;
   /** Number of exec() calls that completed. */
   execCount: number;
-  /** Error message, present when status is `Failed`. */
-  error?: string;
 }
 
 /** Options for filtering session listings. */


### PR DESCRIPTION
…error

These enum values and the error field on SandboxDetails were never producible — no ledger event path exists to derive them. Sandboxes that fail to start never emit sandbox_created, and close() emits sandbox_closed in a finally block so all completed sessions land as Completed regardless of error.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
