### PR TITLE
feat(@drej/agent): fix extension_ui_request stall bug + add auto-retr…

### DIFF
--- a/.changeset/agent-reliability.md
+++ b/.changeset/agent-reliability.md
@@ -1,0 +1,13 @@
+---
+"@drej/agent": patch
+---
+
+Fix extension_ui_request bug and add auto-retry API
+
+- **Bug fix**: `extension_ui_request` events from Pi extensions were silently dropped by the bridge. Dialog requests (select/confirm/input/editor) now receive an immediate `cancelled` response so Pi never stalls indefinitely. All extension UI events are forwarded through the stream as a new `extension_ui` AgentEvent.
+
+- **New**: `agent.setAutoRetry(enabled)` — enable or disable Pi's built-in exponential-backoff retry on transient errors (429, 5xx). On by default (3 attempts, 2 s / 4 s / 8 s).
+
+- **New**: `agent.abortRetry()` — abort an in-progress retry immediately.
+
+- **New events**: `auto_retry_start` and `auto_retry_end` are now forwarded through the AgentStream with full context (attempt, maxAttempts, delayMs, errorMessage, finalError).

--- a/apps/docs/content/docs/agent/api-reference/agent.mdx
+++ b/apps/docs/content/docs/agent/api-reference/agent.mdx
@@ -230,6 +230,44 @@ Cycle Pi's thinking level. Returns `null` if the current model doesn't support t
 
 ---
 
+## Reliability
+
+### agent.setAutoRetry()
+
+```ts
+async setAutoRetry(enabled: boolean): Promise<void>
+```
+
+Enable or disable Pi's automatic retry on transient errors (429, 500, 502, 503, 504). Auto-retry is **on by default**: 3 attempts with exponential backoff (2 s / 4 s / 8 s).
+
+Disable it when you want to handle errors yourself by observing `auto_retry_start` and `auto_retry_end` events in the stream:
+
+```ts
+await agent.setAutoRetry(false);
+
+for await (const ev of agent.prompt("Run the test suite.")) {
+  if (ev.type === "text") process.stdout.write(ev.text);
+  if (ev.type === "auto_retry_start") {
+    console.error(
+      `[retry] attempt ${ev.attempt}/${ev.maxAttempts} in ${ev.delayMs}ms — ${ev.errorMessage}`,
+    );
+  }
+  if (ev.type === "auto_retry_end" && !ev.success) {
+    console.error(`[retry] failed after ${ev.attempt} attempts: ${ev.finalError}`);
+  }
+}
+```
+
+### agent.abortRetry()
+
+```ts
+async abortRetry(): Promise<void>
+```
+
+Abort an in-progress auto-retry immediately. Pi stops waiting and fails the current operation, emitting `auto_retry_end` with `success: false`.
+
+---
+
 ## Context management
 
 ### agent.setAutoCompaction()
@@ -421,7 +459,16 @@ type AgentEvent =
   | { type: "text"; text: string }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool_update"; toolCallId: string; toolName: string; partialResult: unknown }
-  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean };
+  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: "extension_ui"; method: string; params: unknown; isDialog: boolean; requestId?: string }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 ```
 
 See [Streaming & tool events](/docs/agent/getting-started/streaming) for usage examples.

--- a/apps/docs/content/docs/agent/getting-started/streaming.mdx
+++ b/apps/docs/content/docs/agent/getting-started/streaming.mdx
@@ -12,15 +12,27 @@ type AgentEvent =
   | { type: "text"; text: string }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool_update"; toolCallId: string; toolName: string; partialResult: unknown }
-  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean };
+  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: "extension_ui"; method: string; params: unknown; isDialog: boolean; requestId?: string }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 ```
 
-| Event         | When it fires                                                    |
-| ------------- | ---------------------------------------------------------------- |
-| `text`        | Pi is writing a text chunk                                       |
-| `tool_start`  | Pi has invoked a tool (e.g. `bash`, `write_file`)                |
-| `tool_update` | Partial output from a long-running tool                          |
-| `tool_end`    | Tool completed — includes the full result and whether it errored |
+| Event              | When it fires                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `text`             | Pi is writing a text chunk                                                                   |
+| `tool_start`       | Pi has invoked a tool (e.g. `bash`, `write_file`)                                            |
+| `tool_update`      | Partial output from a long-running tool                                                      |
+| `tool_end`         | Tool completed — includes the full result and whether it errored                             |
+| `extension_ui`     | A Pi extension requested UI interaction (dialog auto-cancelled; forwarded for observability) |
+| `auto_retry_start` | Pi is retrying after a transient error (429, 5xx)                                            |
+| `auto_retry_end`   | Retry sequence completed — `success` indicates whether it recovered                          |
 
 ## Text-only with textOnly()
 

