### PR TITLE
fix(agent): reword AgentSpec JSDoc to state facts plainly

### DIFF
--- a/.changeset/fix-jsdoc-tone.md
+++ b/.changeset/fix-jsdoc-tone.md
@@ -1,0 +1,5 @@
+---
+"@drej/agent": patch
+---
+
+Reword `AgentSpec.cliVersion`/`.metadata`/`.registryDependencies` JSDoc to state their current behavior as plain fact instead of flag-style "NOT YET IMPLEMENTED" annotations. No behavior change.

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -30,11 +30,10 @@ export interface AgentSpec {
   /** CLI to run inside the sandbox. Currently only `"pi"` is supported. */
   cli: "pi";
   /**
-   * NOT YET IMPLEMENTED: does not actually pin the installed CLI version —
-   * `install()` always runs `npm install -g @earendil-works/pi-coding-agent`
-   * with no version qualifier, so the latest is always installed regardless
-   * of this value. Currently only affects the setup-hash cache key, so
-   * changing it forces a fresh snapshot rebuild.
+   * Included in the setup-hash cache key, so changing it forces a fresh
+   * snapshot rebuild. `install()` always runs
+   * `npm install -g @earendil-works/pi-coding-agent` with no version
+   * qualifier — this does not pin a specific installed CLI version.
    */
   cliVersion?: string;
   /**
@@ -64,9 +63,12 @@ export interface AgentSpec {
    * Falls back to defaults in `drej.config.json` if omitted.
    */
   resources?: { cpu: string; memory: string; gpu?: string };
-  /** NOT YET IMPLEMENTED: declared but never read anywhere in `@drej/agent`. */
+  /** Not read anywhere in `@drej/agent`; has no effect on the sandbox. */
   metadata?: Record<string, string>;
-  /** NOT YET IMPLEMENTED: declared but never read anywhere in `@drej/agent`. */
+  /**
+   * Not read by `@drej/agent` itself — used by `drejx add`, which fetches
+   * and saves each dependency spec first, depth-first.
+   */
   registryDependencies?: string[];
   /**
    * Setup steps run inside the sandbox after Pi CLI install, before the snapshot.


### PR DESCRIPTION
## What

Rewords the `AgentSpec.cliVersion`/`.metadata`/`.registryDependencies` JSDoc comments in `packages/agent/src/schema.ts` (added in #94) from flag-style "NOT YET IMPLEMENTED:" annotations to plain factual prose describing the same behavior.

## Why

Docs (and doc comments) should read as authoritative descriptions of current behavior, not as defect-tracker annotations flagging what was "found" wrong. Same fix already applied across `apps/docs/` in a companion PR — this is the matching cleanup for the one spot in source JSDoc with the same tone issue.

No behavior change — comment-only.

## Test plan

- [x] `bunx tsc --noEmit --strict --project packages/agent/tsconfig.json` — clean
- [x] `bun run --cwd packages/agent build` — succeeds
- [x] `bun run format:check` — clean
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)