### PR TITLE
feat(@drej/agent): complete Pi RPC coverage — 11 new events + 9 new c…

### DIFF
--- a/.changeset/agent-full-rpc.md
+++ b/.changeset/agent-full-rpc.md
@@ -1,0 +1,20 @@
+---
+"@drej/agent": minor
+---
+
+Complete Pi RPC coverage: forward all Pi stdout events and implement all remaining RPC commands.
+
+**New `AgentEvent` variants (11):** `agent_start`, `agent_end`, `turn_start`, `turn_end`, `message_start`, `message_update` (with `delta` field renaming Pi's `assistantMessageEvent`), `message_end`, `queue_update`, `compaction_start`, `compaction_end`, `extension_error`.
+
+**New `Agent` methods (9):**
+- `abortBash()` — stop a running bash command without cancelling the whole prompt
+- `getSessionStats()` — token usage, cost, and message counts (`SessionStats`)
+- `getLastAssistantText()` — retrieve the last Pi response without iterating a stream
+- `getForkMessages()` — list fork entry points in the current session
+- `getCommands()` — introspect Pi slash commands, skills, and prompt templates (`PiSlashCommand[]`)
+- `setSessionName(name)` — set a display name for the current session
+- `setSteeringMode(mode)` — control how queued steers are applied (`"all" | "one-at-a-time"`)
+- `setFollowUpMode(mode)` — control how queued follow-ups are sent (`"all" | "one-at-a-time"`)
+- `exportHtml(outputPath?)` — export an HTML transcript to the sandbox filesystem
+
+**New exported types:** `SessionStats`, `PiSlashCommand`.

--- a/apps/docs/content/docs/agent/api-reference/agent.mdx
+++ b/apps/docs/content/docs/agent/api-reference/agent.mdx
@@ -266,6 +266,115 @@ async abortRetry(): Promise<void>
 
 Abort an in-progress auto-retry immediately. Pi stops waiting and fails the current operation, emitting `auto_retry_end` with `success: false`.
 
+### agent.abortBash()
+
+```ts
+async abortBash(): Promise<void>
+```
+
+Abort a currently-executing bash command without cancelling the whole prompt. No-op when no bash command is running.
+
+---
+
+## Session inspection
+
+### agent.getSessionStats()
+
+```ts
+async getSessionStats(): Promise<SessionStats>
+```
+
+Retrieve token usage, cost, and message counts for the current session.
+
+```ts
+const stats = await agent.getSessionStats();
+console.log(`tokens: ${stats.tokens.total}, cost: $${stats.cost.toFixed(6)}`);
+if (stats.contextUsage) {
+  console.log(`context: ${stats.contextUsage.percent.toFixed(1)}% full`);
+}
+```
+
+See [SessionStats](#sessionstats) for the full type.
+
+### agent.getLastAssistantText()
+
+```ts
+async getLastAssistantText(): Promise<string | null>
+```
+
+Retrieve the text of Pi's most recent assistant response without needing to iterate the stream. Returns `null` if Pi hasn't responded yet in the current session.
+
+### agent.getForkMessages()
+
+```ts
+async getForkMessages(): Promise<{ entryId: string; text: string }[]>
+```
+
+List the fork entry points available in the current session. Each entry has `entryId` (suitable for passing to `fork()`) and `text` (the message content at that point).
+
+```ts
+const points = await agent.getForkMessages();
+for (const p of points) {
+  console.log(`${p.entryId}: "${p.text.slice(0, 60)}"`);
+}
+```
+
+### agent.getCommands()
+
+```ts
+async getCommands(): Promise<PiSlashCommand[]>
+```
+
+List Pi's available slash commands, including extensions, prompt templates, and skills. Returns `PiSlashCommand[]`.
+
+```ts
+const cmds = await agent.getCommands();
+for (const cmd of cmds) {
+  console.log(`/${cmd.name} [${cmd.source}]${cmd.description ? ` — ${cmd.description}` : ""}`);
+}
+```
+
+### agent.setSessionName()
+
+```ts
+async setSessionName(name: string): Promise<void>
+```
+
+Set a display name for the current Pi session.
+
+### agent.exportHtml()
+
+```ts
+async exportHtml(outputPath?: string): Promise<{ path: string }>
+```
+
+Export a static HTML transcript of the current session to the sandbox filesystem. Returns the container path of the generated file. Use `agent.sandbox.readFile(path)` to retrieve the contents.
+
+```ts
+const { path } = await agent.exportHtml();
+const html = await agent.sandbox.readFile(path);
+```
+
+---
+
+## Advanced control
+
+### agent.setSteeringMode()
+
+```ts
+async setSteeringMode(mode: "all" | "one-at-a-time"): Promise<void>
+```
+
+Control how Pi processes queued steering messages. `"all"` applies all queued steers at once; `"one-at-a-time"` applies them sequentially between turns.
+
+### agent.setFollowUpMode()
+
+```ts
+async setFollowUpMode(mode: "all" | "one-at-a-time"): Promise<void>
+```
+
+Control how Pi processes queued follow-up messages. `"all"` sends all queued follow-ups at once; `"one-at-a-time"` sends them sequentially.
+
 ---
 
 ## Context management
@@ -468,7 +577,24 @@ type AgentEvent =
       delayMs: number;
       errorMessage: string;
     }
-  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+  | { type: "agent_start" }
+  | { type: "agent_end"; messages: unknown[] }
+  | { type: "turn_start"; turnIndex: number; timestamp: number }
+  | { type: "turn_end"; turnIndex: number; message: unknown; toolResults: unknown[] }
+  | { type: "message_start"; message: unknown }
+  | { type: "message_update"; message: unknown; delta: unknown }
+  | { type: "message_end"; message: unknown }
+  | { type: "queue_update"; steering: string[]; followUp: string[] }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+  | {
+      type: "compaction_end";
+      reason: string;
+      result: object | null;
+      aborted: boolean;
+      willRetry: boolean;
+    }
+  | { type: "extension_error"; extensionPath: string; event: string; error: string };
 ```
 
 See [Streaming & tool events](/docs/agent/getting-started/streaming) for usage examples.
@@ -490,6 +616,50 @@ for await (const chunk of textOnly(agent.prompt("Hello"))) {
   process.stdout.write(chunk);
 }
 ```
+
+---
+
+## SessionStats
+
+```ts
+import type { SessionStats } from "@drej/agent";
+```
+
+Returned by `agent.getSessionStats()`.
+
+| Field               | Type      | Description                                         |
+| ------------------- | --------- | --------------------------------------------------- |
+| `sessionId`         | `string`  | Pi's internal session identifier                    |
+| `sessionFile`       | `string?` | Path to the session file on disk                    |
+| `userMessages`      | `number`  | Number of user turns                                |
+| `assistantMessages` | `number`  | Number of assistant turns                           |
+| `toolCalls`         | `number`  | Total tool calls made                               |
+| `toolResults`       | `number`  | Total tool results received                         |
+| `totalMessages`     | `number`  | Sum of all messages                                 |
+| `tokens.input`      | `number`  | Input tokens consumed                               |
+| `tokens.output`     | `number`  | Output tokens generated                             |
+| `tokens.cacheRead`  | `number`  | Tokens read from prompt cache                       |
+| `tokens.cacheWrite` | `number`  | Tokens written to prompt cache                      |
+| `tokens.total`      | `number`  | Total tokens (all categories)                       |
+| `cost`              | `number`  | Estimated cost in USD                               |
+| `contextUsage`      | `object?` | `{ tokens, contextWindow, percent }` — context fill |
+
+---
+
+## PiSlashCommand
+
+```ts
+import type { PiSlashCommand } from "@drej/agent";
+```
+
+Returned by `agent.getCommands()`.
+
+| Field         | Type                                 | Description                                      |
+| ------------- | ------------------------------------ | ------------------------------------------------ |
+| `name`        | `string`                             | Invokable command name (without the leading `/`) |
+| `description` | `string?`                            | Human-readable description                       |
+| `source`      | `"extension" \| "prompt" \| "skill"` | Where the command comes from                     |
+| `sourceInfo`  | `unknown`                            | Metadata about the owning resource               |
 
 ---
 

--- a/apps/docs/content/docs/agent/getting-started/index.mdx
+++ b/apps/docs/content/docs/agent/getting-started/index.mdx
@@ -22,6 +22,16 @@ description: Load an agent spec, send a prompt, and understand snapshotting, wor
   <Card
     href="/docs/agent/getting-started/streaming"
     title="Streaming & tool events"
-    description="Observe Pi's text output and tool calls in real time using AgentStream and AgentEvent."
+    description="Observe Pi's text output, tool calls, and lifecycle events in real time."
+  />
+  <Card
+    href="/docs/agent/getting-started/reliability"
+    title="Reliability & error recovery"
+    description="Handle transient API errors with auto-retry, observe retry events, and abort mid-flight bash commands."
+  />
+  <Card
+    href="/docs/agent/getting-started/session-inspection"
+    title="Session inspection & control"
+    description="Inspect token usage, retrieve session history, list available commands, and export HTML transcripts."
   />
 </Cards>

--- a/apps/docs/content/docs/agent/getting-started/reliability.mdx
+++ b/apps/docs/content/docs/agent/getting-started/reliability.mdx
@@ -1,0 +1,105 @@
+---
+title: Reliability & error recovery
+description: Handle transient API errors with auto-retry, observe retry events, and abort mid-flight bash commands.
+---
+
+Pi has built-in transient-error recovery that fires automatically when the AI provider returns a 429 (rate limit) or 5xx (server error). The `@drej/agent` bridge surfaces this as observable events so you can build responsive UIs without writing retry logic yourself.
+
+## Auto-retry
+
+Auto-retry is **on by default**: Pi retries up to 3 times with exponential backoff (2 s → 4 s → 8 s). You don't need to configure anything for it to work.
+
+When a transient error occurs mid-prompt, Pi pauses internally and emits `auto_retry_start`. After the delay it retries, and on completion emits `auto_retry_end`.
+
+```ts
+for await (const ev of agent.prompt("Run the full test suite.")) {
+  switch (ev.type) {
+    case "text":
+      process.stdout.write(ev.text);
+      break;
+
+    case "auto_retry_start":
+      console.warn(
+        `[retry] attempt ${ev.attempt}/${ev.maxAttempts} — ` +
+          `waiting ${ev.delayMs / 1000}s after: ${ev.errorMessage}`,
+      );
+      break;
+
+    case "auto_retry_end":
+      if (!ev.success) {
+        console.error(`[retry] failed after ${ev.attempt} attempts: ${ev.finalError}`);
+      }
+      break;
+  }
+}
+```
+
+`auto_retry_start` and `auto_retry_end` are part of the `AgentEvent` discriminated union — they're always present in the stream, so no extra setup is required.
+
+## Disabling auto-retry
+
+If you want full control over when retries happen — for example to gate them on user confirmation — disable auto-retry and handle failures yourself:
+
+```ts
+await agent.setAutoRetry(false);
+
+for await (const ev of agent.prompt("Deploy the application.")) {
+  if (ev.type === "text") process.stdout.write(ev.text);
+
+  if (ev.type === "auto_retry_end" && !ev.success) {
+    // auto-retry is off, so this fires immediately on the first failure
+    const shouldRetry = await askUser("API error. Retry?");
+    if (shouldRetry) {
+      await agent.setAutoRetry(true); // re-enable for the next prompt
+    }
+  }
+}
+```
+
+Re-enable it at any time with `agent.setAutoRetry(true)`. The setting persists across prompts until changed.
+
+## Aborting a retry in progress
+
+If a retry is currently waiting (counting down the backoff delay), you can cancel it immediately:
+
+```ts
+// User clicks "Cancel retry"
+await agent.abortRetry();
+```
+
+Pi fails the current operation immediately and emits `auto_retry_end` with `success: false`. No-op when no retry is pending.
+
+## Aborting a bash command
+
+`agent.abortBash()` stops a currently-executing bash command without cancelling the whole prompt. Pi receives the abort, the bash result is marked as errored, and Pi continues with whatever it would do next (typically reporting the failure to the user):
+
+```ts
+// Show a stop button while Pi is running bash
+const stream = agent.prompt("Run the build.");
+let bashRunning = false;
+
+for await (const ev of stream) {
+  if (ev.type === "tool_start" && ev.toolName === "bash") {
+    bashRunning = true;
+    showStopButton(() => agent.abortBash());
+  }
+  if (ev.type === "tool_end" && ev.toolName === "bash") {
+    bashRunning = false;
+    hideStopButton();
+  }
+  if (ev.type === "text") process.stdout.write(ev.text);
+}
+```
+
+`abortBash()` is a no-op when no bash command is running — safe to call speculatively.
+
+## Summary
+
+| Method / Event        | What it does                                                   |
+| --------------------- | -------------------------------------------------------------- |
+| `setAutoRetry(true)`  | Enable auto-retry on transient errors (default)                |
+| `setAutoRetry(false)` | Disable — handle `auto_retry_end` failures manually            |
+| `abortRetry()`        | Cancel the current retry countdown; Pi fails immediately       |
+| `abortBash()`         | Stop the running bash command; prompt continues                |
+| `auto_retry_start`    | Fires when a retry attempt is about to begin                   |
+| `auto_retry_end`      | Fires when the retry sequence completes (success or exhausted) |

--- a/apps/docs/content/docs/agent/getting-started/session-inspection.mdx
+++ b/apps/docs/content/docs/agent/getting-started/session-inspection.mdx
@@ -1,0 +1,151 @@
+---
+title: Session inspection & control
+description: Inspect token usage, retrieve session history, list available commands, and control how Pi processes queued messages.
+---
+
+The agent SDK exposes a set of methods for inspecting the current Pi session without streaming a new prompt. These are useful for building dashboards, debugging token usage, navigating session history, and managing how Pi handles queued messages.
+
+## Token usage and cost
+
+`agent.getSessionStats()` returns a snapshot of the current session's resource consumption:
+
+```ts
+const stats = await agent.getSessionStats();
+
+console.log(`Session:       ${stats.sessionId}`);
+console.log(`Messages:      ${stats.userMessages} user / ${stats.assistantMessages} assistant`);
+console.log(`Tool calls:    ${stats.toolCalls}`);
+console.log(`Tokens:        ${stats.tokens.input} in / ${stats.tokens.output} out`);
+console.log(`Cache:         ${stats.tokens.cacheRead} read / ${stats.tokens.cacheWrite} write`);
+console.log(`Cost:          $${stats.cost.toFixed(6)}`);
+
+if (stats.contextUsage) {
+  const { tokens, contextWindow, percent } = stats.contextUsage;
+  console.log(`Context:       ${percent.toFixed(1)}% (${tokens} / ${contextWindow})`);
+}
+```
+
+This is a synchronous read from Pi — it doesn't start a new prompt. Call it after any `prompt()` completes to track cumulative usage across a long session.
+
+### Context window pressure
+
+`contextUsage.percent` tells you how full Pi's context window is. Pi will auto-compact when it approaches the limit (see [Streaming — Compaction events](/docs/agent/getting-started/streaming#compaction-events)), but you can also monitor it proactively:
+
+```ts
+const stats = await agent.getSessionStats();
+if ((stats.contextUsage?.percent ?? 0) > 80) {
+  await agent.compact(); // manual compaction before it becomes automatic
+}
+```
+
+## Retrieving the last response
+
+`agent.getLastAssistantText()` returns the text of Pi's most recent assistant message without opening a new stream:
+
+```ts
+const text = await agent.getLastAssistantText();
+if (text) {
+  console.log(`Last response: ${text.slice(0, 200)}`);
+}
+```
+
+Returns `null` if Pi has not yet responded in the current session. Useful for building "copy last response" buttons or logging the final assistant message after a long autonomous run.
+
+## Fork entry points
+
+`agent.getForkMessages()` lists the entry points in the current session that can be used as `fork()` targets:
+
+```ts
+const points = await agent.getForkMessages();
+
+for (const { entryId, text } of points) {
+  console.log(`${entryId}  "${text.slice(0, 60)}"`);
+}
+
+// Fork from a specific point
+if (points.length > 0) {
+  const { text, cancelled } = await agent.fork(points[0].entryId);
+  console.log(`Forked at: "${text.slice(0, 60)}" (cancelled: ${cancelled})`);
+}
+```
+
+Each entry corresponds to a user turn in Pi's session history. Forking creates a new session branch at that point — useful for trying alternative responses or replaying from a known state.
+
+## Available commands
+
+`agent.getCommands()` lists all slash commands Pi can understand in the current environment — including commands contributed by installed extensions, prompt templates, and skills:
+
+```ts
+const commands = await agent.getCommands();
+
+for (const cmd of commands) {
+  const source = cmd.source; // "extension" | "prompt" | "skill"
+  const desc = cmd.description ?? "(no description)";
+  console.log(`/${cmd.name} [${source}]  ${desc}`);
+}
+```
+
+This is primarily useful when building a command palette or auto-complete UI on top of the agent.
+
+## Naming sessions
+
+`agent.setSessionName()` sets a display name for the current Pi session. The name is stored as metadata in the session file — it doesn't affect the session ID or behaviour:
+
+```ts
+await agent.setSessionName(`audit-${new Date().toISOString().slice(0, 10)}`);
+```
+
+## Exporting an HTML transcript
+
+`agent.exportHtml()` generates a static HTML file containing the full session transcript and writes it to the sandbox filesystem:
+
+```ts
+const { path } = await agent.exportHtml();
+// path is a container-relative path, e.g. /root/pi-session-2024-01-15_abc123.html
+
+// Read the file from the sandbox back to the host
+const html = await agent.sandbox.readFile(path);
+
+// Write it somewhere local
+await Bun.write("./session-transcript.html", html);
+```
+
+You can optionally specify where the file should be written inside the container:
+
+```ts
+const { path } = await agent.exportHtml("/workspace/exports/session.html");
+```
+
+## Queue processing modes
+
+When `agent.followUp()` or `agent.steer()` are called while a prompt is in flight, Pi queues the message and processes it after the current turn. Two methods control how that queue is consumed.
+
+### Steering mode
+
+`agent.setSteeringMode()` controls how Pi applies queued steering messages:
+
+- `"all"` (default) — Pi applies every queued steer at once when it processes the queue
+- `"one-at-a-time"` — Pi applies steers one per turn, giving you finer control over the conversation
+
+```ts
+await agent.setSteeringMode("one-at-a-time");
+
+const stream = agent.prompt("Write a very long document.");
+setTimeout(() => agent.steer("Focus on section 3."), 1000);
+setTimeout(() => agent.steer("Now add an executive summary."), 2000);
+
+for await (const ev of stream) {
+  if (ev.type === "text") process.stdout.write(ev.text);
+  if (ev.type === "queue_update") {
+    console.log(`\n[${ev.steering.length} steers pending]`);
+  }
+}
+```
+
+### Follow-up mode
+
+`agent.setFollowUpMode()` mirrors `setSteeringMode()` but for follow-up messages queued with `agent.followUp()`:
+
+```ts
+await agent.setFollowUpMode("one-at-a-time");
+```

--- a/apps/docs/content/docs/agent/getting-started/streaming.mdx
+++ b/apps/docs/content/docs/agent/getting-started/streaming.mdx
@@ -21,18 +21,46 @@ type AgentEvent =
       delayMs: number;
       errorMessage: string;
     }