--- a/examples/pi-agent/index.ts
+++ b/examples/pi-agent/index.ts
@@ -6,6 +6,7 @@
  *   setModel, cycleModel, setThinkingLevel, cycleThinkingLevel
  *   setAutoCompaction, compact
  *   clone, fork
+ *   setAutoRetry, abortRetry
  *   setEnv, getLogs
  *   sandbox.exec, sandbox.writeFile, sandbox.readFile
  *
@@ -189,8 +190,35 @@ try {
   }
   console.log("\n");
 
-  // ── 13. getLogs ───────────────────────────────────────────────────────────────
-  section("13. getLogs — bridge ring-buffer (last 5 entries)");
+  // ── 13. setAutoRetry — toggle Pi's built-in transient-error retry ────────────
+  // Auto-retry is ON by default (3 attempts, 2s/4s/8s exponential backoff).
+  // Disable it when you want to handle transient failures yourself via events.
+  section("13. setAutoRetry — toggle transient-error retry");
+  await agent.setAutoRetry(false);
+  console.log("setAutoRetry(false) → ok (retry disabled)");
+  await agent.setAutoRetry(true);
+  console.log("setAutoRetry(true)  → ok (retry re-enabled)\n");
+
+  // To observe retry events, iterate the raw AgentStream:
+  // (We can't force a transient error here, so we just show the pattern.)
+  console.log("Retry event pattern (fires automatically on 429/5xx):");
+  console.log(
+    "  { type: 'auto_retry_start', attempt: 1, maxAttempts: 3, delayMs: 2000, errorMessage: '...' }",
+  );
+  console.log("  { type: 'auto_retry_end',   success: true, attempt: 1 }");
+  console.log(
+    "\nTo observe live, iterate agent.prompt() and switch on ev.type === 'auto_retry_start'.\n",
+  );
+
+  // ── 14. abortRetry — cancel an in-progress retry ─────────────────────────────
+  // abortRetry() is a no-op if no retry is currently pending.
+  // In production use it to let users cancel a stuck retry immediately.
+  section("14. abortRetry — cancel in-progress retry (no-op if idle)");
+  await agent.abortRetry();
+  console.log("abortRetry() → ok\n");
+
+  // ── 15. getLogs ───────────────────────────────────────────────────────────────
+  section("15. getLogs — bridge ring-buffer (last 5 entries)");
   const logs = await agent.getLogs();
   const logLines = logs.trim().split("\n");
   console.log(`${logLines.length} log entries total. Last 5:`);

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -113,7 +113,16 @@ type AgentEvent =
   | { type: "text"; text: string }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool_update"; toolCallId: string; toolName: string; partialResult: unknown }
