### PR TITLE
fix(ci): exclude CHANGELOG.md from oxfmt format check

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "test:integration": "bun run --cwd tests/integration test",
     "lint": "oxlint packages examples",
     "lint:fix": "oxlint --fix packages examples",
-    "format": "oxfmt packages examples apps",
-    "format:check": "oxfmt --check packages examples apps"
+    "format": "oxfmt packages examples apps '!**/CHANGELOG.md'",
+    "format:check": "oxfmt --check packages examples apps '!**/CHANGELOG.md'"
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0",


### PR DESCRIPTION
## What

Excludes `**/CHANGELOG.md` from `bun run format` / `format:check`.

## Why

Changesets auto-generates `CHANGELOG.md` in every package on each "Version Packages" release PR, in a format that doesn't match our `oxfmt` config — currently breaking `Typecheck & Lint` on #82:

```
packages/core/CHANGELOG.md
packages/sdks/typescript/CHANGELOG.md

Format issues found in above 2 files.
```

These are bot-generated changelog files, not code we hand-format, so they shouldn't be part of the format gate. Without this fix, every future release PR will hit the same failure.

## Test plan

- [x] `bun run format:check` — clean (267 files, was 293 including 25 untouched CHANGELOG.md files that all had pre-existing format deviations)
- [x] `bun run typecheck && bun run test && bun run build` — all green, unaffected
- [x] No changeset — root `package.json` has no `version` field, not tracked by changesets (consistent with prior root-config-only PRs this cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)