-  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+  | { type: "agent_start" }
+  | { type: "agent_end"; messages: unknown[] }
+  | { type: "turn_start"; turnIndex: number; timestamp: number }
+  | { type: "turn_end"; turnIndex: number; message: unknown; toolResults: unknown[] }
+  | { type: "message_start"; message: unknown }
+  | { type: "message_update"; message: unknown; delta: unknown }
+  | { type: "message_end"; message: unknown }
+  | { type: "queue_update"; steering: string[]; followUp: string[] }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+  | {
+      type: "compaction_end";
+      reason: string;
+      result: object | null;
+      aborted: boolean;
+      willRetry: boolean;
+    }
+  | { type: "extension_error"; extensionPath: string; event: string; error: string };
 ```
 
-| Event              | When it fires                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------------- |
-| `text`             | Pi is writing a text chunk                                                                   |
-| `tool_start`       | Pi has invoked a tool (e.g. `bash`, `write_file`)                                            |
-| `tool_update`      | Partial output from a long-running tool                                                      |
-| `tool_end`         | Tool completed — includes the full result and whether it errored                             |
-| `extension_ui`     | A Pi extension requested UI interaction (dialog auto-cancelled; forwarded for observability) |
-| `auto_retry_start` | Pi is retrying after a transient error (429, 5xx)                                            |
-| `auto_retry_end`   | Retry sequence completed — `success` indicates whether it recovered                          |
+| Event              | When it fires                                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `text`             | Pi is writing a text chunk                                                                                     |
+| `tool_start`       | Pi has invoked a tool (e.g. `bash`, `write_file`)                                                              |
+| `tool_update`      | Partial output from a long-running tool                                                                        |
+| `tool_end`         | Tool completed — includes the full result and whether it errored                                               |
+| `extension_ui`     | A Pi extension requested UI interaction (dialog auto-cancelled; forwarded for observability)                   |
+| `auto_retry_start` | Pi is retrying after a transient error (429, 5xx)                                                              |
+| `auto_retry_end`   | Retry sequence completed — `success` indicates whether it recovered                                            |
+| `agent_start`      | Pi began processing the prompt                                                                                 |
+| `agent_end`        | Pi finished the full agent run (all turns complete); includes all messages                                     |
+| `turn_start`       | A new LLM turn began; includes `turnIndex` and `timestamp`                                                     |
+| `turn_end`         | A turn completed with its assistant message and tool results                                                   |
+| `message_start`    | A new assistant message began streaming                                                                        |
+| `message_update`   | Streaming delta from an in-flight message; `delta` is the raw Pi event (text, thinking, tool call delta, etc.) |
+| `message_end`      | An assistant message completed                                                                                 |
+| `queue_update`     | The steering/follow-up queue changed (e.g. after `followUp()`)                                                 |
+| `compaction_start` | Pi began compacting context (manual or automatic)                                                              |
+| `compaction_end`   | Context compaction finished; `result` has token counts, `aborted` if it was cancelled                          |
+| `extension_error`  | A Pi extension threw an error                                                                                  |
 
 ## Text-only with textOnly()
 

--- a/apps/docs/content/docs/agent/getting-started/streaming.mdx
+++ b/apps/docs/content/docs/agent/getting-started/streaming.mdx
@@ -135,3 +135,120 @@ for await (const chunk of textOnly(agent.bash("ls -la /workspace"))) {
   process.stdout.write(chunk);
 }
 ```