-  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean };
+  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: "extension_ui"; method: string; params: unknown; isDialog: boolean; requestId?: string }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 ```
 
 Use `textOnly()` to filter to just the text chunks (equivalent to the old `PromptStream` behavior):
@@ -286,6 +295,22 @@ Enable or disable Pi's automatic context compaction.
 #### `agent.compact(customInstructions?)`
 
 Manually trigger Pi's context compaction. Returns `{ tokensBefore, estimatedTokensAfter }`.
+
+---
+
+### Reliability
+
+#### `agent.setAutoRetry(enabled)`
+
+Enable or disable Pi's automatic retry on transient errors (429, 500, 502, 503, 504). Auto-retry is **on by default**: 3 attempts with exponential backoff (2 s / 4 s / 8 s). Disable it when you want to handle failures yourself via `auto_retry_start` / `auto_retry_end` events.
+
+```ts
+await agent.setAutoRetry(false); // take full control
+```
+
+#### `agent.abortRetry()`
+
+Abort an in-progress auto-retry immediately. Pi fails the current operation and emits `auto_retry_end` with `success: false`.
 
 ---
 

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -211,6 +211,38 @@ function handleLine(line) {
     return;
   }
 
+  // Extension UI requests from Pi extensions.
+  // Dialog methods (select/confirm/input/editor) block Pi waiting for extension_ui_response.
+  // We auto-cancel them immediately so Pi never stalls — even when there is no active prompt.
+  // Fire-and-forget methods need no response; we just forward them.
+  if (ev.type === "extension_ui_request") {
+    var DIALOG_METHODS = ["select", "confirm", "input", "editor"];
+    var isDialog = DIALOG_METHODS.indexOf(ev.method) !== -1;
+    var uiParams = {};
+    Object.keys(ev).forEach(function(k) { if (k !== "type" && k !== "id") uiParams[k] = ev[k]; });
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "extension_ui", method: ev.method, params: uiParams, isDialog: isDialog, requestId: isDialog ? ev.id : undefined }) + "\\n\\n");
+    }
+    if (isDialog && ev.id) {
+      rpc({ type: "extension_ui_response", id: ev.id, cancelled: true });
+    }
+    return;
+  }
+
+  if (ev.type === "auto_retry_start") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "auto_retry_start", attempt: ev.attempt, maxAttempts: ev.maxAttempts, delayMs: ev.delayMs, errorMessage: ev.errorMessage || "" }) + "\\n\\n");
+    }
+    return;
+  }
+
+  if (ev.type === "auto_retry_end") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "auto_retry_end", success: !!ev.success, attempt: ev.attempt, finalError: ev.finalError }) + "\\n\\n");
+    }
+    return;
+  }
+
   var item = state.active;
   if (!item) return;
 
@@ -365,6 +397,14 @@ http.createServer(function(req, res) {
         rpcWithAck({ id: "sac" + Date.now(), type: "set_auto_compaction", enabled: !!data.enabled }, res);
         return;
 
+      case "/set-auto-retry":
+        rpcWithAck({ id: "sar" + Date.now(), type: "set_auto_retry", enabled: !!data.enabled }, res);
+        return;
+
+      case "/abort-retry":
+        rpcWithAck({ id: "ar" + Date.now(), type: "abort_retry" }, res);
+        return;
+
       case "/reload-env":
         // Merge any inline env the host sent, then restart Pi so it picks up the new env file.
         if (data.env && typeof data.env === "object") Object.assign(process.env, data.env);
@@ -505,6 +545,14 @@ export class PiAdapter {
 
   async setAutoCompaction(enabled: boolean): Promise<void> {
     await rpcPost(this.bridgeUrl, "/set-auto-compaction", { enabled });
+  }
+
+  async setAutoRetry(enabled: boolean): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/set-auto-retry", { enabled });
+  }
+
+  async abortRetry(): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/abort-retry");
   }
 
   // --- commands that return data ---

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -296,6 +296,24 @@ export class Agent {
     return this._adapter.setAutoCompaction(enabled);
   }
 
+  /**
+   * Enable or disable Pi's automatic retry on transient errors (429, 500, 502, 503, 504).
+   * Auto-retry is ON by default: 3 attempts with exponential backoff (2 s / 4 s / 8 s).
+   * Disable it when you want to handle errors yourself via `auto_retry_start`/`auto_retry_end`
+   * events in the stream.
+   */
+  async setAutoRetry(enabled: boolean): Promise<void> {
+    return this._adapter.setAutoRetry(enabled);
+  }
+
+  /**
+   * Abort an in-progress auto-retry immediately. Pi stops waiting and fails the current
+   * operation, emitting `auto_retry_end` with `success: false`.
+   */
+  async abortRetry(): Promise<void> {
+    return this._adapter.abortRetry();
+  }
+
   // --- commands that return data ---
 
   /**

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -5,12 +5,37 @@
  * - `tool_start` — Pi started executing a tool (bash, file write, etc.)
  * - `tool_update` — streaming progress from an in-flight tool execution
  * - `tool_end` — a tool finished; `result` holds its output, `isError` whether it failed
+ * - `extension_ui` — a Pi extension requested UI interaction; dialog requests are
+ *   auto-cancelled by the bridge so Pi never stalls, but the event is forwarded so
+ *   callers can observe what was requested
+ * - `auto_retry_start` — Pi is about to retry after a transient error (429, 5xx)
+ * - `auto_retry_end` — Pi's retry sequence completed (success or exhausted)
  */
 export type AgentEvent =
   | { type: "text"; text: string }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool_update"; toolCallId: string; toolName: string; partialResult: unknown }
-  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean };
+  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | {
+      type: "extension_ui";
+      method: string;
+      params: unknown;
+      isDialog: boolean;
+      requestId?: string;
+    }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | {
+      type: "auto_retry_end";
+      success: boolean;
+      attempt: number;
+      finalError?: string;
+    };
 
 /**
  * Async iterable of structured agent events. Returned by `Agent.prompt()` and `Agent.bash()`.


### PR DESCRIPTION
…y API

- Fix: extension_ui_request events from Pi extensions were silently dropped. Dialog methods (select/confirm/input/editor) now receive an immediate cancelled response so Pi never stalls. Auto-cancel is unconditional — it fires even when no prompt is active, since Pi can emit these outside of prompts. All extension UI events forwarded as new `extension_ui` AgentEvent.

- New: agent.setAutoRetry(enabled) — toggle Pi's built-in exponential-backoff retry for transient errors (429/5xx). On by default (3 attempts, 2s/4s/8s).

- New: agent.abortRetry() — abort an in-progress retry immediately.

- New events: auto_retry_start and auto_retry_end now forwarded through the AgentStream with full context (attempt, maxAttempts, delayMs, errorMessage, finalError).

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
