### PR TITLE
fix(docs): audit apps/docs content against source, fix 30+ mismatches

### DIFF
--- a/.changeset/fix-docs-content-audit.md
+++ b/.changeset/fix-docs-content-audit.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Audited every .mdx page against the source code it documents and fixed 30+ mismatches: a systemic fabricated `client.connect()`/`client.close()` API (repeated across 7 files — `Drej` has neither), a completely rewritten `docs/drejx/` section (11 files — the CLI only manages local `AgentSpec` files, it never provisions sandboxes, checkpoints, or writes `.drej/sandboxes.json`, which is dead code), incorrect error-class docs (`SandboxError` vs `DrejError`), wrong `checkpoint()` return type, an incomplete `IStorageAdapter` transcription, wrong Postgres/SQLite schemas, fabricated `SandboxStatus` values, a wrong `searchFiles()` return type, a hand-rolled `execCode()` context example that doesn't work, fabricated `execCode()` options, incorrect `AgentEvent.compaction_end` types, an incomplete `compact()` return shape, `AgentSpec.cliVersion`/`.metadata`/`.registryDependencies` documented as functional when they're no-ops, and several smaller wording fixes (retry backoff math, `when()`'s cumulative-stdout semantics, a documented known limitation in concurrent `forEach`). No behavior changes — doc-only.

--- a/apps/docs/content/docs/agent/api-reference/agent.mdx
+++ b/apps/docs/content/docs/agent/api-reference/agent.mdx
@@ -28,7 +28,7 @@ static async load(specPath: string, opts?: { rebuild?: boolean }): Promise<Agent
 
 Load and validate the JSON spec at `specPath`, spin up a `node:22` sandbox, install the Pi CLI and any `setup` steps, and return a ready `Agent`.
 
-On first load the container is checkpointed after install. Subsequent calls restore from the snapshot — skipping the install and completing in ~5 s instead of ~50 s. See [Snapshotting](/docs/agent/getting-started/snapshotting).
+On first load the container is checkpointed after install. Subsequent calls restore from the snapshot — skipping the install and starting in ~3s instead of ~90s. See [Snapshotting](/docs/agent/getting-started/snapshotting).
 
 ```ts
 const agent = await Agent.load("./agents/my-agent.json");
@@ -84,7 +84,7 @@ for await (const ev of agent.prompt("Run /workspace/script.py")) {
 bash(command: string): AgentStream
 ```
 
-Run a shell command inside Pi's working context and stream stdout. Returns the same `AgentStream` type as `prompt()`.
+Run a shell command inside Pi's working context. Returns the same `AgentStream` type as `prompt()`, but not incrementally streamed — Pi returns bash output synchronously, so the full output arrives as a single `text` event once the command completes.
 
 ```ts
 for await (const chunk of textOnly(agent.bash("ls -la /workspace"))) {
@@ -152,13 +152,12 @@ Branch the current Pi session at the current position, creating a new session fi
 async fork(entryId: string): Promise<{ text: string; cancelled: boolean }>
 ```
 
-Branch from a specific message entry in the conversation history. `entryId` comes from `getMessages()` — either `message.id` or `message.entryId`. Returns the text of the forked message and whether it was cancelled.
+Branch from a specific message entry in the conversation history. `entryId` comes from `getForkMessages()` (see below), not `getMessages()` — `PiMessage` has no `id`/`entryId` field. Returns the text of the forked message and whether it was cancelled.
 
 ```ts
-const messages = await agent.getMessages();
-const msg = messages.find((m) => m.role === "user" && m.id);
-if (msg) {
-  const forked = await agent.fork(msg.id);
+const points = await agent.getForkMessages();
+if (points.length > 0) {
+  const forked = await agent.fork(points[0].entryId);
   console.log(`Forked from: "${forked.text.slice(0, 60)}"`);
 }
 ```
@@ -393,7 +392,7 @@ Enable or disable Pi's automatic context compaction.
 async compact(customInstructions?: string): Promise<CompactResult>
 ```
 
-Manually trigger Pi's context compaction. Returns `{ tokensBefore, estimatedTokensAfter }`.
+Manually trigger Pi's context compaction. Returns a `CompactResult`: `{ summary, firstKeptEntryId, tokensBefore, estimatedTokensAfter }`.
 
 ---
 
@@ -487,23 +486,23 @@ The JSON shape of an agent spec file. Pass the path to `Agent.load(specPath)`.
 import type { AgentSpec } from "@drej/agent";
 ```
 
-| Field                  | Type                                     | Description                                                             |
-| ---------------------- | ---------------------------------------- | ----------------------------------------------------------------------- |
-| `name`                 | `string`                                 | Unique identifier. Used as the sandbox session name.                    |
-| `cli`                  | `"pi"`                                   | CLI to run. Only `"pi"` is supported.                                   |
-| `cliVersion`           | `string?`                                | Pin to a specific Pi version, e.g. `"0.80.2"`. Defaults to latest.      |
-| `model`                | `string?`                                | Model ID passed to Pi via `--model`.                                    |
-| `provider`             | `string?`                                | AI provider passed via `--provider`. Omit for a direct Google API key.  |
-| `packages`             | `string[]?`                              | APT packages to install before Pi (e.g. `["python3", "git"]`).          |
-| `env`                  | `Record<string,string>?`                 | Env vars for the sandbox. Values may reference host env: `"${MY_VAR}"`. |
-| `resources`            | `{ cpu: string; memory: string; gpu? }?` | Container resource limits. Falls back to `drej.config.json` defaults.   |
-| `setup`                | `SetupStep[]?`                           | Workspace setup steps — run after Pi install, baked into the snapshot.  |
-| `title`                | `string?`                                | Human-readable display name.                                            |
-| `description`          | `string?`                                | Short description of the agent.                                         |
-| `author`               | `string?`                                | Author name.                                                            |
-| `categories`           | `string[]?`                              | Arbitrary category tags.                                                |
-| `metadata`             | `Record<string,string>?`                 | Arbitrary labels attached to the sandbox.                               |
-| `registryDependencies` | `string[]?`                              | Other agent spec URLs to load as dependencies.                          |
+| Field                  | Type                                     | Description                                                                                                                                                                 |
+| ---------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | `string`                                 | Unique identifier. Used as the sandbox session name.                                                                                                                        |
+| `cli`                  | `"pi"`                                   | CLI to run. Only `"pi"` is supported.                                                                                                                                       |
+| `cliVersion`           | `string?`                                | Included in the setup-hash cache key, so changing it forces a fresh Pi CLI install. `Agent.load()` always installs the latest Pi CLI — this doesn't pin a specific version. |
+| `model`                | `string?`                                | Model ID passed to Pi via `--model`.                                                                                                                                        |
+| `provider`             | `string?`                                | AI provider passed via `--provider`. Omit for a direct Google API key.                                                                                                      |
+| `packages`             | `string[]?`                              | APT packages to install before Pi (e.g. `["python3", "git"]`).                                                                                                              |
+| `env`                  | `Record<string,string>?`                 | Env vars for the sandbox. Values may reference host env: `"${MY_VAR}"`.                                                                                                     |
+| `resources`            | `{ cpu: string; memory: string; gpu? }?` | Container resource limits. Falls back to `drej.config.json` defaults.                                                                                                       |
+| `setup`                | `SetupStep[]?`                           | Workspace setup steps — run after Pi install, baked into the snapshot.                                                                                                      |
+| `title`                | `string?`                                | Human-readable display name.                                                                                                                                                |
+| `description`          | `string?`                                | Short description of the agent.                                                                                                                                             |
+| `author`               | `string?`                                | Author name.                                                                                                                                                                |
+| `categories`           | `string[]?`                              | Arbitrary category tags.                                                                                                                                                    |
+| `metadata`             | `Record<string,string>?`                 | Not read anywhere in `@drej/agent`; has no effect on the sandbox.                                                                                                           |
+| `registryDependencies` | `string[]?`                              | Other agent spec URLs. Not read by `@drej/agent` itself — used by `drejx add`, which fetches and saves each one first, depth-first.                                         |
 
 ### Example
 
@@ -589,8 +588,14 @@ type AgentEvent =
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | {
       type: "compaction_end";
-      reason: string;
-      result: object | null;
+      reason: "manual" | "threshold" | "overflow";
+      result: {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+        estimatedTokensAfter: number;
+        details: unknown;
+      } | null;
       aborted: boolean;
       willRetry: boolean;
     }

--- a/apps/docs/content/docs/agent/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/agent/getting-started/quickstart.mdx
@@ -64,7 +64,7 @@ try {
 bun run.ts
 ```
 
-`Agent.load()` logs timing for each phase. The first run installs the Pi CLI (~30–60 s) and checkpoints the sandbox. Subsequent runs restore from that snapshot in ~5 s:
+`Agent.load()` logs timing for each phase. The first run installs the Pi CLI and checkpoints the sandbox — on the order of a minute. Subsequent runs restore from that snapshot in a few seconds:
 
 ```
 # First run

--- a/apps/docs/content/docs/agent/getting-started/snapshotting.mdx
+++ b/apps/docs/content/docs/agent/getting-started/snapshotting.mdx
@@ -6,8 +6,8 @@ description: How Agent.load() caches the Pi install so subsequent loads take sec
 On the first call to `Agent.load()`, the SDK installs the Pi CLI inside a `node:22` sandbox, runs any [workspace setup steps](/docs/agent/getting-started/workspace-setup), then checkpoints the container. On every subsequent call it restores from that snapshot — skipping the install entirely.
 
 ```
-Load 1 (cold):   sandbox → Pi install → setup steps → checkpoint → bridge   ~50s
-Load 2+ (warm):  snapshot restore → bridge                                   ~5s
+Load 1 (cold):   sandbox → Pi install → setup steps → checkpoint → bridge   ~90s
+Load 2+ (warm):  snapshot restore → bridge                                   ~3s
 ```
 
 ## fromSnapshot

--- a/apps/docs/content/docs/agent/getting-started/streaming.mdx
+++ b/apps/docs/content/docs/agent/getting-started/streaming.mdx
@@ -33,8 +33,14 @@ type AgentEvent =
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | {
       type: "compaction_end";
-      reason: string;
-      result: object | null;
+      reason: "manual" | "threshold" | "overflow";
+      result: {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+        estimatedTokensAfter: number;
+        details: unknown;
+      } | null;
       aborted: boolean;
       willRetry: boolean;
     }
@@ -128,7 +134,7 @@ console.log("Tools used:", [...new Set(toolNames)].join(", "));
 
 ## bash()
 
-`agent.bash()` runs a shell command inside Pi's working context and returns the same `AgentStream`. Tool events from the bash execution are surfaced the same way:
+`agent.bash()` runs a shell command inside Pi's working context and returns the same `AgentStream` type — but unlike `prompt()`, it's not incrementally streamed. Pi returns bash output synchronously, so the full output arrives as a single `text` event once the command completes; no `tool_start`/`tool_update`/`tool_end` events are emitted for it:
 
 ```ts
 for await (const chunk of textOnly(agent.bash("ls -la /workspace"))) {

--- a/apps/docs/content/docs/core/adapters/custom.mdx
+++ b/apps/docs/content/docs/core/adapters/custom.mdx
@@ -18,6 +18,11 @@ export interface IStorageAdapter {
   listAllSandboxDetails(opts?: ListSandboxOptions): Promise<SandboxDetails[]>;
   getSandboxDetails(name: string, sandboxId: string): Promise<SandboxDetails | null>;
   deleteSandbox(name: string, sandboxId: string): Promise<void>;
+  listCheckpoints(name: string, sandboxId: string): Promise<CheckpointInfo[]>;
+  getEnvironment(name: string): Promise<EnvironmentRecord | null>;
+  saveEnvironment(record: EnvironmentRecord): Promise<void>;
+  deleteEnvironment(name: string): Promise<void>;
+  listEnvironments(): Promise<EnvironmentRecord[]>;
 }
 ```
 
@@ -30,22 +35,29 @@ import type {
   LedgerEvent,
   SandboxDetails,
   ListSandboxOptions,
+  CheckpointInfo,
+  EnvironmentRecord,
 } from "@drej/core";
 ```
 
 ## Method reference
 
-| Method                               | Required | Description                                                                  |
-| ------------------------------------ | -------- | ---------------------------------------------------------------------------- |
-| `connect()`                          | No       | Initialize connections. Called by `client.connect()`.                        |
-| `close()`                            | No       | Release connections. Called by `client.close()`.                             |
-| `append(entry)`                      | Yes      | Persist a single ledger event. Called during every exec.                     |
-| `readAll(name, sandboxId)`           | Yes      | Return all events for a session in ascending `ts` order. Used by `resume()`. |
-| `lastCheckpoint(name, sandboxId)`    | Yes      | Return the most recent `checkpoint_created` entry, or `null`.                |
-| `listSandboxDetails(name, opts?)`    | Yes      | Return sessions with this name, newest first.                                |
-| `listAllSandboxDetails(opts?)`       | Yes      | Return all sessions across all names, newest first.                          |
-| `getSandboxDetails(name, sandboxId)` | Yes      | Return a single session, or `null`.                                          |
-| `deleteSandbox(name, sandboxId)`     | Yes      | Delete all events for a session.                                             |
+| Method                               | Required | Description                                                                                                                     |
+| ------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `connect()`                          | No       | Initialize connections. Called lazily, once, the first time the client needs the adapter — not by any method you call yourself. |
+| `close()`                            | No       | Release connections. Called automatically when the process exits.                                                               |
+| `append(entry)`                      | Yes      | Persist a single ledger event. Called during every live exec.                                                                   |
+| `readAll(name, sandboxId)`           | Yes      | Return all events for a session in ascending `ts` order. Used by `resume()`.                                                    |
+| `lastCheckpoint(name, sandboxId)`    | Yes      | Return the most recent `checkpoint_created` entry, or `null`.                                                                   |
+| `listSandboxDetails(name, opts?)`    | Yes      | Return sessions with this name, newest first.                                                                                   |
+| `listAllSandboxDetails(opts?)`       | Yes      | Return all sessions across all names, newest first.                                                                             |
+| `getSandboxDetails(name, sandboxId)` | Yes      | Return a single session, or `null`.                                                                                             |
+| `deleteSandbox(name, sandboxId)`     | Yes      | Delete all events for a session.                                                                                                |
+| `listCheckpoints(name, sandboxId)`   | Yes      | Return all checkpoints for a session, in creation order.                                                                        |
+| `getEnvironment(name)`               | Yes      | Return the cached record for a named environment, or `null` if not built yet.                                                   |
+| `saveEnvironment(record)`            | Yes      | Upsert an environment record after a successful build.                                                                          |
+| `deleteEnvironment(name)`            | Yes      | Remove the record for a named environment. Does not delete the server-side snapshot.                                            |
+| `listEnvironments()`                 | Yes      | Return all environment records, newest first.                                                                                   |
 
 ## LedgerEntry
 
@@ -67,11 +79,19 @@ interface LedgerEntry {
 Useful for testing:
 
 ```ts
-import type { IStorageAdapter, LedgerEntry, SandboxDetails, ListSandboxOptions } from "@drej/core";
+import type {
+  IStorageAdapter,
+  LedgerEntry,
+  SandboxDetails,
+  ListSandboxOptions,
+  CheckpointInfo,
+  EnvironmentRecord,
+} from "@drej/core";
 import { SandboxStatus, LedgerEvent } from "@drej/core";
 
 export class MemoryAdapter implements IStorageAdapter {
   private readonly _events: LedgerEntry[] = [];
+  private readonly _environments = new Map<string, EnvironmentRecord>();
 
   async append(entry: LedgerEntry): Promise<void> {
     this._events.push(entry);
@@ -137,6 +157,32 @@ export class MemoryAdapter implements IStorageAdapter {
       this._events.splice(idx, 1);
     }
   }
+
+  async listCheckpoints(name: string, sandboxId: string): Promise<CheckpointInfo[]> {
+    const events = await this.readAll(name, sandboxId);
+    return events
+      .filter((e) => e.event === LedgerEvent.CheckpointCreated)
+      .map((e) => {
+        const payload = e.payload as { snapshotId: string; name?: string };
+        return { snapshotId: payload.snapshotId, tag: payload.name, createdAt: e.ts };
+      });
+  }
+
+  async getEnvironment(name: string): Promise<EnvironmentRecord | null> {
+    return this._environments.get(name) ?? null;
+  }
+
+  async saveEnvironment(record: EnvironmentRecord): Promise<void> {
+    this._environments.set(record.name, record);
+  }
+
+  async deleteEnvironment(name: string): Promise<void> {
+    this._environments.delete(name);
+  }
+
+  async listEnvironments(): Promise<EnvironmentRecord[]> {
+    return [...this._environments.values()].sort((a, b) => b.builtAt - a.builtAt);
+  }
 }
 ```
 
@@ -149,5 +195,5 @@ const client = new Drej({
   baseUrl: "http://localhost:8080",
   adapter: new MemoryAdapter(),
 });
-await client.connect();
+// No connect() call needed — the adapter is used as soon as the client is.
 ```

--- a/apps/docs/content/docs/core/adapters/postgres.mdx
+++ b/apps/docs/content/docs/core/adapters/postgres.mdx
@@ -23,9 +23,8 @@ const client = new Drej({
   adapter: new PostgresAdapter(process.env.DATABASE_URL!),
 });
 
-await client.connect(); // runs CREATE TABLE IF NOT EXISTS migrations
-// ...
-await client.close(); // releases the connection pool
+// No connect() or close() needed — migrations run automatically on first
+// use, and the connection closes itself when the process exits.
 ```
 
 ## Constructor
@@ -48,21 +47,31 @@ The adapter uses the `postgres` package internally, which also respects the `PGP
 
 ## Migrations
 
-`connect()` runs `CREATE TABLE IF NOT EXISTS` migrations — safe to call on every startup. No migration tool required.
+Migrations run automatically as `CREATE TABLE IF NOT EXISTS` the first time the adapter is used — safe on every startup, no migration tool required.
 
 Schema created:
 
 ```sql
 CREATE TABLE IF NOT EXISTS drej_events (
-  id         SERIAL PRIMARY KEY,
-  sandbox_id TEXT    NOT NULL,
-  name       TEXT    NOT NULL,
-  step_idx   INTEGER NOT NULL,
-  branch     INTEGER,
-  event      TEXT    NOT NULL,
-  payload    JSONB,
-  error      TEXT,
-  ts         BIGINT  NOT NULL
+  id          BIGSERIAL   PRIMARY KEY,
+  sandbox_id  TEXT        NOT NULL,
+  name        TEXT        NOT NULL,
+  step_idx    INTEGER     NOT NULL,
+  branch      INTEGER,
+  event       TEXT        NOT NULL,
+  payload     JSONB,
+  error       TEXT,
+  ts          BIGINT      NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS drej_events_sandbox_id ON drej_events(sandbox_id);
+CREATE INDEX IF NOT EXISTS drej_events_name ON drej_events(name);
+
+CREATE TABLE IF NOT EXISTS drej_environments (
+  name        TEXT    PRIMARY KEY,
+  snapshot_id TEXT    NOT NULL,
+  image       TEXT    NOT NULL,
+  built_at    BIGINT  NOT NULL
 );
 ```
 

--- a/apps/docs/content/docs/core/adapters/sqlite.mdx
+++ b/apps/docs/content/docs/core/adapters/sqlite.mdx
@@ -22,12 +22,11 @@ const client = new Drej({
   adapter: new SQLiteAdapter("./ledger.db"),
 });
 
-await client.connect(); // creates the file and runs migrations
-// ...
-await client.close(); // closes the database connection
+// No connect() or close() needed — the file is created and migrations run
+// automatically the first time the adapter is used.
 ```
 
-The file is created if it doesn't exist. `connect()` runs `CREATE TABLE IF NOT EXISTS` migrations so it's safe to call on every startup.
+`CREATE TABLE IF NOT EXISTS` migrations run automatically on first use, so it's safe to construct the adapter fresh on every startup.
 
 ## Constructor
 
@@ -41,7 +40,7 @@ new SQLiteAdapter(path: string)
 
 ## WAL mode
 
-`SQLiteAdapter` enables WAL (Write-Ahead Logging) mode automatically on `connect()`. WAL mode prevents writers from blocking readers, so multiple concurrent sandbox sessions in the same process are safe.
+`SQLiteAdapter` enables WAL (Write-Ahead Logging) mode automatically the first time it's used. WAL mode prevents writers from blocking readers, so multiple concurrent sandbox sessions in the same process are safe.
 
 ## When to use
 
@@ -64,18 +63,28 @@ Switch to `@drej/postgres` when:
 
 ## Schema
 
-`connect()` creates a single table:
+The following is created automatically on first use:
 
 ```sql
 CREATE TABLE IF NOT EXISTS drej_events (
-  id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  sandbox_id TEXT    NOT NULL,
-  name       TEXT    NOT NULL,
-  step_idx   INTEGER NOT NULL,
-  branch     INTEGER,
-  event      TEXT    NOT NULL,
-  payload    TEXT,
-  error      TEXT,
-  ts         INTEGER NOT NULL
+  id          INTEGER  PRIMARY KEY AUTOINCREMENT,
+  sandbox_id  TEXT     NOT NULL,
+  name        TEXT     NOT NULL,
+  step_idx    INTEGER  NOT NULL,
+  branch      INTEGER,
+  event       TEXT     NOT NULL,
+  payload     TEXT,
+  error       TEXT,
+  ts          INTEGER  NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS drej_events_sandbox_id ON drej_events(sandbox_id);
+CREATE INDEX IF NOT EXISTS drej_events_name ON drej_events(name);
+
+CREATE TABLE IF NOT EXISTS drej_environments (
+  name        TEXT    PRIMARY KEY,
+  snapshot_id TEXT    NOT NULL,
+  image       TEXT    NOT NULL,
+  built_at    INTEGER NOT NULL
 );
 ```

--- a/apps/docs/content/docs/core/api-reference/drej-client.mdx
+++ b/apps/docs/content/docs/core/api-reference/drej-client.mdx
@@ -128,27 +128,27 @@ See [Sandbox](#sandbox) below for the object returned by `sandbox()` and `resume
 
 ### Sandbox methods
 
-| Method                            | Returns                               | Description                                 |
-| --------------------------------- | ------------------------------------- | ------------------------------------------- |
-| `sb.exec(cmd, opts?)`             | `ExecHandle`                          | Run a shell command                         |
-| `sb.execCode(code, opts?)`        | `ExecHandle`                          | Run code via the interpreter                |
-| `sb.proxy(port)`                  | `Promise<{ url, headers }>`           | Get a proxied URL for an in-sandbox port    |
-| `sb.metrics()`                    | `Promise<{ cpu, memory, timestamp }>` | Current CPU and memory usage                |
-| `sb.writeFile(path, content)`     | `Promise<void>`                       | Write a UTF-8 file into the container       |
-| `sb.readFile(path)`               | `Promise<string>`                     | Read a file from the container as a string  |
-| `sb.moveFile(from, to)`           | `Promise<void>`                       | Move or rename a file                       |
-| `sb.deleteFile(path)`             | `Promise<void>`                       | Delete a file                               |
-| `sb.createDirectory(path)`        | `Promise<void>`                       | Create a directory (and parents)            |
-| `sb.deleteDirectory(path)`        | `Promise<void>`                       | Delete a directory                          |
-| `sb.getFileInfo(path)`            | `Promise<FileInfo>`                   | File metadata: size, type, mode, timestamps |
-| `sb.replaceInFiles(replacements)` | `Promise<void>`                       | In-place substring replacement across files |
-| `sb.transfer(path, target)`       | `Promise<void>`                       | Copy a file to another `Sandbox` instance   |
-| `sb.searchFiles(pattern, path?)`  | `Promise<string[]>`                   | Search for files matching a glob            |
-| `sb.listDirectory(path, opts?)`   | `Promise<FileInfo[]>`                 | List directory entries with metadata        |
-| `sb.checkpoint(name?)`            | `Promise<void>`                       | Snapshot the container state                |
-| `sb.listCheckpoints()`            | `Promise<CheckpointInfo[]>`           | All checkpoints for this sandbox            |
-| `sb.fork(tag?)`                   | `Promise<Sandbox>`                    | Snapshot and return an independent copy     |
-| `sb.close()`                      | `Promise<void>`                       | Delete the container and release resources  |
+| Method                            | Returns                               | Description                                           |
+| --------------------------------- | ------------------------------------- | ----------------------------------------------------- |
+| `sb.exec(cmd, opts?)`             | `ExecHandle`                          | Run a shell command                                   |
+| `sb.execCode(code, opts?)`        | `ExecHandle`                          | Run code via the interpreter                          |
+| `sb.proxy(port)`                  | `Promise<{ url, headers }>`           | Get a proxied URL for an in-sandbox port              |
+| `sb.metrics()`                    | `Promise<{ cpu, memory, timestamp }>` | Current CPU and memory usage                          |
+| `sb.writeFile(path, content)`     | `Promise<void>`                       | Write a UTF-8 file into the container                 |
+| `sb.readFile(path)`               | `Promise<string>`                     | Read a file from the container as a string            |
+| `sb.moveFile(from, to)`           | `Promise<void>`                       | Move or rename a file                                 |
+| `sb.deleteFile(path)`             | `Promise<void>`                       | Delete a file                                         |
+| `sb.createDirectory(path)`        | `Promise<void>`                       | Create a directory (and parents)                      |
+| `sb.deleteDirectory(path)`        | `Promise<void>`                       | Delete a directory                                    |
+| `sb.getFileInfo(path)`            | `Promise<FileInfo>`                   | File metadata: size, type, mode, timestamps           |
+| `sb.replaceInFiles(replacements)` | `Promise<void>`                       | In-place substring replacement across files           |
+| `sb.transfer(path, target)`       | `Promise<void>`                       | Copy a file to another `Sandbox` instance             |
+| `sb.searchFiles(pattern, path?)`  | `Promise<string[]>`                   | Search for files matching a glob                      |
+| `sb.listDirectory(path, opts?)`   | `Promise<FileInfo[]>`                 | List directory entries with metadata                  |
+| `sb.checkpoint(name?)`            | `Promise<string>`                     | Snapshot the container state, returns the snapshot ID |
+| `sb.listCheckpoints()`            | `Promise<CheckpointInfo[]>`           | All checkpoints for this sandbox                      |
+| `sb.fork(tag?)`                   | `Promise<Sandbox>`                    | Snapshot and return an independent copy               |
+| `sb.close()`                      | `Promise<void>`                       | Delete the container and release resources            |
 
 ### Sandbox properties
 

--- a/apps/docs/content/docs/core/api-reference/errors.mdx
+++ b/apps/docs/content/docs/core/api-reference/errors.mdx
@@ -1,23 +1,24 @@
 ---
 title: Errors
-description: CommandError, SandboxError, ExecConnectionError, and WorkflowError — the full drej error hierarchy.
+description: CommandError, SandboxError, ExecConnectionError, WorkflowError, and DrejError — the full drej error hierarchy.
 ---
 
 ```ts
-import { CommandError, SandboxError, ExecConnectionError, WorkflowError } from "drej";
+import { CommandError, SandboxError, ExecConnectionError, WorkflowError, DrejError } from "drej";
 ```
 
 ## Error hierarchy
 
 ```
 Error
-└── WorkflowError        — base class for all drej errors
-    ├── SandboxError     — container failed to start or reach Running
-    ├── ExecConnectionError — execd not ready after retry window
-    └── CommandError     — non-zero exit code in strict mode
+├── WorkflowError            — base class for Sandbox-level errors
+│   ├── SandboxError        — Sandbox method failed to start, resume, or reach Running
+│   ├── ExecConnectionError — execd not ready after retry window
+│   └── CommandError        — non-zero exit code in strict mode
+└── DrejError                — client-level errors from Drej itself (not a WorkflowError)
 ```
 
-All drej errors extend `WorkflowError`, which extends `Error`. You can catch all of them with `e instanceof WorkflowError`.
+`SandboxError`, `ExecConnectionError`, and `CommandError` all extend `WorkflowError`, which extends `Error` — catch all three with `e instanceof WorkflowError`. `DrejError` is a separate, sibling class thrown by `Drej` client methods (`sandbox()`, `resume()`, `sandboxes.*`, `environment()`) rather than by `Sandbox` methods — see [DrejError](#drejerror) below.
 
 ## WorkflowError
 
@@ -75,19 +76,18 @@ const { exitCode } = await sb.exec("test -f /etc/hosts", { strict: false });
 
 ## SandboxError
 
-Thrown when a sandbox fails to create, boot, or reach `Running` state. Also thrown internally if a snapshot fails.
+Thrown by methods on `Sandbox` itself: `resume()` if the container never reaches `Running` (or enters `Failed`/`Terminated`), an exec call while the sandbox is paused, `fork()` when the deps don't support it, or a failed snapshot wait.
+
+A failure during `client.sandbox()`'s own initial creation throws `DrejError`, not `SandboxError` — see below.
 
 ```ts
 import { SandboxError } from "drej";
 
 try {
-  const sb = await client.sandbox({
-    image: "nonexistent:image",
-    resources: { cpu: "500m", memory: "256Mi" },
-  });
+  await sb.resume(); // sandbox previously pause()d, now stuck
 } catch (e) {
   if (e instanceof SandboxError) {
-    console.error(e.message); // "Sandbox <id> entered state Failed: ..."
+    console.error(e.message); // e.g. "Sandbox entered Failed: ..." or "sandbox is paused — call resume() first"
     console.error(e.sandboxId ?? ""); // sandbox ID if assigned before failure
   }
 }

--- a/apps/docs/content/docs/core/api-reference/index.mdx
+++ b/apps/docs/content/docs/core/api-reference/index.mdx
@@ -7,7 +7,7 @@ description: Complete reference for every public symbol exported from drej.
   <Card
     href="/docs/core/api-reference/drej-client"
     title="Drej"
-    description="The main client — sandbox(), resume(), connect(), close(), and sandboxes management."
+    description="The main client — sandbox(), resume(), and sandboxes management. No connect()/close() needed."
   />
   <Card
     href="/docs/core/api-reference/workflow-run"

--- a/apps/docs/content/docs/core/api-reference/workflow-run.mdx
+++ b/apps/docs/content/docs/core/api-reference/workflow-run.mdx
@@ -69,7 +69,7 @@ See [Error handling](/docs/core/patterns/error-handling) for more on `CommandErr
 
 ## Multiple consumers
 
-An `ExecHandle` can only be consumed once — the underlying stream is driven by the first consumer. All consumption modes (`pipe`, `stdout`, `await`, `result`) share the same internal chunk buffer.
+An `ExecHandle` can only be consumed once — the underlying stream starts draining as soon as `sb.exec()`/`sb.execCode()` is called, in the `ExecHandle` constructor, whether or not anything ever consumes it. All consumption modes (`pipe`, `stdout`, `await`, `result`) share the same internal chunk buffer.
 
 ```ts
 const handle = sb.exec("long-running-command");

--- a/apps/docs/content/docs/core/building/control-flow.mdx
+++ b/apps/docs/content/docs/core/building/control-flow.mdx
@@ -42,7 +42,7 @@ With exponential backoff, attempt delays are: `delayMs`, `delayMs * 2`, `delayMs
 
 ## when
 
-Branch on runtime state. The predicate receives `{ stdout, exitCode, vars }` from the last exec:
+Branch on runtime state. The predicate receives the current context: `stdout` accumulated across every exec run so far in the sandbox, `exitCode` from the most recent exec, and `vars` captured so far:
 
 ```ts
 await workflow(client)

--- a/apps/docs/content/docs/core/building/file-ops.mdx
+++ b/apps/docs/content/docs/core/building/file-ops.mdx
@@ -50,7 +50,7 @@ Search for files matching a glob pattern. Returns an array of matching paths:
 ```ts
 const tsFiles = await sb.searchFiles("*.ts", "/workspace/src");
 console.log(tsFiles);
-// [{ path: "/workspace/src/index.ts" }, { path: "/workspace/src/util.ts" }]
+// ["/workspace/src/index.ts", "/workspace/src/util.ts"]
 ```
 
 The second argument is the base path to search from. Defaults to `/` if omitted.

--- a/apps/docs/content/docs/core/concepts/steps.mdx
+++ b/apps/docs/content/docs/core/concepts/steps.mdx
@@ -30,8 +30,9 @@ By default, `exec()` throws `CommandError` on non-zero exit (`strict: true`). Pa
 // Stateless — isolated context each time
 await sb.execCode(`print("hello")`).pipe(process.stdout);
 
-// Stateful — variables persist across calls sharing the same context
-const ctx = { id: "session-1", language: CodeLanguage.Python };
+// Stateful — variables persist across calls sharing the same context.
+// Contexts must be created first via createCodeContext() — you can't hand-roll one.
+const ctx = await sb.createCodeContext(CodeLanguage.Python);
 
 await sb.execCode(`data = [1, 2, 3]`, { context: ctx });
 await sb.execCode(`print(sum(data))`, { context: ctx }).pipe(process.stdout); // 6

--- a/apps/docs/content/docs/core/concepts/storage-adapters.mdx
+++ b/apps/docs/content/docs/core/concepts/storage-adapters.mdx
@@ -3,7 +3,7 @@ title: Storage adapters
 description: How the IStorageAdapter interface persists every exec event for durability and replay.
 ---
 
-Every exec, checkpoint, and sandbox lifecycle event is written to a storage adapter as it happens. This makes runs durable — if your process crashes, the ledger contains everything needed to know what ran and what was captured.
+Every live exec, checkpoint, and sandbox lifecycle event is written to a storage adapter as it happens. This makes runs durable — if your process crashes, the ledger contains everything needed to know what ran and what was captured. (Replayed execs in a resumed sandbox return cached output instantly and do not write new events — see [Checkpoint & resume](/docs/core/building/snapshots).)
 
 ## Why persistence matters
 
@@ -31,10 +31,9 @@ const client = new Drej({
   baseUrl: "http://localhost:8080",
   adapter: new SQLiteAdapter("./ledger.db"),
 });
-await client.connect(); // runs migrations, enables WAL
 ```
 
-The file is created if it doesn't exist. WAL mode means readers don't block writers, so multiple concurrent sandbox sessions are safe.
+The file is created if it doesn't exist. WAL mode means readers don't block writers, so multiple concurrent sandbox sessions are safe. No `connect()` call is needed — see [Connect and close](#connect-and-close) below.
 
 ## Postgres
 
@@ -47,20 +46,17 @@ const client = new Drej({
   baseUrl: process.env.OPEN_SANDBOX_URL!,
   adapter: new PostgresAdapter(process.env.DATABASE_URL!),
 });
-await client.connect(); // runs CREATE TABLE IF NOT EXISTS migrations
 ```
 
 ## Connect and close
 
-Always call `await client.connect()` before first use and `await client.close()` on shutdown:
+`Drej` has no `connect()` or `close()` method to call — the adapter initializes lazily (`CREATE TABLE IF NOT EXISTS` migrations run automatically on first use) and closes itself automatically via a `process.on("beforeExit", ...)` hook. Just construct the client and start using it:
 
 ```ts
-await client.connect(); // opens connection, runs migrations
-// ... use client ...
-await client.close(); // releases connections
+const client = new Drej({ baseUrl: "...", adapter: new PostgresAdapter("...") });
+// ... use client — migrations run on first call, no setup step needed ...
+// no close() call needed; the adapter shuts down on process exit
 ```
-
-`connect()` is where migrations run — `CREATE TABLE IF NOT EXISTS` so it's safe to call on every startup.
 
 ## Events written to the ledger
 

--- a/apps/docs/content/docs/core/concepts/workflows.mdx
+++ b/apps/docs/content/docs/core/concepts/workflows.mdx
@@ -17,7 +17,6 @@ const client = new Drej({
   baseUrl: "http://localhost:8080",
   adapter: new SQLiteAdapter("./ledger.db"),
 });
-await client.connect();
 
 const sb = await client.sandbox({
   image: "node:22",

--- a/apps/docs/content/docs/core/getting-started/how-it-works.mdx
+++ b/apps/docs/content/docs/core/getting-started/how-it-works.mdx
@@ -48,7 +48,7 @@ All three modes drive the same underlying SSE stream from execd. `.result()` res
 
 ## The durable ledger
 
-Every `exec()` call writes three events to the storage adapter:
+Every live `exec()` call writes three events to the storage adapter (replayed execs on a resumed sandbox skip this — see [Checkpoint and resume](#checkpoint-and-resume) below):
 
 ```
 exec_start    { cmd, seq }
@@ -66,7 +66,7 @@ This means every run is fully replayable from the ledger — even if the process
 
 `client.resume(sandboxId)` reads the ledger, finds the last checkpoint, restores a new container from the snapshot, and populates a **replay cache** from execs that completed before the checkpoint.
 
-On the resumed sandbox, calling `sb.exec()` with the same sequence hits the cache — returning the stored result instantly. Subsequent execs run live on the restored container.
+On the resumed sandbox, calling `sb.exec()` with the same sequence hits the cache — returning the stored result instantly, without writing any new `exec_start`/`exec_event`/`exec_complete` events (they're already in the ledger from the original run). Subsequent execs run live on the restored container and are logged normally.
 
 ```
 Original run:

--- a/apps/docs/content/docs/core/patterns/run-management.mdx
+++ b/apps/docs/content/docs/core/patterns/run-management.mdx
@@ -21,15 +21,16 @@ Sessions are returned newest first.
 
 Each session has:
 
-| Field         | Type            | Description                                              |
-| ------------- | --------------- | -------------------------------------------------------- |
-| `sandboxId`   | `string`        | OpenSandbox container ID                                 |
-| `name`        | `string`        | User-provided name (or auto-generated)                   |
-| `status`      | `SandboxStatus` | `"running"`, `"completed"`, `"failed"`, or `"cancelled"` |
-| `startedAt`   | `number`        | Unix timestamp (ms) of `sandbox_created` event           |
-| `completedAt` | `number?`       | Unix timestamp (ms) of `sandbox_closed` event            |
-| `execCount`   | `number`        | Number of completed execs                                |
-| `error`       | `string?`       | Error message if status is `failed`                      |
+| Field         | Type            | Description                                                                                        |
+| ------------- | --------------- | -------------------------------------------------------------------------------------------------- |
+| `sandboxId`   | `string`        | OpenSandbox container ID                                                                           |
+| `name`        | `string`        | User-provided name (or auto-generated)                                                             |
+| `status`      | `SandboxStatus` | `"running"` or `"completed"` — that's the full set; there is no `"failed"` or `"cancelled"` status |
+| `startedAt`   | `number`        | Unix timestamp (ms) of `sandbox_created` event                                                     |
+| `completedAt` | `number?`       | Unix timestamp (ms) of `sandbox_closed` event                                                      |
+| `execCount`   | `number`        | Number of completed execs                                                                          |
+
+There is no `error` field on `SandboxDetails` — a sandbox that failed to start doesn't get a ledger entry with a `"failed"` status; it just never has a `sandbox_created` event to derive one from.
 
 ## Filter by name
 

--- a/apps/docs/content/docs/drejx/commands/add.mdx
+++ b/apps/docs/content/docs/drejx/commands/add.mdx
@@ -1,6 +1,6 @@
 ---
 title: drejx add
-description: Fetch a registry item from a URL and provision a sandbox from it.
+description: Fetch an agent spec from a URL or local file and save it to your project's agents directory.
 ---
 
 ```bash
@@ -9,82 +9,56 @@ bunx drejx add <url> [options]
 
 ## Arguments
 
-| Argument | Description                                               |
-| -------- | --------------------------------------------------------- |
-| `url`    | URL or local file path to a registry item JSON. Required. |
+| Argument | Description                                              |
+| -------- | -------------------------------------------------------- |
+| `url`    | URL or local file path to an `AgentSpec` JSON. Required. |
 
 ## Options
 
-| Option           | Description                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| `--name <name>`  | Override the sandbox name. Defaults to the `name` field in the registry item.       |
-| `--server <url>` | Use a different OpenSandbox server. Defaults to `serverUrl` in `.drej/config.json`. |
+| Option          | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `--name <name>` | Override the saved file's name. Defaults to the `name` field in the spec. |
+
+There is no `--server` flag — `add` doesn't talk to a server at all, it only reads and writes local files.
 
 ## What it does
 
-1. Reads `.drej/config.json` for the default server URL.
-2. Fetches the URL and validates it as a registry item.
-3. Resolves any `registryDependencies` first (depth-first, recursive).
-4. Creates a sandbox with the image, resources, and env from the spec.
-5. Runs each command in `setup` in order, streaming output to your terminal.
-6. Checkpoints the sandbox so future `client.resume()` calls skip setup entirely.
-7. Closes the sandbox.
-8. Appends an entry to `.drej/sandboxes.json` with the sandbox ID, name, source URL, and timestamp.
+1. Reads `drej.config.json` for `agentsDir` (defaults to `./agents`). Throws if `drej.config.json` doesn't exist — run `drejx init` first.
+2. Fetches the URL (or reads the local file) and validates it as an `AgentSpec`: `name` must be a string, `cli` must be `"pi"`. All other fields are unchecked.
+3. Resolves any `registryDependencies` first — each dependency URL is fetched and saved the same way, recursively, depth-first, before the top-level spec is saved. Dependencies are **not** deduplicated across separate `add` invocations, or within recursive resolution of the same tree — a dependency listed twice is fetched and saved twice.
+4. Writes the validated spec to `<agentsDir>/<name>.json`.
+
+`add` never creates a sandbox, runs `setup`, or contacts the OpenSandbox server directly — it's a local file operation. The sandbox work happens later, the first time you call `Agent.load()` on the saved spec (see [Running an agent spec](/docs/drejx/using-sandboxes)).
 
 ## Examples
 
 **From a URL:**
 
 ```bash
-bunx drejx add https://registry.drej.dev/node-toolchain.json
+bunx drejx add https://example.com/specs/node-toolchain.json
 ```
 
 **From a local file:**
 
 ```bash
-bunx drejx add ./my-sandbox.json
+bunx drejx add ./my-agent.json
 ```
 
 **With a custom name:**
 
 ```bash
-bunx drejx add https://registry.drej.dev/node-toolchain.json --name ci-env
-```
-
-**Against a remote server:**
-
-```bash
-bunx drejx add https://registry.drej.dev/node-toolchain.json --server https://sandbox.mycompany.com
+bunx drejx add https://example.com/specs/node-toolchain.json --name ci-env
 ```
 
 ## Output
 
-The sandbox ID printed at the end is what you pass to `client.resume()`:
-
 ```
-Sandbox ready: sb_a1b2c3d4  (node-toolchain)
-Resume it with: client.resume("sb_a1b2c3d4")
-```
-
-It is also stored in `.drej/sandboxes.json` so you can retrieve it with `drejx list`.
-
-## `.drej/sandboxes.json`
-
-Each `add` appends one entry:
-
-```json
-[
-  {
-    "name": "node-toolchain",
-    "sandboxId": "sb_a1b2c3d4e5f6g7h8",
-    "url": "https://registry.drej.dev/node-toolchain.json",
-    "createdAt": "2026-06-26T10:00:00.000Z"
-  }
-]
+Agent spec saved: agents/node-toolchain.json
+Load it with: Agent.load("agents/node-toolchain.json") from @drej/agent
 ```
 
 ## Notes
 
-- `drejx add` requires `drejx init` to have been run first (`.drej/config.json` must exist).
-- If a spec has no `setup` commands, the sandbox is created and checkpointed immediately with no setup time.
-- If two specs share a `registryDependency`, the dependency is provisioned once per `add` invocation — it is not deduplicated across invocations.
+- `drejx add` requires `drejx init` to have been run first (`drej.config.json` must exist).
+- If a spec's `registryDependencies` chain is large or has cycles, `add` will fetch and save every one of them without any cycle detection — be careful publishing self-referential or deeply nested dependency chains.
+- Re-running `add` on the same URL overwrites the previously saved spec file with the latest content from the URL.

--- a/apps/docs/content/docs/drejx/commands/index.mdx
+++ b/apps/docs/content/docs/drejx/commands/index.mdx
@@ -12,16 +12,16 @@ description: All drejx commands and their options.
   <Card
     href="/docs/drejx/commands/add"
     title="add"
-    description="Fetch a registry item and provision a sandbox from it."
+    description="Fetch an agent spec from a URL or file and save it locally."
   />
   <Card
     href="/docs/drejx/commands/list"
     title="list"
-    description="List all sandboxes provisioned in this project."
+    description="List the agent specs saved in this project."
   />
   <Card
     href="/docs/drejx/commands/remove"
     title="remove"
-    description="Remove a sandbox entry from the project."
+    description="Delete a saved agent spec file."
   />
 </Cards>

--- a/apps/docs/content/docs/drejx/commands/init.mdx
+++ b/apps/docs/content/docs/drejx/commands/init.mdx
@@ -14,33 +14,39 @@ bunx drejx init
 3. If the container exists but is stopped, restarts it.
 4. Otherwise, pulls `opensandbox/server:latest` and starts it, mounting the Docker socket so the server can manage sandbox containers.
 5. Waits up to 60 seconds for the server to report healthy.
-6. Writes `.drej/config.json` in the current directory with the server URL and adapter path.
+6. Writes `drej.config.json` in the current directory (project root) if it doesn't already exist.
 
 ## Output files
 
-### `.drej/config.json`
+### `drej.config.json`
 
-Written once. Contains the connection details for your project.
+Written once, in the project root (not under `.drej/`). Contains the connection details and defaults used by both `drejx` and `@drej/agent`.
 
 ```json
 {
   "serverUrl": "http://localhost:8080",
   "useServerProxy": true,
   "apiKey": "",
-  "adapterPath": "./.drej/ledger.db"
+  "adapterPath": "./.drej/ledger.db",
+  "agentsDir": "./agents",
+  "defaults": {
+    "resources": { "cpu": "1000m", "memory": "1Gi" }
+  }
 }
 ```
 
-| Field            | Description                                                                              |
-| ---------------- | ---------------------------------------------------------------------------------------- |
-| `serverUrl`      | The OpenSandbox server URL.                                                              |
-| `useServerProxy` | Always `true` when started via `drejx init`. Pass this to the `Drej` client constructor. |
-| `apiKey`         | Empty for local dev. Set this if your server requires authentication.                    |
-| `adapterPath`    | Path to the SQLite ledger database for this project.                                     |
+| Field                | Description                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| `serverUrl`          | The OpenSandbox server URL.                                                                  |
+| `useServerProxy`     | Always `true` when started via `drejx init`. `@drej/agent` reads this for its `Drej` client. |
+| `apiKey`             | Empty for local dev. Set this if your server requires authentication.                        |
+| `adapterPath`        | Path to the SQLite ledger database for this project.                                         |
+| `agentsDir`          | Directory `drejx add`/`list`/`remove` read and write agent spec files in.                    |
+| `defaults.resources` | CPU/memory used for an agent's sandbox when its spec omits `resources`.                      |
 
 ## Idempotency
 
-`drejx init` is safe to run multiple times. If the server is already running it prints the URL and exits. If `.drej/config.json` already exists it is not overwritten.
+`drejx init` is safe to run multiple times. If the server is already running it prints the URL and exits. If `drej.config.json` already exists it is not overwritten.
 
 ## Docker requirements
 

--- a/apps/docs/content/docs/drejx/commands/list.mdx
+++ b/apps/docs/content/docs/drejx/commands/list.mdx
@@ -1,31 +1,32 @@
 ---
 title: drejx list
-description: List all sandboxes provisioned in the current project.
+description: List the agent specs saved in the current project's agents directory.
 ---
 
 ```bash
 bunx drejx list
 ```
 
-Reads `.drej/sandboxes.json` and prints a table of all provisioned sandboxes.
+Reads `drej.config.json` for `agentsDir` (defaults to `./agents`), lists every `.json` file there, and prints a table. It does not query the OpenSandbox server or check whether any sandbox exists for a spec — it only reads local files.
 
 ## Example output
 
 ```
-NAME                  SANDBOX ID            AGE     URL
-node-toolchain        sb_a1b2c3d4e5f6g7    2m      https://registry.drej.dev/node-toolchain.json
-python-data-sci       sb_h8i9j0k1l2m3n4    1h      https://registry.drej.dev/python-ds.json
+NAME                  CLI       DESCRIPTION
+node-toolchain        pi        A Node.js sandbox with TypeScript tooling.
+python-data-sci        pi        A Python sandbox for data science work.
 ```
 
-| Column       | Description                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------- |
-| `NAME`       | The name given to the sandbox (from the registry item or `--name`).                                            |
-| `SANDBOX ID` | The first 16 characters of the sandbox ID. Use `client.resume()` with the full ID from `.drej/sandboxes.json`. |
-| `AGE`        | How long ago the sandbox was provisioned.                                                                      |
-| `URL`        | The registry item URL used to provision it.                                                                    |
+| Column        | Description                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `NAME`        | The spec's `name` field, or the filename (without `.json`) as a fallback. Truncated to 19 characters. |
+| `CLI`         | The spec's `cli` field (currently always `"pi"`). Truncated to 7 characters.                          |
+| `DESCRIPTION` | The spec's `description` field, falling back to `title`, or blank if neither is set.                  |
+
+A spec file that fails to parse as JSON is still listed, with `(unreadable)` in place of its columns, instead of being silently skipped.
 
 ## Notes
 
-- `list` shows the sandboxes tracked in this project's `.drej/sandboxes.json`. It does not query the running OpenSandbox server.
-- A sandbox appearing here does not mean its container is currently running — the container is stopped after provisioning and resumed on demand.
-- If no sandboxes have been provisioned yet, `list` prints a short message and exits cleanly.
+- `list` only reflects what's in `agentsDir` on disk — a spec appearing here does not mean it has ever been `Agent.load()`ed or has a sandbox snapshot yet.
+- If `agentsDir` doesn't exist, `list` prints `No agents dir found at '<dir>'. Run 'drejx add <url>' to add an agent spec.` and exits cleanly.
+- If `agentsDir` exists but is empty, `list` prints `No agent specs found. Run 'drejx add <url>' to add one.` and exits cleanly.

--- a/apps/docs/content/docs/drejx/commands/remove.mdx
+++ b/apps/docs/content/docs/drejx/commands/remove.mdx
@@ -1,6 +1,6 @@
 ---
 title: drejx remove
-description: Remove a sandbox entry from the current project.
+description: Delete a saved agent spec file from the current project.
 ---
 
 ```bash
@@ -9,25 +9,25 @@ bunx drejx remove <name>
 
 ## Arguments
 
-| Argument | Description                                          |
-| -------- | ---------------------------------------------------- |
-| `name`   | The sandbox name as shown by `drejx list`. Required. |
+| Argument | Description                                       |
+| -------- | ------------------------------------------------- |
+| `name`   | The spec name as shown by `drejx list`. Required. |
 
 ## What it does
 
-1. Looks up the sandbox by name in `.drej/sandboxes.json`.
-2. Sends a best-effort delete request to the OpenSandbox server (silently ignored if the container is already gone).
-3. Removes the entry from `.drej/sandboxes.json`.
+1. Looks for `<agentsDir>/<name>.json`. Throws `No agent spec named '<name>' in '<agentsDir>'. Run 'drejx list' to see available specs.` if it doesn't exist.
+2. Deletes the file.
+
+No network calls are made and no sandbox is touched — `remove` is a plain local file delete.
 
 ## Example
 
 ```bash
 bunx drejx remove node-toolchain
-# Removed sandbox 'node-toolchain' (sb_a1b2c3d4e5f6g7h8)
+# Removed agent spec 'node-toolchain'
 ```
 
 ## Notes
 
-- If the sandbox container was already stopped (the usual state after `drejx add`), the delete request is a no-op and `remove` still succeeds.
-- `remove` only removes the entry from `.drej/sandboxes.json`. It does not delete the ledger history in `.drej/ledger.db`. The audit trail is preserved.
-- To remove a sandbox that was renamed with `--name`, use the custom name, not the name from the registry item.
+- `remove` only deletes the spec JSON file. It does not delete any sandbox snapshot created by a prior `Agent.load()` — that's tracked separately, in `agent-snapshots.json` next to your ledger — nor does it touch the ledger itself.
+- To remove a spec that was saved with `--name` on `add`, use that custom name, not the `name` field from inside the spec file.

--- a/apps/docs/content/docs/drejx/getting-started/index.mdx
+++ b/apps/docs/content/docs/drejx/getting-started/index.mdx
@@ -1,26 +1,34 @@
 ---
 title: What is drejx?
-description: drejx lets you spin up a pre-configured sandbox environment from a URL — no Dockerfile knowledge, no manual setup.
+description: drejx fetches and manages @drej/agent spec files locally, and starts a local OpenSandbox server for you — it doesn't provision sandboxes itself.
 ---
 
-`drejx` is a CLI for the drej registry. A registry item is a JSON spec that describes a sandbox — its base image, setup commands, and resource limits. Anyone with the URL can provision a live, ready-to-use sandbox from it with a single command.
+`drejx` is a small local CLI for working with [`@drej/agent`](/docs/agent) spec files (`AgentSpec` — the JSON that describes a Pi coding-agent sandbox: CLI, model/provider, packages, env, and setup steps). It does **not** talk to OpenSandbox, provision containers, or checkpoint anything — it only manages spec files on disk.
 
 ```bash
 bunx drejx init
 bunx drejx add https://example.com/my-agent.json
 ```
 
-The first command starts a local OpenSandbox server via Docker. The second fetches the spec, provisions a sandbox, runs any setup commands, and saves a reference so you can resume it from your code.
+The first command starts a local OpenSandbox server via Docker and writes `drej.config.json` to your project. The second fetches an agent spec from a URL (or local file), validates it, and saves it under `./agents/<name>.json`.
 
 ## When to use drejx
 
-- You want to share a reproducible sandbox environment (a pre-loaded Node.js toolchain, a Python data-science environment, a code review agent) with your team or the public.
-- You want to provision sandboxes from a URL without writing any provisioning code.
 - You want a local OpenSandbox server running without manually configuring or running `uvx opensandbox-server`.
+- You want to fetch a shared agent spec (e.g. a pre-configured Pi coding-agent setup) from a URL instead of writing the JSON by hand.
+- You want a simple way to list and remove the agent specs saved in your project's `agents/` directory.
 
-## How it relates to drej
+## How it relates to `@drej/agent`
 
-`drejx` uses the `drej` SDK under the hood. Once you run `drejx add`, you use the standard `drej` client in your code to connect to the provisioned sandbox — `drejx` just handles the provisioning step.
+`drejx` only manages spec files — it never runs an agent or touches a sandbox itself. To actually run one, load the spec `drejx add` saved with `@drej/agent`'s `Agent.load()`:
+
+```ts
+import { Agent } from "@drej/agent";
+
+const agent = await Agent.load("./agents/my-agent.json");
+```
+
+`Agent.load()` reads `drej.config.json` itself (the same file `drejx init` writes) to know where the OpenSandbox server is — you don't pass connection details manually.
 
 ## Next steps
 
@@ -28,7 +36,7 @@ The first command starts a local OpenSandbox server via Docker. The second fetch
   <Card
     href="/docs/drejx/getting-started/quickstart"
     title="Quickstart"
-    description="Install, init, and add your first registry sandbox."
+    description="Install drejx, start OpenSandbox, and fetch your first agent spec."
   />
   <Card
     href="/docs/drejx/commands"

--- a/apps/docs/content/docs/drejx/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/drejx/getting-started/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Start a local OpenSandbox server and provision your first sandbox in under five minutes.
+description: Start a local OpenSandbox server and fetch your first agent spec in under five minutes.
 ---
 
 ## Prerequisites
@@ -10,7 +10,7 @@ description: Start a local OpenSandbox server and provision your first sandbox i
 
 ## 1. Start OpenSandbox locally
 
-Run `drejx init` once per project. It starts an OpenSandbox server in Docker and writes a `.drej/config.json` to your project.
+Run `drejx init` once per project. It starts an OpenSandbox server in Docker and writes a `drej.config.json` to your project root.
 
 ```bash
 bunx drejx init
@@ -23,71 +23,67 @@ Waiting for OpenSandbox to be ready...
 OpenSandbox running at http://localhost:8080 — ready.
 ```
 
-If the server is already running from a previous `init`, `drejx init` exits immediately without starting a second container.
+If the server is already running from a previous `init`, `drejx init` prints the URL and exits immediately without starting a second container.
 
-## 2. Provision a sandbox
+## 2. Fetch an agent spec
 
-Point `drejx add` at any URL (or local file) that returns a valid registry item:
+Point `drejx add` at any URL (or local file path) that returns a valid `AgentSpec` JSON:
 
 ```bash
-bunx drejx add https://registry.drej.dev/node-toolchain.json
+bunx drejx add https://example.com/specs/code-reviewer.json
 ```
 
 ```
-Spawning sandbox 'node-toolchain'...
-  $ npm install -g typescript eslint
-  $ mkdir -p /workspace
-Sandbox ready: sb_a1b2c3d4  (node-toolchain)
-Resume it with: client.resume("sb_a1b2c3d4")
+Agent spec saved: agents/code-reviewer.json
+Load it with: Agent.load("agents/code-reviewer.json") from @drej/agent
 ```
 
-`drejx` fetches the spec, runs the setup commands, checkpoints the result, and records the sandbox ID in `.drej/sandboxes.json`. The checkpoint means future resumes skip setup entirely and start in seconds.
+`drejx add` fetches the spec, validates it (`name` and `cli: "pi"` are required), resolves any `registryDependencies` first (fetched recursively, depth-first), and writes it to `<agentsDir>/<name>.json` — `agentsDir` defaults to `./agents`. It does **not** create a sandbox, run setup, or checkpoint anything — that happens later, the first time you `Agent.load()` the spec.
 
-## 3. List your sandboxes
+## 3. List your saved specs
 
 ```bash
 bunx drejx list
 ```
 
 ```
-NAME                  SANDBOX ID            AGE     URL
-node-toolchain        sb_a1b2c3d4e5f6g7    2m      https://registry.drej.dev/node-toolchain.json
+NAME                  CLI       DESCRIPTION
+code-reviewer         pi        A Node.js sandbox pre-loaded with TypeScript tooling.
 ```
 
-## 4. Use the sandbox in your code
+## 4. Run the agent
 
-Read the sandbox ID from the output (or from `.drej/sandboxes.json`) and resume it with the `drej` client:
+`Agent.load()` (from `@drej/agent`) does the actual sandbox work: on first load it spins up a `node:22` sandbox, installs the Pi CLI and any `setup` steps, then checkpoints it. Subsequent loads restore from that snapshot, skipping the install.
 
 ```ts
-import { Drej } from "drej";
-import { SQLiteAdapter } from "@drej/sqlite";
+import { Agent, textOnly } from "@drej/agent";
 
-const client = new Drej({
-  baseUrl: "http://localhost:8080",
-  useServerProxy: true,
-  adapter: new SQLiteAdapter("./.drej/ledger.db"),
-});
+const agent = await Agent.load("agents/code-reviewer.json");
 
-const sb = await client.resume("sb_a1b2c3d4");
-try {
-  await sb.exec("tsc --version").pipe(process.stdout);
-} finally {
-  await sb.close();
+for await (const chunk of textOnly(agent.prompt("Review this repo for obvious bugs."))) {
+  process.stdout.write(chunk);
 }
+
+await agent.close();
 ```
 
-`useServerProxy: true` is required when the server was started by `drejx init`. The `.drej/config.json` written by `init` contains all the right values if you prefer to read them from there.
+`Agent.load()` reads `drej.config.json` itself for the OpenSandbox server URL and other defaults — the same file `drejx init` wrote in step 1. You don't need to construct a `Drej` client or pass connection details by hand.
 
-## 5. Remove a sandbox
+## 5. Remove a spec
 
 ```bash
-bunx drejx remove node-toolchain
+bunx drejx remove code-reviewer
 ```
 
-This removes the entry from `.drej/sandboxes.json`. The sandbox ID is no longer tracked.
+```
+Removed agent spec 'code-reviewer'
+```
+
+This deletes `agents/code-reviewer.json`. It's purely a local file operation — no sandbox or snapshot is touched. If you'd previously run `Agent.load()` on that spec, its sandbox snapshot (tracked separately, in `agent-snapshots.json` next to your ledger) is unaffected.
 
 ## Next steps
 
 - [Commands reference](/docs/drejx/commands) — all flags for each command
-- [Registry format](/docs/drejx/registry) — publish your own sandbox spec
-- [Using sandboxes in code](/docs/drejx/using-sandboxes) — full details on resuming and working with sandboxes
+- [Registry format](/docs/drejx/registry) — publish your own agent spec
+- [Running an agent spec](/docs/drejx/using-sandboxes) — full details on `Agent.load()`
+- [@drej/agent overview](/docs/agent) — the full Agent API (prompting, streaming, sessions, snapshotting)

--- a/apps/docs/content/docs/drejx/index.mdx
+++ b/apps/docs/content/docs/drejx/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: drejx
-description: "drejx — the drej CLI for provisioning pre-built sandboxes from a registry URL."
+description: "drejx — a local CLI for managing @drej/agent spec files: fetch, list, and remove them, plus a one-command local OpenSandbox server."
 ---
 
 <Cards>
   <Card
     href="/docs/drejx/getting-started"
     title="Getting Started"
-    description="Install drejx, start a local OpenSandbox server, and provision your first sandbox."
+    description="Install drejx, start a local OpenSandbox server, and fetch your first agent spec."
   />
   <Card
     href="/docs/drejx/commands"
@@ -17,11 +17,11 @@ description: "drejx — the drej CLI for provisioning pre-built sandboxes from a
   <Card
     href="/docs/drejx/registry"
     title="Registry Format"
-    description="Publish your own sandbox specs so others can spin them up with a single command."
+    description="Publish your own agent spec files so others can fetch them with a single command."
   />
   <Card
     href="/docs/drejx/using-sandboxes"
-    title="Using Sandboxes in Code"
-    description="Connect to a provisioned sandbox from your drej application."
+    title="Running an agent spec"
+    description="Load an agent spec saved by drejx add with @drej/agent's Agent.load()."
   />
 </Cards>

--- a/apps/docs/content/docs/drejx/registry/index.mdx
+++ b/apps/docs/content/docs/drejx/registry/index.mdx
@@ -1,53 +1,57 @@
 ---
 title: Registry
-description: Publish a JSON spec to let anyone spin up your sandbox environment with a single command.
+description: Publish an AgentSpec JSON file so others can fetch it with a single command.
 ---
 
-A drejx registry is just a URL that returns a JSON object. There is no central registry — any URL works, including a GitHub raw file, a Gist, or your own server.
+A drejx "registry item" is just a URL that returns an `AgentSpec` JSON object (the same spec type used by [`@drej/agent`](/docs/agent)). There is no central registry — any URL works, including a GitHub raw file, a Gist, or your own server.
 
 <Cards>
   <Card
     href="/docs/drejx/registry/schema"
-    title="Registry item schema"
-    description="All fields, types, and constraints for a valid registry item."
+    title="AgentSpec schema"
+    description="All fields, types, and constraints for a valid agent spec."
   />
 </Cards>
 
-## Publishing a registry item
+## Publishing a spec
 
-A registry item is a static JSON file. Hosting it is as simple as pushing it to a public GitHub repository and sharing the raw URL:
+An agent spec is a static JSON file. Hosting it is as simple as pushing it to a public GitHub repository and sharing the raw URL:
 
 ```
-https://raw.githubusercontent.com/your-org/your-repo/main/sandboxes/node-toolchain.json
+https://raw.githubusercontent.com/your-org/your-repo/main/agents/node-toolchain.json
 ```
 
-Anyone can then provision it with:
+Anyone can then fetch it into their own project with:
 
 ```bash
-bunx drejx add https://raw.githubusercontent.com/your-org/your-repo/main/sandboxes/node-toolchain.json
+bunx drejx add https://raw.githubusercontent.com/your-org/your-repo/main/agents/node-toolchain.json
 ```
 
+This only saves the spec locally — it doesn't run anything. See [Running an agent spec](/docs/drejx/using-sandboxes) for how to actually load and run it with `Agent.load()`.
+
 ## Minimal example
+
+Every spec runs inside a `node:22` sandbox (there's no `image` field — the base image is fixed) and requires `cli: "pi"`:
 
 ```json
 {
   "name": "node-toolchain",
-  "image": "node:22",
-  "resources": { "cpu": "500m", "memory": "512Mi" },
-  "setup": ["npm install -g typescript eslint prettier", "mkdir -p /workspace"]
+  "cli": "pi",
+  "setup": [{ "name": "install tools", "run": "npm install -g typescript eslint prettier" }]
 }
 ```
 
 ## Composition with `registryDependencies`
 
-A registry item can declare dependencies on other items. `drejx add` provisions them first, depth-first:
+A spec can declare dependencies on other specs by URL. `drejx add` fetches and saves them first, depth-first, before saving the top-level spec — it does not merge or run them, each dependency just ends up as its own separate spec file in `agentsDir`:
 
 ```json
 {
   "name": "ts-reviewer",
-  "image": "node:22",
-  "resources": { "cpu": "500m", "memory": "512Mi" },
-  "registryDependencies": ["https://registry.drej.dev/node-toolchain.json"],
-  "setup": ["npm install -g @typescript-eslint/parser"]
+  "cli": "pi",
+  "registryDependencies": ["https://example.com/agents/node-toolchain.json"],
+  "setup": [{ "name": "install linter", "run": "npm install -g @typescript-eslint/parser" }]
 }
 ```
+
+There's no cycle detection — avoid dependency chains that reference each other.

--- a/apps/docs/content/docs/drejx/registry/schema.mdx
+++ b/apps/docs/content/docs/drejx/registry/schema.mdx
@@ -1,9 +1,9 @@
 ---
-title: Registry item schema
-description: Complete field reference for a drejx registry item JSON.
+title: AgentSpec schema
+description: Complete field reference for the AgentSpec JSON fetched by drejx add and run by @drej/agent's Agent.load().
 ---
 
-A registry item is a JSON object. Only `name`, `image`, and `resources` are required.
+An agent spec is a JSON object — the same `AgentSpec` type `@drej/agent` exports. Only `name` and `cli` are required; `drejx add` and `Agent.load()` both use the same [`validateAgentSpec()`](https://github.com/DrejT/drej/blob/main/packages/agent/src/schema.ts) function.
 
 ## Full example
 
@@ -15,68 +15,56 @@ A registry item is a JSON object. Only `name`, `image`, and `resources` are requ
   "author": "acme <https://github.com/acme>",
   "categories": ["agent", "typescript"],
 
-  "image": "node:22",
+  "cli": "pi",
+  "provider": "google",
+  "model": "gemini-flash-latest",
+  "packages": ["git"],
+  "env": { "GEMINI_API_KEY": "${GEMINI_API_KEY}" },
   "resources": { "cpu": "500m", "memory": "512Mi" },
-  "env": { "NODE_ENV": "production" },
 
-  "setup": ["npm install -g typescript eslint", "mkdir -p /workspace"],
+  "setup": [
+    { "name": "install tools", "run": "npm install -g typescript eslint" },
+    { "name": "make workspace", "run": "mkdir -p /workspace" }
+  ],
 
-  "ports": [3000],
-
-  "metadata": { "version": "1.0.0" },
-
-  "registryDependencies": ["https://registry.drej.dev/base-node.json"]
+  "registryDependencies": ["https://example.com/agents/base-node.json"]
 }
 ```
+
+There's no `image` field — every spec runs in a fixed `node:22` sandbox — and no `ports` field.
 
 ## Fields
 
 ### Required
 
-| Field       | Type                  | Description                                                                                         |
-| ----------- | --------------------- | --------------------------------------------------------------------------------------------------- |
-| `name`      | `string`              | Unique identifier for the sandbox. Used as the entry name in `drejx list`.                          |
-| `image`     | `string \| ImageSpec` | Container image. A plain string (`"node:22"`) or an object `{ uri, auth? }` for private registries. |
-| `resources` | `ResourceSpec`        | CPU and memory limits. Required by the OpenSandbox server.                                          |
-
-**`ResourceSpec`**
-
-```json
-{ "cpu": "500m", "memory": "512Mi" }
-```
-
-| Field    | Type     | Description                                                         |
-| -------- | -------- | ------------------------------------------------------------------- |
-| `cpu`    | `string` | CPU limit in Kubernetes resource notation (`"500m"`, `"1"`, `"2"`). |
-| `memory` | `string` | Memory limit (`"256Mi"`, `"1Gi"`).                                  |
-| `gpu`    | `string` | Optional GPU limit.                                                 |
-
-**`ImageSpec`** (for private registries)
-
-```json
-{ "uri": "ghcr.io/your-org/your-image:latest", "auth": { "username": "x", "password": "ghp_..." } }
-```
+| Field  | Type     | Description                                                                                        |
+| ------ | -------- | -------------------------------------------------------------------------------------------------- |
+| `name` | `string` | Unique identifier. Used as the saved filename (`<name>.json`) and the sandbox session name.        |
+| `cli`  | `"pi"`   | CLI to run inside the sandbox. Currently only `"pi"` is accepted — anything else fails validation. |
 
 ### Optional
 
-| Field                  | Type                     | Description                                                                                                    |
-| ---------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| `title`                | `string`                 | Human-readable display name.                                                                                   |
-| `description`          | `string`                 | Short description shown in tooling.                                                                            |
-| `author`               | `string`                 | Author name and optional URL.                                                                                  |
-| `categories`           | `string[]`               | Tags for discovery (e.g. `["agent", "python"]`).                                                               |
-| `env`                  | `Record<string, string>` | Environment variables injected at sandbox startup.                                                             |
-| `setup`                | `string[]`               | Shell commands run in order after the sandbox starts. The result is checkpointed so future resumes skip setup. |
-| `ports`                | `number[]`               | Informational. Documents which ports the sandbox exposes. Call `sb.proxy(port)` to reach them from your code.  |
-| `metadata`             | `Record<string, string>` | Arbitrary key-value labels attached to the sandbox.                                                            |
-| `registryDependencies` | `string[]`               | URLs of other registry items to provision first. Resolved depth-first before this item's setup runs.           |
+| Field                  | Type                                            | Description                                                                                                                                                                                                                                                                           |
+| ---------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | `string`                                        | Human-readable display name.                                                                                                                                                                                                                                                          |
+| `description`          | `string`                                        | Shown by `drejx list`, falling back from `title` if `description` is unset.                                                                                                                                                                                                           |
+| `author`               | `string`                                        | Author name and optional URL.                                                                                                                                                                                                                                                         |
+| `categories`           | `string[]`                                      | Tags for discovery. Not currently used by any command — informational only.                                                                                                                                                                                                           |
+| `cliVersion`           | `string`                                        | Included in the setup-hash cache key, so changing it forces a fresh install. `Agent.load()` always installs the latest Pi CLI — this doesn't pin a specific version.                                                                                                                  |
+| `provider`             | `string`                                        | AI provider passed to Pi via `--provider`. Omit for a direct Google API key (Pi's default).                                                                                                                                                                                           |
+| `model`                | `string`                                        | Model ID passed to Pi via `--model`.                                                                                                                                                                                                                                                  |
+| `packages`             | `string[]`                                      | APT packages installed before the CLI starts. `nodejs`/`nodejs_22` are silently ignored (the base image already has Node).                                                                                                                                                            |
+| `env`                  | `Record<string, string>`                        | Environment variables available inside the sandbox. Values may reference host env vars: `"${MY_API_KEY}"` → `process.env.MY_API_KEY` at load time.                                                                                                                                    |
+| `resources`            | `{ cpu: string; memory: string; gpu?: string }` | Falls back to `defaults.resources` in `drej.config.json` if omitted (`1000m` / `1Gi` by default).                                                                                                                                                                                     |
+| `metadata`             | `Record<string, string>`                        | Not read anywhere in `@drej/agent`; has no effect on the sandbox.                                                                                                                                                                                                                     |
+| `registryDependencies` | `string[]`                                      | URLs of other agent specs. `drejx add` fetches and saves each one first, depth-first, before saving this spec. No cycle detection.                                                                                                                                                    |
+| `setup`                | `SetupStep[]`                                   | Steps run inside the sandbox after CLI install, before the checkpoint. Each is `{ name, run, cwd? }` — `run` is a bash command, `cwd` optionally changes directory first. Any change here invalidates the setup-hash cache, forcing a fresh install+setup on the next `Agent.load()`. |
 
 ## Validation
 
-`drejx add` validates the JSON before provisioning. It will error if:
+Both `drejx add` and `Agent.load()` call the same `validateAgentSpec()`. It only checks two things:
 
-- `name` is missing or not a string.
-- `image` is missing.
-- `resources` is missing, or `resources.cpu` / `resources.memory` are not strings.
+- `name` is present and is a string.
+- `cli` is exactly `"pi"`.
 
-All other fields are optional and silently ignored if malformed.
+Every other field is unchecked at validation time — a malformed `resources`, `setup` entry, or `env` value won't be caught until it's actually used (typically inside the sandbox, at load/run time).

--- a/apps/docs/content/docs/drejx/using-sandboxes.mdx
+++ b/apps/docs/content/docs/drejx/using-sandboxes.mdx
@@ -1,107 +1,85 @@
 ---
-title: Using Sandboxes in Code
-description: Connect to a drejx-provisioned sandbox from your drej application.
+title: Running an agent spec
+description: Load an agent spec saved by drejx add with @drej/agent's Agent.load() — drejx never creates a sandbox itself.
 ---
 
-After `drejx add` finishes, the sandbox is checkpointed and its ID is stored in `.drej/sandboxes.json`. To use it, create a `Drej` client and call `client.resume()`.
+`drejx add` only fetches and saves an `AgentSpec` JSON file — it never creates a sandbox, runs setup, or checkpoints anything. To actually run the agent, load the spec with [`@drej/agent`](/docs/agent)'s `Agent.load()`.
 
 ## Setup
 
 ```bash
-bun add drej @drej/sqlite
+bun add @drej/agent
 ```
 
-## Connecting
+## Loading and prompting
 
 ```ts
-import { Drej } from "drej";
-import { SQLiteAdapter } from "@drej/sqlite";
+import { Agent, textOnly } from "@drej/agent";
 
-const client = new Drej({
-  baseUrl: "http://localhost:8080",
-  useServerProxy: true,
-  adapter: new SQLiteAdapter("./.drej/ledger.db"),
-});
-```
+const agent = await Agent.load("agents/node-toolchain.json");
 
-`useServerProxy: true` is required when the server was started by `drejx init`. The values for `baseUrl` and `adapterPath` are in `.drej/config.json` if you want to read them dynamically.
-
-## Resuming a sandbox
-
-Pass the sandbox ID printed by `drejx add` (or read from `.drej/sandboxes.json`) to `client.resume()`:
-
-```ts
-const sb = await client.resume("sb_a1b2c3d4e5f6g7h8");
-try {
-  await sb.exec("node --version").pipe(process.stdout);
-} finally {
-  await sb.close();
+for await (const chunk of textOnly(agent.prompt("What Node version is installed?"))) {
+  process.stdout.write(chunk);
 }
+
+await agent.close();
 ```
 
-`resume()` restores the sandbox from its checkpoint. Because the setup was already run and checkpointed by `drejx add`, the sandbox is ready in seconds — no re-running of `setup` commands.
+`Agent.load()` reads `drej.config.json` itself — the same file `drejx init` writes — for the OpenSandbox server URL, `useServerProxy`, and default resource limits. You don't construct a `Drej` client or pass connection details by hand.
 
-## Reading the config and sandboxes file
+## What happens on load
 
-You can load connection details and sandbox IDs directly from the files `drejx` writes:
+- **First load for a spec**: spins up a `node:22` sandbox, installs the Pi CLI and any `setup` steps from the spec, then checkpoints the sandbox. This is the slow path.
+- **Subsequent loads**: restore from that checkpoint, skipping the install entirely — much faster. The snapshot is keyed on a hash of `cli`, `cliVersion`, `packages`, and `setup`, so changing any of those forces a fresh install on the next load.
+- Pass `{ rebuild: true }` to force a full reinstall regardless of the cache: `Agent.load(specPath, { rebuild: true })`.
+
+See [Snapshotting](/docs/agent/getting-started/snapshotting) for the full details.
+
+## Accessing the underlying sandbox
+
+`agent.sandbox` is the live `Sandbox` from `@drej/core` — use it for anything not covered by the `Agent` API, like reading files or exposing a port:
 
 ```ts
-import { readFileSync } from "fs";
+const agent = await Agent.load("agents/web-service.json");
 
-const config = JSON.parse(readFileSync(".drej/config.json", "utf8"));
-const sandboxes = JSON.parse(readFileSync(".drej/sandboxes.json", "utf8"));
+await agent.sandbox.exec("node server.js &");
+const { url, headers } = await agent.sandbox.proxy(3000);
+const res = await fetch(`${url}/health`, { headers });
+console.log(await res.text());
 
-const entry = sandboxes.find((s: { name: string }) => s.name === "node-toolchain");
-
-const client = new Drej({
-  baseUrl: config.serverUrl,
-  useServerProxy: config.useServerProxy,
-  adapter: new SQLiteAdapter(config.adapterPath),
-});
-
-const sb = await client.resume(entry.sandboxId);
+await agent.close();
 ```
 
-## Accessing ports
+## Multiple agents
 
-If the registry item documented exposed ports, use `sb.proxy()` to get a URL you can send HTTP requests to:
-
-```ts
-const sb = await client.resume("sb_a1b2c3d4");
-try {
-  await sb.exec("node server.js &");
-  const { url, headers } = await sb.proxy(3000);
-  const res = await fetch(`${url}/health`, { headers });
-  console.log(await res.text());
-} finally {
-  await sb.close();
-}
-```
-
-## Multiple resumes
-
-Every `client.resume()` call creates a fresh container restored from the same checkpoint. Each resume is independent — running commands on one does not affect another.
+Each `Agent.load()` call for the same spec restores an independent sandbox from the same checkpoint — running one doesn't affect another:
 
 ```ts
-const [sb1, sb2] = await Promise.all([client.resume("sb_a1b2c3d4"), client.resume("sb_a1b2c3d4")]);
-
-// sb1 and sb2 are separate containers, both starting from the same state
-await Promise.all([
-  sb1.exec("npm test").pipe(process.stdout),
-  sb2.exec("npm run build").pipe(process.stdout),
+const [a1, a2] = await Promise.all([
+  Agent.load("agents/reviewer.json"),
+  Agent.load("agents/reviewer.json"),
 ]);
 
-await Promise.all([sb1.close(), sb2.close()]);
+await Promise.all([
+  (async () => {
+    for await (const chunk of textOnly(a1.prompt("Review src/a.ts"))) process.stdout.write(chunk);
+  })(),
+  (async () => {
+    for await (const chunk of textOnly(a2.prompt("Review src/b.ts"))) process.stdout.write(chunk);
+  })(),
+]);
+
+await Promise.all([a1.close(), a2.close()]);
 ```
 
-## Sandbox lifecycle
+## Lifecycle
 
-- `client.resume()` creates a container. It costs resources until `sb.close()` is called.
-- Always call `sb.close()` when done — use `try/finally` to ensure it runs on error.
-- The original checkpoint is preserved after every resume. You can resume the same sandbox ID as many times as needed.
+- `Agent.load()` creates a sandbox (or resumes one). It costs resources until `agent.close()` is called.
+- Always call `agent.close()` when done — use `try/finally` to ensure it runs on error.
+- The checkpoint from the first load is preserved. You can `Agent.load()` the same spec as many times as needed without repeating setup.
 
 ## See also
 
+- [@drej/agent overview](/docs/agent) — the full `Agent` API: prompting, streaming, sessions, snapshotting
 - [drej core SDK — exec](/docs/core/building/exec)
 - [drej core SDK — file operations](/docs/core/building/file-ops)
-- [drej core SDK — snapshots and resume](/docs/core/building/snapshots)

--- a/apps/docs/content/docs/workflow/api-reference/builder.mdx
+++ b/apps/docs/content/docs/workflow/api-reference/builder.mdx
@@ -174,7 +174,7 @@ sb.retry(
 ): this
 ```
 
-Queue a retry block. On failure, waits `delayMs` and retries up to `maxAttempts` times.
+Queue a retry block. Runs up to `maxAttempts` total attempts (the first run plus retries), waiting `delayMs` between each on failure.
 
 ```ts
 interface RetryOptions {

--- a/apps/docs/content/docs/workflow/building/control-flow.mdx
+++ b/apps/docs/content/docs/workflow/building/control-flow.mdx
@@ -26,7 +26,7 @@ sb.retry(
 | `delayMs` | `number`                   | `1000`    | Wait between attempts (ms) |
 | `backoff` | `"fixed" \| "exponential"` | `"fixed"` | Delay growth strategy      |
 
-With `backoff: "exponential"`, each retry multiplies `delayMs` by the attempt number: 1s, 2s, 4s, ...
+With `backoff: "exponential"`, the delay doubles each attempt (`delayMs * 2^(attempt-1)`): 1s, 2s, 4s, ...
 
 ## when
 
@@ -77,6 +77,8 @@ sb.forEach(packages, (sb, pkg) => sb.exec(`npm install ${pkg}`), { concurrency: 
 | Option        | Type     | Default | Description             |
 | ------------- | -------- | ------- | ----------------------- |
 | `concurrency` | `number` | `1`     | Max parallel iterations |
+
+With `concurrency > 1`, each parallel branch flushes against a shallow copy of the outer `FlushContext`. `stdout`/`exitCode` writes inside those branches don't propagate back to the outer context afterward — only `vars` (an object reference) does. Don't rely on `ctx.stdout`/`ctx.exitCode` reflecting what happened inside a concurrent `forEach` after it completes.
 
 ## Composing
 

--- a/apps/docs/content/docs/workflow/building/sandbox-builder.mdx
+++ b/apps/docs/content/docs/workflow/building/sandbox-builder.mdx
@@ -19,10 +19,14 @@ Queue a shell command. `strict: true` (default) throws `CommandError` on non-zer
 ## execCode
 
 ```ts
-sb.execCode(`print("hello")`, { language: "python" });
+import { CodeLanguage } from "@drej/opensandbox";
+
+sb.execCode(`print("hello")`, { context: { id: "my-context", language: CodeLanguage.Python } });
 ```
 
-Queue a code snippet via the interpreter. Stateless by default — each call gets a fresh context. Pass `{ stateful: true }` to share state across execCode calls in the same sandbox.
+Queue a code snippet via the interpreter. There's no `language` shorthand or `stateful` flag — `ExecCodeOptions` only takes an optional `context: { id, language }`. Reusing the same `id` across calls shares interpreter state between them; a call with no `context` runs stateless.
+
+`SandboxBuilder` has no queued equivalent of `Sandbox.createCodeContext()` — you supply the context object directly (as above) rather than obtaining one from execd first. If you need a context created via `createCodeContext()`, use the direct `Sandbox` API outside the workflow builder instead (see [Executing code](/docs/core/building/exec)).
 
 ## writeFile
 

--- a/apps/docs/content/docs/workflow/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/workflow/getting-started/quickstart.mdx
@@ -20,9 +20,9 @@ const client = new Drej({
   baseUrl: "http://localhost:8080",
   adapter: new SQLiteAdapter("./ledger.db"),
 });
-
-await client.connect();
 ```
+
+No `connect()` call needed — the adapter initializes lazily on first use.
 
 ## Run a workflow
 
@@ -33,9 +33,9 @@ await workflow(client)
     sb.exec("npm --version");
   })
   .pipe(process.stdout);
-
-await client.close();
 ```
+
+No `close()` call needed either — `Drej` has no such method; the adapter closes itself automatically when the process exits.
 
 The callback receives a `SandboxBuilder`. All calls inside it queue operations synchronously — nothing runs until `.pipe()` or `.result()` is awaited. The sandbox is created, all ops are flushed in order, then the sandbox is closed automatically.
 


### PR DESCRIPTION
## What

Audited all 65 `.mdx` files across `apps/docs/content/docs/` (agent, core, workflow, drejx sections) against the source code they document. 6 parallel research passes, every claimed mismatch personally verified against source before fixing. Fixed 30+ confirmed mismatches. Doc-only — no behavior changes.

## Highlights

- **Systemic fabricated `client.connect()`/`client.close()` API**, repeated across 7 files (storage-adapters, workflows, postgres, sqlite, custom, api-reference/index, workflow quickstart). `Drej` has neither method — the adapter initializes and closes itself automatically.
- **`docs/drejx/` (11 files) completely rewritten.** The real CLI only manages local `AgentSpec` JSON files (`drejx add/list/remove`) — it never provisions sandboxes, checkpoints, or writes `.drej/sandboxes.json` (dead code, never imported by any command). Config path was also wrong everywhere (`drej.config.json` at project root, not `.drej/config.json`).
- `errors.mdx`: `SandboxError`'s central example was actually `DrejError`'s behavior — `client.sandbox()` failures throw `DrejError`, not `SandboxError`.
- `drej-client.mdx`: `checkpoint()` returns `Promise<string>` (the snapshot ID), not `Promise<void>`.
- `custom.mdx`: `IStorageAdapter` transcription and the `MemoryAdapter` example both omitted 5 required methods — as written, the example wouldn't have compiled against the real interface.
- `postgres.mdx`/`sqlite.mdx`: schema examples used `SERIAL` instead of `BIGSERIAL` (postgres), and both omitted the indexes and the entire `drej_environments` table.
- `run-management.mdx`: `SandboxStatus` table listed `"failed"`/`"cancelled"` and an `error` field that don't exist — the real enum only has `Running`/`Completed`.
- `workflow-run.mdx`: `ExecHandle`'s stream starts draining in the constructor, not "driven by the first consumer" as claimed.
- `file-ops.mdx`: `searchFiles()` returns `string[]`, not `{path}[]`.
- `steps.mdx`/`sandbox-builder.mdx`: `execCode()` examples hand-rolled a fake context object instead of using `createCodeContext()`; a fabricated `language`/`stateful` shorthand that doesn't exist on `ExecCodeOptions`.
- `agent.mdx`/`streaming.mdx`: `AgentEvent`'s `compaction_end` had loose placeholder types instead of the real structured type; `compact()`'s documented return shape was missing two fields; `bash()` and its example both claimed incremental streaming that doesn't happen; `fork()`'s example used a nonexistent `message.id` field instead of `getForkMessages()`.
- Smaller fixes: retry backoff math ("doubles" not "multiplies by attempt number"), `maxAttempts` off-by-one wording, `when()`'s cumulative-stdout semantics, and a documented (not fixed — flagged as follow-up) data-loss limitation in concurrent `forEach`.

## Test plan

- [x] `cd apps/docs && bun run build` — 73 static pages, clean
- [x] `bun run format:check` — clean
- [x] Changeset added (`docs` is tracked — has a `version` field unlike `www`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)