+
+## Lifecycle events
+
+Every `prompt()` call fires a sequence of lifecycle events around the text and tool events. These are useful for measuring per-turn latency, building progress indicators, or capturing the full structured response.
+
+```ts
+for await (const ev of agent.prompt("Refactor this module.")) {
+  switch (ev.type) {
+    case "agent_start":
+      console.time("agent");
+      break;
+
+    case "turn_start":
+      console.log(`turn ${ev.turnIndex} started at ${new Date(ev.timestamp).toISOString()}`);
+      break;
+
+    case "text":
+      process.stdout.write(ev.text);
+      break;
+
+    case "turn_end":
+      // ev.message is the full assistant message; ev.toolResults holds tool results from this turn
+      console.log(`\nturn ${ev.turnIndex} done — ${ev.toolResults.length} tool(s) used`);
+      break;
+
+    case "agent_end":
+      // ev.messages contains every message generated across all turns
+      console.timeEnd("agent");
+      console.log(`total messages in run: ${ev.messages.length}`);
+      break;
+  }
+}
+```
+
+The event order within a single turn is always:
+
+```
+agent_start
+  turn_start (turnIndex: 0)
+    message_start
+      message_update  ← repeated for each streaming delta
+      text            ← emitted alongside message_update for text deltas
+    message_end
+    tool_start / tool_update / tool_end  ← if Pi used tools
+  turn_end
+  turn_start (turnIndex: 1)  ← if Pi needed another turn
+  ...
+agent_end
+```
+
+## Observing thinking and tool-call deltas
+
+`message_update` carries the raw Pi delta in its `delta` field. In addition to `text_delta` (which the bridge also surfaces as a `text` event), it can carry thinking and tool-call deltas from models that support extended thinking:
+
+```ts
+for await (const ev of agent.prompt("Solve this step by step.")) {
+  if (ev.type === "message_update") {
+    const delta = ev.delta as { type: string; delta?: string; thinking?: string };
+    if (delta.type === "thinking_delta") {
+      process.stdout.write(`[thinking] ${delta.thinking ?? ""}`);
+    }
+    // delta.type === "text_delta" is also emitted as a "text" event — no need to handle it twice
+  }
+  if (ev.type === "text") {
+    process.stdout.write(ev.text);
+  }
+}
+```
+
+## Compaction events
+
+Auto-compaction fires between turns when Pi's context fills past a threshold. The `compaction_start` and `compaction_end` events let you surface this to the user instead of silently pausing:
+
+```ts
+for await (const ev of agent.prompt("Analyse the entire repo.")) {
+  switch (ev.type) {
+    case "text":
+      process.stdout.write(ev.text);
+      break;
+
+    case "compaction_start":
+      console.log(`\n[compacting — ${ev.reason}]`);
+      break;
+
+    case "compaction_end":
+      if (ev.result) {
+        const saved = ev.result.tokensBefore - ev.result.estimatedTokensAfter;
+        console.log(`[compaction done — freed ~${saved} tokens]`);
+      }
+      if (ev.aborted) {
+        console.warn("[compaction aborted]");
+      }
+      break;
+  }
+}
+```
+
+`reason` is one of `"manual"` (triggered by `agent.compact()`), `"threshold"` (auto, approaching context limit), or `"overflow"` (auto, context was full).
+
+## Queue events
+
+`queue_update` fires when the steering or follow-up queue changes — for example, immediately after `agent.followUp()` is called while a prompt is in flight:
+
+```ts
+const stream = agent.prompt("Write a long analysis...");
+
+setTimeout(async () => {
+  await agent.followUp("Now summarize that in one paragraph.");
+}, 1000);
+
+for await (const ev of stream) {
+  if (ev.type === "text") process.stdout.write(ev.text);
+  if (ev.type === "queue_update") {
+    console.log(`\n[queued follow-ups: ${ev.followUp.length}]`);
+  }
+}
+```

