### PR TITLE
fix: resolve workspace:* protocol before npm publish

### DIFF
--- a/.changeset/fix-workspace-protocol-publish.md
+++ b/.changeset/fix-workspace-protocol-publish.md
@@ -1,0 +1,18 @@
+---
+"@drej/core": patch
+"@drej/opensandbox": patch
+"drej": patch
+"@drej/workflow": patch
+"@drej/postgres": patch
+"@drej/sqlite": patch
+"@drej/otel": patch
+"@drej/flue": patch
+"@drej/agent": patch
+"drejx": patch
+---
+
+Fix every published package that depends on a sibling workspace package shipping a literal `"workspace:*"` version string instead of a real semver range.
+
+`changeset publish` always shells out to plain `npm publish`, which has no concept of the `workspace:` protocol — unlike `bun publish`/`pnpm publish`, which resolve it automatically. Every currently published version of `drej`, `@drej/agent`, `@drej/workflow`, and `drejx` has `"workspace:*"` in its `dependencies`, which `npm install` cannot resolve at all (`EUNSUPPORTEDPROTOCOL`). Installing any of these packages from npm fails outright.
+
+Added `scripts/resolve-workspace-protocol.ts`, run in CI immediately before `npm publish`, which rewrites every `workspace:*`/`workspace:^`/`workspace:~` dependency range to the corresponding package's already-resolved version before the tarball is packed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          publish: bun changeset publish
+          publish: bun scripts/resolve-workspace-protocol.ts && bun changeset publish
           version: bun changeset version
           title: "chore: version packages"
           commit: "chore: version packages"

--- a/scripts/resolve-workspace-protocol.ts
+++ b/scripts/resolve-workspace-protocol.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env bun
+// Rewrites `workspace:*` / `workspace:^` / `workspace:~` dependency ranges to
+// concrete resolved versions before `npm publish` runs.
+//
+// `changeset publish` always shells out to plain `npm publish`, which has no
+// concept of the `workspace:` protocol (unlike `bun publish` or `pnpm publish`,
+// which rewrite it automatically). Left unresolved, every published package
+// that depends on a sibling workspace package ships a literal "workspace:*"
+// string, which breaks `npm install` for consumers entirely.
+//
+// Run this once, right before `npm publish`, against the already-versioned
+// checkout. It mutates package.json files in place; it is never committed.
+
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const rootPkg = await Bun.file(join(root, "package.json")).json();
+
+const packageJsonPaths: string[] = [];
+for (const pattern of rootPkg.workspaces as string[]) {
+  const glob = new Bun.Glob(`${pattern}/package.json`);
+  for await (const match of glob.scan({ cwd: root, absolute: true })) {
+    packageJsonPaths.push(match);
+  }
+}
+
+const versionByName = new Map<string, string>();
+const packages = await Promise.all(
+  packageJsonPaths.map(async (path) => ({ path, json: await Bun.file(path).json() })),
+);
+for (const { json } of packages) {
+  versionByName.set(json.name, json.version);
+}
+
+const depFields = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+let changedCount = 0;
+for (const { path, json } of packages) {
+  let changed = false;
+  for (const field of depFields) {
+    const deps = json[field];
+    if (!deps) continue;
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range !== "string" || !range.startsWith("workspace:")) continue;
+      const resolved = versionByName.get(name);
+      if (!resolved) {
+        throw new Error(
+          `Cannot resolve workspace dependency "${name}" (${range}) referenced from ${path}`,
+        );
+      }
+      const specifier = range.slice("workspace:".length);
+      deps[name] = specifier === "*" || specifier === "" ? resolved : `${specifier}${resolved}`;
+      changed = true;
+    }
+  }
+  if (changed) {
+    await Bun.write(path, `${JSON.stringify(json, null, 2)}\n`);
+    changedCount++;
+    console.log(`resolved workspace: protocol in ${path}`);
+  }
+}
+
+console.log(`Done. Rewrote ${changedCount} package.json file(s).`);


### PR DESCRIPTION
## Summary

Every currently published version of `drej`, `@drej/agent`, `@drej/workflow`, and `drejx` is **broken on npm right now** — installing any of them fails immediately:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

Confirmed live:
```
$ npm view drejx@latest dependencies --json
{ "@drej/agent": "workspace:*", "@drej/sqlite": "workspace:*", "drej": "workspace:*" }
```

## Root cause

`changeset publish` (the `publish:` step in `.github/workflows/release.yml`) always shells out to plain `npm publish` internally — confirmed in `@changesets/cli`'s source, it hardcodes `npm`. `npm publish` has no concept of the `workspace:` protocol, unlike `bun publish`/`pnpm publish`, which rewrite it to a concrete version automatically. I verified `bun pm pack` on `@drej/agent` locally *does* rewrite `workspace:*` → `0.5.0` correctly, confirming the fix belongs at the "which publish command actually runs" layer, not in the packages themselves.

## Fix

Added `scripts/resolve-workspace-protocol.ts`, chained into the release workflow's `publish` step right before `bun changeset publish` runs:

```
publish: bun scripts/resolve-workspace-protocol.ts && bun changeset publish
```

It reads the root `workspaces` globs, builds a name→version map across all workspace packages, and rewrites any `workspace:*`/`workspace:^`/`workspace:~` dependency range in place to the corresponding package's resolved version — right before `npm publish` packs the tarball. It never gets committed; it only mutates the CI checkout immediately before publish.

Added a changeset (patch bump, all 10 publishable packages) so merging this triggers a new "Version Packages" PR — merging *that* is what actually re-publishes corrected versions to npm and fixes the currently-broken `@latest` installs.

## Test plan

- [x] Ran the script against a real checkout and confirmed it rewrites `workspace:*` to the exact resolved versions (verified `packages/agent/package.json` picked up `@drej/core: "0.5.2"`, `@drej/sqlite: "0.3.3"`, `drej: "0.9.2"` — matching what's live on npm)
- [x] Reverted the test-run diff (`git checkout -- examples packages tests`) before committing — nothing but the workflow + new script is part of this PR
- [x] `bun run typecheck && bun run test && bun run build && bun run format:check` all pass
- [ ] CI green