### PR TITLE
fix: run workspace-protocol resolve + changeset publish via a real shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          publish: bun scripts/resolve-workspace-protocol.ts && bun changeset publish
+          publish: bun run release:publish
           version: bun changeset version
           title: "chore: version packages"
           commit: "chore: version packages"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint": "oxlint packages examples",
     "lint:fix": "oxlint --fix packages examples",
     "format": "oxfmt packages examples apps '!**/CHANGELOG.md'",
-    "format:check": "oxfmt --check packages examples apps '!**/CHANGELOG.md'"
+    "format:check": "oxfmt --check packages examples apps '!**/CHANGELOG.md'",
+    "release:publish": "bun scripts/resolve-workspace-protocol.ts && bun changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0",


### PR DESCRIPTION
## Summary

PR #100 (merged) added a fix for `workspace:*` protocol strings leaking into published packages, wired in as:

```yaml
publish: bun scripts/resolve-workspace-protocol.ts && bun changeset publish
```

After merging the resulting "Version Packages" PR (#101), the Release run reported **success**, but nothing actually got published — `@drej/agent`, `drejx`, etc. are still stuck on their old versions on npm, still with literal `"workspace:*"` in their `dependencies`.

## Root cause

`changesets/action` runs the `publish:` field via `@actions/exec`'s `exec(commandLine)`, which does **not** invoke a shell — it just splits the string on spaces into a command + literal argv. So our `&&`-chained string was executed as:

```
bun ["scripts/resolve-workspace-protocol.ts", "&&", "bun", "changeset", "publish"]
```

Bun ran the resolve script (ignoring the trailing tokens as unused argv) and exited — `bun changeset publish` never ran at all. Confirmed in the [run #101 log](https://github.com/DrejT/drej/actions/runs/28696934716): execution stops right after the resolve script prints `Done. Rewrote 25 package.json file(s).`, with zero subsequent npm publish output, no errors, nothing.

## Fix

Move the chain into a package.json script:

```json
"release:publish": "bun scripts/resolve-workspace-protocol.ts && bun changeset publish"
```

and point the workflow at that single script:

```yaml
publish: bun run release:publish
```

`bun run <script>` spawns the script body through a real shell (verified locally with a throwaway `"chain": "echo first && echo second"` script — both lines print), so the `&&` is interpreted correctly this time.

## Why no changeset

The versions bumped by the last "Version Packages" PR (`@drej/agent@0.3.2`, `drejx@0.2.4`, etc.) are already committed on `main` — they were bumped, just never actually published. `changesets/action` publishes whatever unpublished versions are already sitting in package.json when no changesets are pending, so merging this fix directly triggers a correct publish attempt for those existing target versions. No version bump needed.

## Test plan

- [x] Verified locally that `bun run <script-with-&&>` executes through a real shell (unlike a raw `&&`-joined string passed to `@actions/exec`)
- [x] `bun run typecheck && bun run test && bun run build && bun run format:check` all pass
- [x] `bunx changeset status --since origin/main` — no changeset required (only root `package.json`/workflow changed, no publishable package touched)
- [ ] CI green
- [ ] After merge: confirm the Release run actually publishes (npm notice output, not silent success) and `npm view drejx@latest dependencies` no longer shows `workspace:*`