--- a/examples/pi-agent/index.ts
+++ b/examples/pi-agent/index.ts
@@ -7,6 +7,8 @@
  *   setAutoCompaction, compact
  *   clone, fork
  *   setAutoRetry, abortRetry
+ *   abortBash, getSessionStats, getLastAssistantText, getForkMessages
+ *   getCommands, setSessionName, setSteeringMode, setFollowUpMode, exportHtml
  *   setEnv, getLogs
  *   sandbox.exec, sandbox.writeFile, sandbox.readFile
  *
@@ -217,8 +219,105 @@ try {
   await agent.abortRetry();
   console.log("abortRetry() → ok\n");
 
-  // ── 15. getLogs ───────────────────────────────────────────────────────────────
-  section("15. getLogs — bridge ring-buffer (last 5 entries)");
+  // ── 15. abortBash — stop a running bash without cancelling the prompt ────────
+  // No-op when idle; useful to interrupt a long-running shell command mid-flight.
+  section("15. abortBash — stop running bash (no-op if idle)");
+  await agent.abortBash();
+  console.log("abortBash() → ok\n");
+
+  // ── 16. getSessionStats — token usage + cost ──────────────────────────────────
+  section("16. getSessionStats — token usage and cost");
+  const stats = await agent.getSessionStats();
+  console.log(`sessionId:        ${stats.sessionId}`);
+  console.log(`messages:         ${stats.userMessages} user, ${stats.assistantMessages} assistant`);
+  console.log(`toolCalls:        ${stats.toolCalls}`);
+  console.log(
+    `tokens:           ${stats.tokens.input} in, ${stats.tokens.output} out, ${stats.tokens.total} total`,
+  );
+  console.log(`cost:             $${stats.cost.toFixed(6)}`);
+  if (stats.contextUsage) {
+    console.log(
+      `contextUsage:     ${stats.contextUsage.percent.toFixed(1)}% (${stats.contextUsage.tokens}/${stats.contextUsage.contextWindow})`,
+    );
+  }
+  console.log();
+
+  // ── 17. getLastAssistantText ──────────────────────────────────────────────────
+  section("17. getLastAssistantText — last Pi response (no stream needed)");
+  const lastText = await agent.getLastAssistantText();
+  if (lastText) {
+    console.log(
+      `Last response (first 120 chars): "${lastText.slice(0, 120).replace(/\n/g, " ")}…"`,
+    );
+  } else {
+    console.log("No assistant response yet.");
+  }
+  console.log();
+
+  // ── 18. getForkMessages — list fork entry points in current session ───────────
+  section("18. getForkMessages — list fork entry points");
+  const forkMessages = await agent.getForkMessages();
+  console.log(`${forkMessages.length} fork point(s) available:`);
+  for (const m of forkMessages.slice(0, 3)) {
+    console.log(
+      `  ${m.entryId.slice(0, 12)}… "${String(m.text).slice(0, 60).replace(/\n/g, " ")}"`,
+    );
+  }
+  if (forkMessages.length > 3) console.log(`  … and ${forkMessages.length - 3} more`);
+  console.log();
+
+  // ── 19. getCommands — introspect Pi slash commands, skills, prompt templates ──
+  section("19. getCommands — available slash commands");
+  const commands = await agent.getCommands();
+  console.log(`${commands.length} command(s) available:`);
+  for (const cmd of commands.slice(0, 8)) {
+    const desc = cmd.description ? ` — ${cmd.description.slice(0, 50)}` : "";
+    console.log(`  /${cmd.name} [${cmd.source}]${desc}`);
+  }
+  if (commands.length > 8) console.log(`  … and ${commands.length - 8} more`);
+  console.log();
+
+  // ── 20. setSessionName ────────────────────────────────────────────────────────
+  section("20. setSessionName — label the current session");
+  await agent.setSessionName("pi-agent-example-run");
+  console.log('setSessionName("pi-agent-example-run") → ok');
+  const statsAfterRename = await agent.getSessionStats();
+  console.log(`sessionId: ${statsAfterRename.sessionId} (name is metadata, id unchanged)\n`);
+
+  // ── 21. setSteeringMode / setFollowUpMode ─────────────────────────────────────
+  section("21. setSteeringMode + setFollowUpMode — queue processing modes");
+  await agent.setSteeringMode("one-at-a-time");
+  console.log('setSteeringMode("one-at-a-time") → ok');
+  await agent.setSteeringMode("all");
+  console.log('setSteeringMode("all")           → ok (restored)');
+  await agent.setFollowUpMode("one-at-a-time");
+  console.log('setFollowUpMode("one-at-a-time") → ok');
+  await agent.setFollowUpMode("all");
+  console.log('setFollowUpMode("all")           → ok (restored)\n');
+
+  // ── 22. exportHtml — HTML transcript of the current session ──────────────────
+  section("22. exportHtml — write HTML transcript to sandbox");
+  const exported = await agent.exportHtml();
+  console.log(`exportHtml() → ${exported.path}`);
+  // Verify the file exists in the sandbox.
+  const { stdout: htmlSize } = await agent.sandbox.exec(
+    `wc -c < "${exported.path}" 2>/dev/null || echo 0`,
+  );
+  console.log(`file size: ${htmlSize.trim()} bytes\n`);
+
+  // ── 23. event coverage — observe all new event types in a real stream ─────────
+  // Run a short prompt and log every event type we see.
+  // This exercises agent_start, turn_start, message_start, message_update,
+  // message_end, turn_end, agent_end — all in a single short response.
+  section("23. event coverage — observe all event types in raw stream");
+  const seenTypes = new Set<string>();
+  for await (const ev of agent.prompt("Reply with exactly: 'event coverage ok'")) {
+    seenTypes.add(ev.type);
+  }
+  console.log(`Event types seen: ${[...seenTypes].sort().join(", ")}\n`);
+
+  // ── 24. getLogs ───────────────────────────────────────────────────────────────
+  section("24. getLogs — bridge ring-buffer (last 5 entries)");
   const logs = await agent.getLogs();
   const logLines = logs.trim().split("\n");
   console.log(`${logLines.length} log entries total. Last 5:`);

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -122,7 +122,24 @@ type AgentEvent =
       delayMs: number;
       errorMessage: string;
     }
