### PR TITLE
fix: correct JSDoc comments that no longer matched the code

### DIFF
--- a/.changeset/fix-jsdoc-accuracy.md
+++ b/.changeset/fix-jsdoc-accuracy.md
@@ -1,0 +1,9 @@
+---
+"@drej/core": patch
+"@drej/otel": patch
+"@drej/agent": patch
+"drej": patch
+"@drej/workflow": patch
+---
+
+Fix JSDoc comments that no longer matched the code they document (stale `DrejClient` references, incorrect claims about `DrejError`, `watchMetrics()`, `resume()`, `exec()` ledger logging, `CommandError`, `computeSetupHash`, `bash()` streaming, and the `when()` predicate context), and flag two fields (`AgentSpec.cliVersion`, `.metadata`, `.registryDependencies`) and one known concurrency limitation (`FlushContext` under `forEach({ concurrency > 1 })`) that are currently no-ops/buggy rather than doing what they were documented to do. No behavior changes — doc-only.

--- a/packages/adapters/otel/src/index.ts
+++ b/packages/adapters/otel/src/index.ts
@@ -15,7 +15,7 @@ export interface OtelHooksOptions {
  * Span structure:
  * ```
  * sandbox.run            ← root span (sandboxId attribute)
- *   sandbox.exec         ← child per exec (cmd, exitCode, seq)
+ *   sandbox.exec         ← child per exec (cmd, seq, exitCode unless recordExitCode: false)
  *   sandbox.checkpoint   ← child per checkpoint (snapshotId)
  * ```
  *

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -267,7 +267,11 @@ export class Agent {
     return this._adapter.prompt(message, opts);
   }
 
-  /** Run a shell command inside Pi's working context and stream stdout. */
+  /**
+   * Run a shell command inside Pi's working context. Not incrementally
+   * streamed — Pi returns bash output synchronously, so the full output
+   * arrives as a single `text` event once the command completes.
+   */
   bash(command: string): AgentStream {
     return this._adapter.bash(command);
   }

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -29,7 +29,13 @@ export interface AgentSpec {
   categories?: string[];
   /** CLI to run inside the sandbox. Currently only `"pi"` is supported. */
   cli: "pi";
-  /** Pin to a specific CLI version (e.g. `"0.80.2"`). Defaults to latest. */
+  /**
+   * NOT YET IMPLEMENTED: does not actually pin the installed CLI version —
+   * `install()` always runs `npm install -g @earendil-works/pi-coding-agent`
+   * with no version qualifier, so the latest is always installed regardless
+   * of this value. Currently only affects the setup-hash cache key, so
+   * changing it forces a fresh snapshot rebuild.
+   */
   cliVersion?: string;
   /**
    * AI provider passed to the CLI via `--provider`. For Pi with a direct Google
@@ -58,9 +64,9 @@ export interface AgentSpec {
    * Falls back to defaults in `drej.config.json` if omitted.
    */
   resources?: { cpu: string; memory: string; gpu?: string };
-  /** Arbitrary labels attached to the sandbox. */
+  /** NOT YET IMPLEMENTED: declared but never read anywhere in `@drej/agent`. */
   metadata?: Record<string, string>;
-  /** Other agent specs to load as dependencies before this one. */
+  /** NOT YET IMPLEMENTED: declared but never read anywhere in `@drej/agent`. */
   registryDependencies?: string[];
   /**
    * Setup steps run inside the sandbox after Pi CLI install, before the snapshot.

--- a/packages/agent/src/snapshots.ts
+++ b/packages/agent/src/snapshots.ts
@@ -12,8 +12,8 @@ export interface AgentSnapshotRecord {
 }
 
 /**
- * Hash of the fields that require re-installing the agent CLI:
- * cli, cliVersion, and packages. Excludes env (hot-reloadable),
+ * Hash of the fields that require re-installing the agent CLI or rerunning
+ * setup: cli, cliVersion, packages, and setup. Excludes env (hot-reloadable),
  * model/provider (CLI flags only), and cosmetic fields.
  */
 export function computeSetupHash(spec: AgentSpec): string {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -102,7 +102,10 @@ export async function* textOnly(stream: AgentStream): AsyncIterable<string> {
  */
 export type PromptStream = AsyncIterable<string>;
 
-/** A Pi model as returned by `getAvailableModels`, `setModel`, and `cycleModel`. */
+/**
+ * A Pi model as returned by `getAvailableModels`, `setModel`, and (nested in
+ * `{ model, thinkingLevel, isScoped } | null`) `cycleModel`.
+ */
 export interface PiModel {
   id: string;
   api: string;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -31,8 +31,11 @@ export class ExecConnectionError extends WorkflowError {
 }
 
 /**
- * Thrown when an `exec()` step exits with a non-zero exit code and the
- * `strict` option is enabled. Carries the exit code and original command.
+ * Thrown when a command exits with a non-zero exit code. Carries the exit
+ * code and original command. For `Sandbox.exec()`, only thrown when `strict`
+ * is enabled (the default — pass `{ strict: false }` to opt out). For
+ * `BashSession.exec()` (a persistent session from `createSession()`), always
+ * thrown on non-zero exit; there is no `strict` option for session execs.
  */
 export class CommandError extends WorkflowError {
   constructor(

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -49,7 +49,7 @@ export interface SandboxHooks {
   onSandboxResumed?(sandboxId: string): void;
 }
 
-/** Internal dependencies injected by `DrejClient`. */
+/** Internal dependencies injected by `Drej`. */
 export interface SandboxDeps {
   control: ControlClient;
   adapter: IStorageAdapter;
@@ -93,7 +93,7 @@ export async function resolveExecClient(
 }
 
 /**
- * A live sandbox container. Returned by `DrejClient.sandbox()` and `DrejClient.resume()`.
+ * A live sandbox container. Returned by `Drej.sandbox()` and `Drej.resume()`.
  *
  * Call `exec()` to run commands, `checkpoint()` to snapshot state, and `close()`
  * when done. Multiple sandboxes can be held simultaneously — just assign to
@@ -115,7 +115,7 @@ export class Sandbox {
   readonly name: string;
 
   private readonly _deps: SandboxDeps;
-  /** Cached exec results for replay mode (populated by DrejClient.resume()). */
+  /** Cached exec results for replay mode (populated by `Drej.resume()`). */
   private readonly _replayCache: Map<number, ExecResult>;
   private _execClient: ExecClient | null = null;
   private _seq = 0;
@@ -179,9 +179,9 @@ export class Sandbox {
    * Execute a shell command inside the sandbox.
    *
    * Returns an `ExecHandle` — await it for the result, call `.pipe()` to stream
-   * stdout, or use `.stdout()` as an async generator. Every call is logged to
+   * stdout, or use `.stdout()` as an async generator. Live execs are logged to
    * the ledger; replayed execs in a resumed sandbox return cached output
-   * instantly without re-running.
+   * instantly without re-running and without emitting new ledger events.
    *
    * @example
    * ```ts
@@ -416,8 +416,9 @@ export class Sandbox {
   /**
    * Stream real-time CPU and memory metrics from execd via SSE.
    *
-   * Holds a long-lived connection — break out of the loop or pass an AbortSignal
-   * when done to avoid leaking the connection.
+   * Holds a long-lived connection — break out of the loop when done to avoid
+   * leaking the connection. Takes no arguments; there is no way to cancel it
+   * other than breaking out of the `for await` loop.
    *
    * @example
    * ```ts
@@ -461,7 +462,9 @@ export class Sandbox {
   }
 
   /**
-   * Restore a paused sandbox to Running state and re-resolve the execd endpoint.
+   * Restore a paused sandbox to Running state. The execd endpoint is not
+   * re-resolved here — `pause()` clears the cached client, so it's lazily
+   * re-resolved on the next call that needs it (e.g. the next `exec()`).
    *
    * On Docker, this unfreezes the container instantly. On Kubernetes, a new pod
    * is created from the OCI snapshot — in-memory process state is not preserved.
@@ -548,8 +551,8 @@ export class Sandbox {
    * Snapshot the current sandbox and return a new independent `Sandbox` from that state.
    *
    * The original sandbox keeps running. Both operate on separate containers restored
-   * from the same snapshot. Equivalent to `checkpoint()` followed by `resume()` on a
-   * clone, but without closing the original.
+   * from the same snapshot. Equivalent to `checkpoint()` followed by `Drej.resume()`
+   * into a new sandbox, but without closing the original.
    *
    * @example
    * ```ts
@@ -574,8 +577,8 @@ export class Sandbox {
    * Capture a snapshot of the sandbox's current filesystem state.
    *
    * Writes a `checkpoint_created` event to the ledger with the snapshot ID and
-   * returns the snapshot ID. Use `DrejClient.resume(sandboxId)` to restore from
-   * the latest checkpoint, or pass the returned ID to `DrejClient.restoreSnapshot()`.
+   * returns the snapshot ID. Use `Drej.resume(sandboxId)` to restore from
+   * the latest checkpoint, or pass the returned ID to `Drej.restoreSnapshot()`.
    */
   async checkpoint(name?: string): Promise<string> {
     const snap = await this._deps.control.createSnapshot(this.sandboxId);

--- a/packages/sdks/typescript/src/types.ts
+++ b/packages/sdks/typescript/src/types.ts
@@ -3,7 +3,14 @@ import { SandboxStatus } from "@drej/core";
 
 export { SandboxStatus };
 
-/** Thrown when an OpenSandbox API call returns a non-2xx response. */
+/**
+ * Client-side SDK error carrying an HTTP-style status code, thrown for
+ * invariant/state failures such as a sandbox missing from the local ledger
+ * (404), a sandbox not in `Running` state (409), or a client-side timeout
+ * (408). This does not wrap non-2xx OpenSandbox API responses — those throw
+ * `OpenSandboxError` from `@drej/opensandbox`, which is never rethrown as a
+ * `DrejError`.
+ */
 export class DrejError extends Error {
   constructor(
     message: string,

--- a/packages/workflow/src/sandbox-builder.ts
+++ b/packages/workflow/src/sandbox-builder.ts
@@ -117,7 +117,9 @@ export class SandboxBuilder {
   /**
    * Conditionally execute one of two builder callbacks based on a predicate.
    *
-   * The predicate receives `{ stdout, exitCode, vars }` from the last exec.
+   * The predicate receives the current `FlushContext`: `stdout` accumulated
+   * across every exec run so far in this sandbox, `exitCode` from the most
+   * recent exec, and `vars` captured so far.
    *
    * @example
    * ```ts
@@ -155,11 +157,18 @@ export class SandboxBuilder {
   }
 }
 
-/** Execution context threaded through flush operations. */
+/**
+ * Execution context threaded through flush operations.
+ *
+ * Known limitation: inside a `forEach(items, fn, { concurrency: N })` branch
+ * with `N > 1`, each parallel worker flushes against a shallow copy of this
+ * context (`{ ...ctx }`), so `stdout`/`exitCode` writes from those branches
+ * never propagate back — only `vars` (an object reference) does.
+ */
 export interface FlushContext {
-  /** Accumulated stdout across all execs in this sandbox. */
+  /** Accumulated stdout across all execs in this sandbox (see limitation above for concurrent forEach). */
   stdout: string;
-  /** Exit code of the most recent exec. */
+  /** Exit code of the most recent exec (see limitation above for concurrent forEach). */
   exitCode: number;
   /** Named values captured by `readFile`. */
   vars: Record<string, unknown>;


### PR DESCRIPTION
## What

Audited every JSDoc block across the publishable packages (`core`, `opensandbox`, `sdks/typescript`, `workflow`, `agent`, `otel`, `flue`) for accuracy against the code it documents. Fixed 17 confirmed mismatches. Doc-only — no behavior changes.

## Why

Requested as a follow-up doc-accuracy pass. Ran 4 parallel research agents (one per package group), then personally verified every claimed mismatch against source before touching anything.

## Fixes

- Stale `DrejClient` references (class doesn't exist — renamed to `Drej` at some point, docs weren't updated) — 4 spots in `sandbox.ts`
- `DrejError`'s doc claimed it wraps non-2xx OpenSandbox responses; it's actually a client-side synthetic error for 404/409/408/500 invariant checks. The real wrapper is `OpenSandboxError`, never rethrown as `DrejError`
- `watchMetrics()` claimed you could pass an `AbortSignal`; it takes no parameters
- `resume()` claimed it re-resolves the execd endpoint; that happens lazily on the next call that needs it, not inside `resume()`
- `exec()`'s "every call is logged to the ledger" is false for replayed execs, which return cached output with no new ledger events
- `CommandError`'s "strict option" framing didn't cover session execs (`BashSession.exec()`), which always throw on non-zero regardless
- `computeSetupHash()`'s doc omitted `setup` from its hashed-fields list
- `bash()` claimed streaming; Pi returns bash output synchronously as a single chunk
- `when()`'s predicate doc said stdout was "from the last exec"; it's cumulative across the whole sandbox — only `exitCode` is from the last exec
- Minor `PiModel` / `fork()` wording fixes

## Flagged, not fixed (out of scope for a doc pass)

Two of the 17 findings are real code defects the audit surfaced, not just stale wording. Rather than silently leaving the doc wrong *or* smuggling a behavior change into a "docs" PR, I documented them honestly and left them for follow-up:

- **`AgentSpec.cliVersion`** doesn't actually pin the installed CLI version — `install()` always runs `npm install -g @earendil-works/pi-coding-agent` with no version qualifier. The field only affects the setup-hash cache key.
- **`AgentSpec.metadata`** and **`.registryDependencies`** are declared and documented but never read anywhere in `@drej/agent` — dead fields.
- **`FlushContext` under `forEach(items, fn, { concurrency > 1 })`**: `flushForEach`'s parallel path does `flushOps(sandbox, inner._ops, { ...ctx })` — a shallow spread. `stdout`/`exitCode` are primitives, so mutations inside each worker never propagate back to the parent context. Output and exit codes from concurrent `forEach` branches are silently dropped. Documented as a known limitation on `FlushContext`.

## Test plan

- [x] `bun run typecheck` — clean across all 9 packages (incl. `packages/agent`, checked separately)
- [x] `bun run test` — all green, unaffected (comment-only changes)
- [x] `bun run build` — all packages build clean
- [x] `bun run lint` / `bun run format:check` — no new warnings, formatting clean
- [x] Changeset added (patch bump for the 5 touched publishable packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)