-  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+  | { type: "agent_start" }
+  | { type: "agent_end"; messages: unknown[] }
+  | { type: "turn_start"; turnIndex: number; timestamp: number }
+  | { type: "turn_end"; turnIndex: number; message: unknown; toolResults: unknown[] }
+  | { type: "message_start"; message: unknown }
+  | { type: "message_update"; message: unknown; delta: unknown }
+  | { type: "message_end"; message: unknown }
+  | { type: "queue_update"; steering: string[]; followUp: string[] }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+  | {
+      type: "compaction_end";
+      reason: string;
+      result: object | null;
+      aborted: boolean;
+      willRetry: boolean;
+    }
+  | { type: "extension_error"; extensionPath: string; event: string; error: string };
 ```
 
 Use `textOnly()` to filter to just the text chunks (equivalent to the old `PromptStream` behavior):
@@ -311,6 +328,65 @@ await agent.setAutoRetry(false); // take full control
 #### `agent.abortRetry()`
 
 Abort an in-progress auto-retry immediately. Pi fails the current operation and emits `auto_retry_end` with `success: false`.
+
+#### `agent.abortBash()`
+
+Abort a currently-executing bash command without cancelling the whole prompt. No-op when no bash is running.
+
+---
+
+### Session inspection
+
+#### `agent.getSessionStats()`
+
+Retrieve token usage, cost, and message counts for the current session. Returns a `SessionStats` object.
+
+```ts
+const stats = await agent.getSessionStats();
+console.log(`${stats.tokens.total} tokens used, $${stats.cost.toFixed(6)} cost`);
+```
+
+#### `agent.getLastAssistantText()`
+
+Retrieve the text of Pi's most recent assistant response without iterating the stream. Returns `null` if Pi hasn't responded yet.
+
+#### `agent.getForkMessages()`
+
+List the fork entry points available in the current session. Each entry has `entryId` (pass to `fork()`) and `text`.
+
+#### `agent.getCommands()`
+
+List Pi's available slash commands, including extensions, prompt templates, and skills. Returns `PiSlashCommand[]`.
+
+```ts
+const cmds = await agent.getCommands();
+for (const cmd of cmds) console.log(`/${cmd.name} [${cmd.source}]`);
+```
+
+#### `agent.setSessionName(name)`
+
+Set a display name for the current Pi session.
+
+#### `agent.exportHtml(outputPath?)`
+
+Export a static HTML transcript of the session to the sandbox filesystem. Returns `{ path }` — the container path of the file. Use `agent.sandbox.readFile(path)` to retrieve it.
+
+```ts
+const { path } = await agent.exportHtml();
+const html = await agent.sandbox.readFile(path);
+```
+
+---
+
+### Advanced control
+
+#### `agent.setSteeringMode(mode)`
+
+Control how Pi processes queued steering messages: `"all"` applies all at once, `"one-at-a-time"` applies them sequentially.
+
+#### `agent.setFollowUpMode(mode)`
+
+Control how Pi processes queued follow-up messages: `"all"` sends all at once, `"one-at-a-time"` sends them sequentially.
 
 ---
 

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -6,6 +6,8 @@ import type {
   CompactResult,
   PiMessage,
   PiModel,
+  PiSlashCommand,
+  SessionStats,
   ThinkingLevel,
 } from "../types";
 
@@ -243,20 +245,79 @@ function handleLine(line) {
     return;
   }
 
-  var item = state.active;
-  if (!item) return;
+  if (ev.type === "agent_start") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "agent_start" }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "turn_start") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "turn_start", turnIndex: ev.turnIndex, timestamp: ev.timestamp }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "turn_end") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "turn_end", turnIndex: ev.turnIndex, message: ev.message, toolResults: ev.toolResults || [] }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "message_start") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "message_start", message: ev.message }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "message_end") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "message_end", message: ev.message }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "queue_update") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "queue_update", steering: ev.steering || [], followUp: ev.followUp || [] }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "compaction_start") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "compaction_start", reason: ev.reason }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "compaction_end") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "compaction_end", reason: ev.reason, result: ev.result || null, aborted: !!ev.aborted, willRetry: !!ev.willRetry }) + "\\n\\n");
+    }
+    return;
+  }
+  if (ev.type === "extension_error") {
+    if (state.active) {
+      state.active.res.write("data: " + JSON.stringify({ type: "extension_error", extensionPath: ev.extensionPath, event: ev.event, error: ev.error }) + "\\n\\n");
+    }
+    return;
+  }
 
-  // prompt: forward text_delta chunks and agent lifecycle
+  // message_update: forward the raw delta event, then also extract text_delta as a "text" event
+  // so textOnly() keeps working without changes.
   if (ev.type === "message_update") {
+    if (!state.active) return;
+    state.active.res.write("data: " + JSON.stringify({ type: "message_update", message: ev.message, delta: ev.assistantMessageEvent }) + "\\n\\n");
     var aev = ev.assistantMessageEvent || {};
     if (aev.type === "text_delta" && aev.delta) {
-      item.text += aev.delta;
-      item.res.write("data: " + JSON.stringify({ type: "text", text: aev.delta }) + "\\n\\n");
+      state.active.text += aev.delta;
+      state.active.res.write("data: " + JSON.stringify({ type: "text", text: aev.delta }) + "\\n\\n");
     }
-  } else if (ev.type === "agent_end") {
-    log("agent_end: " + item.text.length + " chars in " + (Date.now() - item.t0) + "ms");
-    item.res.write("data: [DONE]\\n\\n");
-    item.res.end();
+    return;
+  }
+  if (ev.type === "agent_end") {
+    if (!state.active) return;
+    state.active.res.write("data: " + JSON.stringify({ type: "agent_end", messages: ev.messages || [] }) + "\\n\\n");
+    log("agent_end: " + state.active.text.length + " chars in " + (Date.now() - state.active.t0) + "ms");
+    state.active.res.write("data: [DONE]\\n\\n");
+    state.active.res.end();
     state.active = null;
     flush();
   }
@@ -403,6 +464,42 @@ http.createServer(function(req, res) {
 
       case "/abort-retry":
         rpcWithAck({ id: "ar" + Date.now(), type: "abort_retry" }, res);
+        return;
+
+      case "/abort-bash":
+        rpcWithAck({ id: "ab" + Date.now(), type: "abort_bash" }, res);
+        return;
+
+      case "/get-session-stats":
+        rpcWithAck({ id: "gss" + Date.now(), type: "get_session_stats" }, res);
+        return;
+
+      case "/get-last-assistant-text":
+        rpcWithAck({ id: "glat" + Date.now(), type: "get_last_assistant_text" }, res);
+        return;
+
+      case "/get-fork-messages":
+        rpcWithAck({ id: "gfm" + Date.now(), type: "get_fork_messages" }, res);
+        return;
+
+      case "/get-commands":
+        rpcWithAck({ id: "gc" + Date.now(), type: "get_commands" }, res);
+        return;
+
+      case "/set-session-name":
+        rpcWithAck({ id: "ssn" + Date.now(), type: "set_session_name", name: data.name }, res);
+        return;
+
+      case "/set-steering-mode":
+        rpcWithAck({ id: "ssm" + Date.now(), type: "set_steering_mode", mode: data.mode }, res);
+        return;
+
+      case "/set-follow-up-mode":
+        rpcWithAck({ id: "sfum" + Date.now(), type: "set_follow_up_mode", mode: data.mode }, res);
+        return;
+
+      case "/export-html":
+        rpcWithAck({ id: "eh" + Date.now(), type: "export_html", outputPath: data.outputPath }, res);
         return;
 
       case "/reload-env":
@@ -553,6 +650,52 @@ export class PiAdapter {
 
   async abortRetry(): Promise<void> {
     await rpcPost(this.bridgeUrl, "/abort-retry");
+  }
+
+  async abortBash(): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/abort-bash");
+  }
+
+  async getSessionStats(): Promise<SessionStats> {
+    return rpcPost<SessionStats>(this.bridgeUrl, "/get-session-stats");
+  }
+
+  async getLastAssistantText(): Promise<string | null> {
+    const r = await rpcPost<{ text: string | null }>(this.bridgeUrl, "/get-last-assistant-text");
+    return r.text;
+  }
+
+  async getForkMessages(): Promise<{ entryId: string; text: string }[]> {
+    const r = await rpcPost<{ messages: { entryId: string; text: string }[] }>(
+      this.bridgeUrl,
+      "/get-fork-messages",
+    );
+    return r.messages;
+  }
+
+  async getCommands(): Promise<PiSlashCommand[]> {
+    const r = await rpcPost<{ commands: PiSlashCommand[] }>(this.bridgeUrl, "/get-commands");
+    return r.commands;
+  }
+
+  async setSessionName(name: string): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/set-session-name", { name });
+  }
+
+  async setSteeringMode(mode: "all" | "one-at-a-time"): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/set-steering-mode", { mode });
+  }
+
+  async setFollowUpMode(mode: "all" | "one-at-a-time"): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/set-follow-up-mode", { mode });
+  }
+
+  async exportHtml(outputPath?: string): Promise<{ path: string }> {
+    return rpcPost<{ path: string }>(
+      this.bridgeUrl,
+      "/export-html",
+      outputPath !== undefined ? { outputPath } : {},
+    );
   }
 
   // --- commands that return data ---

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -10,7 +10,15 @@ import {
   snapshotsPath,
   type AgentSnapshotRecord,
 } from "./snapshots";
-import type { AgentStream, CompactResult, PiMessage, PiModel, ThinkingLevel } from "./types";
+import type {
+  AgentStream,
+  CompactResult,
+  PiMessage,
+  PiModel,
+  PiSlashCommand,
+  SessionStats,
+  ThinkingLevel,
+} from "./types";
 
 function elapsed(t: number) {
   return `${Date.now() - t}ms`;
@@ -312,6 +320,64 @@ export class Agent {
    */
   async abortRetry(): Promise<void> {
     return this._adapter.abortRetry();
+  }
+
+  /** Abort a currently-executing bash command without cancelling the whole prompt. */
+  async abortBash(): Promise<void> {
+    return this._adapter.abortBash();
+  }
+
+  /** Retrieve token usage, cost, and message counts for the current session. */
+  async getSessionStats(): Promise<SessionStats> {
+    return this._adapter.getSessionStats();
+  }
+
+  /** Retrieve the text of Pi's most recent assistant response. Returns `null` if none yet. */
+  async getLastAssistantText(): Promise<string | null> {
+    return this._adapter.getLastAssistantText();
+  }
+
+  /**
+   * List the fork entry points available in the current session.
+   * Each entry has `entryId` (pass to `fork()`) and `text` (the message at that point).
+   */
+  async getForkMessages(): Promise<{ entryId: string; text: string }[]> {
+    return this._adapter.getForkMessages();
+  }
+
+  /** List Pi's available slash commands, including extensions, prompt templates, and skills. */
+  async getCommands(): Promise<PiSlashCommand[]> {
+    return this._adapter.getCommands();
+  }
+
+  /** Set a display name for the current Pi session. */
+  async setSessionName(name: string): Promise<void> {
+    return this._adapter.setSessionName(name);
+  }
+
+  /**
+   * Control how Pi processes queued steering messages.
+   * `"all"` applies all queued steers at once; `"one-at-a-time"` applies them sequentially.
+   */
+  async setSteeringMode(mode: "all" | "one-at-a-time"): Promise<void> {
+    return this._adapter.setSteeringMode(mode);
+  }
+
+  /**
+   * Control how Pi processes queued follow-up messages.
+   * `"all"` sends all queued follow-ups at once; `"one-at-a-time"` sends them sequentially.
+   */
+  async setFollowUpMode(mode: "all" | "one-at-a-time"): Promise<void> {
+    return this._adapter.setFollowUpMode(mode);
+  }
+
+  /**
+   * Export a static HTML transcript of the current session to the sandbox filesystem.
+   * Returns the container path of the generated file — use `agent.sandbox.readFile(path)`
+   * to retrieve it.
+   */
+  async exportHtml(outputPath?: string): Promise<{ path: string }> {
+    return this._adapter.exportHtml(outputPath);
   }
 
   // --- commands that return data ---

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -9,6 +9,8 @@ export type {
   ThinkingLevel,
   PiMessage,
   CompactResult,
+  SessionStats,
+  PiSlashCommand,
 } from "./types";
 export { textOnly } from "./types";
 export type { AgentSnapshotRecord } from "./snapshots";

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -10,6 +10,18 @@
  *   callers can observe what was requested
  * - `auto_retry_start` — Pi is about to retry after a transient error (429, 5xx)
  * - `auto_retry_end` — Pi's retry sequence completed (success or exhausted)
+ * - `agent_start` — Pi began processing the prompt
+ * - `agent_end` — Pi finished the full agent run (all turns complete)
+ * - `turn_start` — a new LLM turn began
+ * - `turn_end` — a turn completed with its assistant message and tool results
+ * - `message_start` — a new assistant message began streaming
+ * - `message_update` — streaming delta from an in-flight message; `delta` is the raw
+ *   Pi assistantMessageEvent (text_delta, thinking_delta, tool_call_delta, etc.)
+ * - `message_end` — an assistant message completed
+ * - `queue_update` — the steering/follow-up queue changed (e.g. after `followUp()`)
+ * - `compaction_start` — Pi began compacting context (manual or auto)
+ * - `compaction_end` — context compaction finished
+ * - `extension_error` — a Pi extension threw an error
  */
 export type AgentEvent =
   | { type: "text"; text: string }
@@ -30,12 +42,30 @@ export type AgentEvent =
       delayMs: number;
       errorMessage: string;
     }
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+  | { type: "agent_start" }
+  | { type: "agent_end"; messages: unknown[] }
+  | { type: "turn_start"; turnIndex: number; timestamp: number }
+  | { type: "turn_end"; turnIndex: number; message: unknown; toolResults: unknown[] }
+  | { type: "message_start"; message: unknown }
+  | { type: "message_update"; message: unknown; delta: unknown }
+  | { type: "message_end"; message: unknown }
+  | { type: "queue_update"; steering: string[]; followUp: string[] }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | {
-      type: "auto_retry_end";
-      success: boolean;
-      attempt: number;
-      finalError?: string;
-    };
+      type: "compaction_end";
+      reason: "manual" | "threshold" | "overflow";
+      result: {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+        estimatedTokensAfter: number;
+        details: unknown;
+      } | null;
+      aborted: boolean;
+      willRetry: boolean;
+    }
+  | { type: "extension_error"; extensionPath: string; event: string; error: string };
 
 /**
  * Async iterable of structured agent events. Returned by `Agent.prompt()` and `Agent.bash()`.
@@ -94,4 +124,36 @@ export interface CompactResult {
   firstKeptEntryId: string;
   tokensBefore: number;
   estimatedTokensAfter: number;
+}
+
+/** Session statistics returned by `agent.getSessionStats()`. */
+export interface SessionStats {
+  sessionFile?: string;
+  sessionId: string;
+  userMessages: number;
+  assistantMessages: number;
+  toolCalls: number;
+  toolResults: number;
+  totalMessages: number;
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+  cost: number;
+  contextUsage?: {
+    tokens: number;
+    contextWindow: number;
+    percent: number;
+  };
+}
+
+/** A Pi slash command as returned by `agent.getCommands()`. */
+export interface PiSlashCommand {
+  name: string;
+  description?: string;
+  source: "extension" | "prompt" | "skill";
+  sourceInfo: unknown;
 }


### PR DESCRIPTION
…ommands

Forward all Pi stdout events: agent_start/end, turn_start/end, message_start/update/end, queue_update, compaction_start/end, extension_error. Add abortBash, getSessionStats, getLastAssistantText, getForkMessages, getCommands, setSessionName, setSteeringMode, setFollowUpMode, exportHtml. Export SessionStats and PiSlashCommand types.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
