### PR TITLE
feat(www): package tabs on the landing page, migrate Features to Tailwind

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -1,8 +1,12 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   output: "static",
   site: "https://drej.dev",
   integrations: [sitemap()],
+  vite: {
+    plugins: [tailwindcss()],
+  },
 });

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -13,5 +13,9 @@
     "@fontsource-variable/geist-mono": "^5.2.2",
     "animejs": "^4.5.0",
     "astro": "^6.4.8"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.2",
+    "tailwindcss": "^4.3.2"
   }
 }

--- a/apps/www/src/components/Features.astro
+++ b/apps/www/src/components/Features.astro
@@ -1,404 +1,386 @@
 ---
-const features = [
+interface Example {
+  keyword: string;
+  desc: string;
+  filename?: string;
+  code: string;
+}
+
+interface Pkg {
+  id: string;
+  label: string;
+  examples: Example[];
+}
+
+const packages: Pkg[] = [
   {
-    index: 0,
-    keyword: "Spawn.",
-    desc: "Start a live container in one call. Pick any Docker image, set resource limits, and get back a Sandbox you hold like any other object.",
+    id: "core",
+    label: "Core",
+    examples: [
+      {
+        keyword: "Spawn.",
+        desc: "Start a live container in one call. Pick any Docker image, set resource limits, and get back a Sandbox you hold like any other object.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">sb</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">client</span><span class="tok-punct">.</span><span class="tok-fn">sandbox</span><span class="tok-punct">(&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">image</span><span class="tok-punct">:</span> <span class="tok-str">"node:22"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">resources</span><span class="tok-punct">: &#123;</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-prop">cpu</span><span class="tok-punct">:</span>    <span class="tok-str">"500m"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-prop">memory</span><span class="tok-punct">:</span> <span class="tok-str">"256Mi"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;);</span></span>`,
+      },
+      {
+        keyword: "Exec.",
+        desc: "Run commands and get stdout, stderr, and exit code back. Stream live output to your process, set a working directory, inject environment variables.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-punct">&#123;</span> <span class="tok-prop">stdout</span> <span class="tok-punct">&#125;</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"node index.js"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// stream live output</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm test"</span><span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">.</span><span class="tok-fn">pipe</span><span class="tok-punct">(</span><span class="tok-var">process</span><span class="tok-punct">.</span><span class="tok-prop">stdout</span><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Files.",
+        desc: "Read and write files directly inside the sandbox. Inject source code, pull build artifacts, inspect logs — all from TypeScript with no extra tooling.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">writeFile</span><span class="tok-punct">(</span><span class="tok-str">"/app/main.py"</span><span class="tok-punct">,</span> <span class="tok-var">src</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">logs</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">readFile</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"/var/log/app.log"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">entries</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">listDirectory</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"/app"</span><span class="tok-punct">,</span> <span class="tok-punct">&#123;</span> <span class="tok-prop">depth</span><span class="tok-punct">:</span> <span class="tok-var">1</span> <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Checkpoint.",
+        desc: "Snapshot the container at any point — filesystem, processes, memory. Resume later from the exact same state. Pay for compute only when you need it.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">checkpoint</span><span class="tok-punct">(</span><span class="tok-str">"before-tests"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// restore exact state later</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">resumed</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">client</span><span class="tok-punct">.</span><span class="tok-fn">resume</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">sandboxId</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">resumed</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm test"</span><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Fork.",
+        desc: "Branch a running container from any checkpoint. Each fork is an independent Sandbox — run parallel test shards, A/B variants, or speculative executions.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">checkpoint</span><span class="tok-punct">();</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">fork</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">fork</span><span class="tok-punct">();</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// two independent containers, same state</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-fn">Promise</span><span class="tok-punct">.</span><span class="tok-fn">all</span><span class="tok-punct">([</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm test -- --shard=1/2"</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">fork</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm test -- --shard=2/2"</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">]);</span></span>`,
+      },
+      {
+        keyword: "Environments.",
+        desc: "Define a named environment once — image, resources, setup script. drej builds it, snapshots it, and restores from that snapshot on every subsequent call.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">env</span> <span class="tok-op">=</span> <span class="tok-var">client</span><span class="tok-punct">.</span><span class="tok-fn">environment</span><span class="tok-punct">(</span><span class="tok-str">"ci"</span><span class="tok-punct">,</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">image</span><span class="tok-punct">:</span> <span class="tok-str">"node:22"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">resources</span><span class="tok-punct">:</span> <span class="tok-punct">&#123;</span> <span class="tok-prop">cpu</span><span class="tok-punct">:</span> <span class="tok-str">"500m"</span><span class="tok-punct">,</span> <span class="tok-prop">memory</span><span class="tok-punct">:</span> <span class="tok-str">"512Mi"</span> <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">setup</span><span class="tok-punct">:</span> <span class="tok-kw">async</span> <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm ci"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// builds once, restores from snapshot</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">sb</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">env</span><span class="tok-punct">.</span><span class="tok-fn">sandbox</span><span class="tok-punct">();</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm test"</span><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "History.",
+        desc: "Every exec is logged to a durable ledger. Query past sessions, inspect exec counts and timing, or delete records — all through a typed API.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">sessions</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">client</span><span class="tok-punct">.</span><span class="tok-var">sandboxes</span><span class="tok-punct">.</span><span class="tok-fn">list</span><span class="tok-punct">(&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">status</span><span class="tok-punct">:</span> <span class="tok-var">SandboxStatus</span><span class="tok-punct">.</span><span class="tok-prop">Running</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">limit</span><span class="tok-punct">:</span> <span class="tok-var">20</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">details</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">client</span><span class="tok-punct">.</span><span class="tok-var">sandboxes</span><span class="tok-punct">.</span><span class="tok-fn">get</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"ci"</span><span class="tok-punct">,</span> <span class="tok-var">sandboxId</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// &#123; status, execCount, startedAt &#125;</span></span>`,
+      },
+    ],
   },
   {
-    index: 1,
-    keyword: "Exec.",
-    desc: "Run commands and get stdout, stderr, and exit code back. Stream live output to your process, set a working directory, inject environment variables.",
+    id: "workflow",
+    label: "Workflow",
+    examples: [
+      {
+        keyword: "Run.",
+        desc: "Chain sandbox steps into one lazy pipeline. Nothing runs until you await .pipe() or .result() — the whole thing executes as a single unit.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">import</span> <span class="tok-punct">&#123;</span> <span class="tok-var">workflow</span> <span class="tok-punct">&#125;</span> <span class="tok-kw">from</span> <span class="tok-str">"@drej/workflow"</span><span class="tok-punct">;</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-fn">workflow</span><span class="tok-punct">(</span><span class="tok-var">client</span><span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">.</span><span class="tok-fn">sandbox</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">&#123;</span> <span class="tok-prop">image</span><span class="tok-punct">:</span> <span class="tok-str">"node:22"</span><span class="tok-punct">,</span> <span class="tok-prop">resources</span><span class="tok-punct">:</span> <span class="tok-punct">&#123;</span> <span class="tok-prop">cpu</span><span class="tok-punct">:</span> <span class="tok-str">"500m"</span><span class="tok-punct">,</span> <span class="tok-prop">memory</span><span class="tok-punct">:</span> <span class="tok-str">"512Mi"</span> <span class="tok-punct">&#125;</span> <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">      <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"node --version"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">      <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm --version"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">.</span><span class="tok-fn">pipe</span><span class="tok-punct">(</span><span class="tok-var">process</span><span class="tok-punct">.</span><span class="tok-prop">stdout</span><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Capture.",
+        desc: "Get combined stdout and any files you read back as vars, in one return value — no manual bookkeeping across steps.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-punct">&#123;</span> <span class="tok-prop">stdout</span><span class="tok-punct">,</span> <span class="tok-prop">vars</span> <span class="tok-punct">&#125;</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-fn">workflow</span><span class="tok-punct">(</span><span class="tok-var">client</span><span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">.</span><span class="tok-fn">sandbox</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">&#123;</span> <span class="tok-prop">image</span><span class="tok-punct">:</span> <span class="tok-str">"node:22"</span><span class="tok-punct">,</span> <span class="tok-prop">resources</span><span class="tok-punct">:</span> <span class="tok-punct">&#123;</span> <span class="tok-prop">cpu</span><span class="tok-punct">:</span> <span class="tok-str">"500m"</span><span class="tok-punct">,</span> <span class="tok-prop">memory</span><span class="tok-punct">:</span> <span class="tok-str">"512Mi"</span> <span class="tok-punct">&#125;</span> <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">      <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"node --version > /tmp/ver.txt"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">      <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">readFile</span><span class="tok-punct">(</span><span class="tok-str">"/tmp/ver.txt"</span><span class="tok-punct">,</span> <span class="tok-str">"nodeVersion"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">.</span><span class="tok-fn">result</span><span class="tok-punct">();</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-var">console</span><span class="tok-punct">.</span><span class="tok-fn">log</span><span class="tok-punct">(</span><span class="tok-var">vars</span><span class="tok-punct">.</span><span class="tok-prop">nodeVersion</span><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Control flow.",
+        desc: "retry and when branch on runtime state — exit codes, captured vars — right inside the builder callback.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">retry</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">3</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"curl -f https://api.example.com/health"</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">&#123;</span> <span class="tok-prop">delayMs</span><span class="tok-punct">:</span> <span class="tok-var">2000</span><span class="tok-punct">,</span> <span class="tok-prop">backoff</span><span class="tok-punct">:</span> <span class="tok-str">"exponential"</span> <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">when</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">(</span><span class="tok-var">ctx</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-var">ctx</span><span class="tok-punct">.</span><span class="tok-prop">exitCode</span> <span class="tok-op">===</span> <span class="tok-var">0</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"tar -xzf /tmp/cache.tar.gz"</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">"npm ci"</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Parallel.",
+        desc: "Fan a step out over a list with forEach, with an optional concurrency cap for parallel branches.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">packages</span> <span class="tok-op">=</span> <span class="tok-punct">[</span><span class="tok-str">"lodash"</span><span class="tok-punct">,</span> <span class="tok-str">"zod"</span><span class="tok-punct">,</span> <span class="tok-str">"tsx"</span><span class="tok-punct">];</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">forEach</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">packages</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">(</span><span class="tok-var">sb</span><span class="tok-punct">,</span> <span class="tok-var">pkg</span><span class="tok-punct">)</span> <span class="tok-op">=&gt;</span> <span class="tok-var">sb</span><span class="tok-punct">.</span><span class="tok-fn">exec</span><span class="tok-punct">(</span><span class="tok-str">\`npm install &#36;&#123;pkg&#125;\`</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-punct">&#123;</span> <span class="tok-prop">concurrency</span><span class="tok-punct">:</span> <span class="tok-var">3</span> <span class="tok-punct">&#125;,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>`,
+      },
+    ],
   },
   {
-    index: 2,
-    keyword: "Files.",
-    desc: "Read and write files directly inside the sandbox. Inject source code, pull build artifacts, inspect logs — all from TypeScript with no extra tooling.",
+    id: "agent",
+    label: "Agent",
+    examples: [
+      {
+        keyword: "Load.",
+        desc: "Spin up a Pi coding agent in a sandbox and stream its response back to your process in one call.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">import</span> <span class="tok-punct">&#123;</span> <span class="tok-var">Agent</span><span class="tok-punct">,</span> <span class="tok-var">textOnly</span> <span class="tok-punct">&#125;</span> <span class="tok-kw">from</span> <span class="tok-str">"@drej/agent"</span><span class="tok-punct">;</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">agent</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">Agent</span><span class="tok-punct">.</span><span class="tok-fn">load</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"./agents/hello-agent.json"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">for</span> <span class="tok-kw">await</span> <span class="tok-punct">(</span><span class="tok-kw">const</span> <span class="tok-var">chunk</span> <span class="tok-kw">of</span> <span class="tok-fn">textOnly</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">prompt</span><span class="tok-punct">(</span><span class="tok-str">"Summarize this repo."</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">))</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">process</span><span class="tok-punct">.</span><span class="tok-var">stdout</span><span class="tok-punct">.</span><span class="tok-fn">write</span><span class="tok-punct">(</span><span class="tok-var">chunk</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;</span></span>`,
+      },
+      {
+        keyword: "Tool events.",
+        desc: "Watch Pi's tool calls as they happen — not just the final text — for full visibility into what the agent is doing.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">for</span> <span class="tok-kw">await</span> <span class="tok-punct">(</span><span class="tok-kw">const</span> <span class="tok-var">ev</span> <span class="tok-kw">of</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">prompt</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"Run /workspace/script.py"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">))</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-kw">if</span> <span class="tok-punct">(</span><span class="tok-var">ev</span><span class="tok-punct">.</span><span class="tok-prop">type</span> <span class="tok-op">===</span> <span class="tok-str">"text"</span><span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-var">process</span><span class="tok-punct">.</span><span class="tok-var">stdout</span><span class="tok-punct">.</span><span class="tok-fn">write</span><span class="tok-punct">(</span><span class="tok-var">ev</span><span class="tok-punct">.</span><span class="tok-prop">text</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-kw">if</span> <span class="tok-punct">(</span><span class="tok-var">ev</span><span class="tok-punct">.</span><span class="tok-prop">type</span> <span class="tok-op">===</span> <span class="tok-str">"tool_start"</span><span class="tok-punct">)</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-var">console</span><span class="tok-punct">.</span><span class="tok-fn">log</span><span class="tok-punct">(</span><span class="tok-str">\`[tool] &#36;&#123;ev.toolName&#125;\`</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;</span></span>`,
+      },
+      {
+        keyword: "Files.",
+        desc: "Read and write files directly inside the agent's sandbox, alongside its own edits — no extra tooling needed.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-var">sandbox</span><span class="tok-punct">.</span><span class="tok-fn">writeFile</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"/workspace/data.csv"</span><span class="tok-punct">,</span> <span class="tok-var">csv</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">summary</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-var">sandbox</span><span class="tok-punct">.</span><span class="tok-fn">readFile</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"/workspace/summary.txt"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>`,
+      },
+      {
+        keyword: "Snapshot.",
+        desc: "First run installs and checkpoints the CLI. Every run after restores from that snapshot in seconds.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">agent</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">Agent</span><span class="tok-punct">.</span><span class="tok-fn">load</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"./agents/hello-agent.json"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-var">console</span><span class="tok-punct">.</span><span class="tok-fn">log</span><span class="tok-punct">(</span><span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-prop">fromSnapshot</span><span class="tok-punct">);</span> <span class="tok-cmt">// true</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// force a full reinstall</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">Agent</span><span class="tok-punct">.</span><span class="tok-fn">load</span><span class="tok-punct">(</span><span class="tok-str">"./agents/hello-agent.json"</span><span class="tok-punct">,</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-prop">rebuild</span><span class="tok-punct">:</span> <span class="tok-kw">true</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;);</span></span>`,
+      },
+    ],
   },
   {
-    index: 3,
-    keyword: "Checkpoint.",
-    desc: "Snapshot the container at any point — filesystem, processes, memory. Resume later from the exact same state. Pay for compute only when you need it.",
-  },
-  {
-    index: 4,
-    keyword: "Fork.",
-    desc: "Branch a running container from any checkpoint. Each fork is an independent Sandbox — run parallel test shards, A/B variants, or speculative executions.",
-  },
-  {
-    index: 5,
-    keyword: "Environments.",
-    desc: "Define a named environment once — image, resources, setup script. drej builds it, snapshots it, and restores from that snapshot on every subsequent call.",
-  },
-  {
-    index: 6,
-    keyword: "Workflow.",
-    desc: "Chain steps into a durable workflow. Each step is logged to the ledger — on failure, replay from the last successful checkpoint without re-running earlier work.",
-  },
-  {
-    index: 7,
-    keyword: "History.",
-    desc: "Every exec is logged to a durable ledger. Query past sessions, inspect exec counts and timing, or delete records — all through a typed API.",
+    id: "cli",
+    label: "CLI",
+    examples: [
+      {
+        keyword: "Init.",
+        desc: "One command starts OpenSandbox locally in Docker and writes your project config — no manual server setup.",
+        filename: "terminal",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-punct">&#36;</span> <span class="tok-punct">bunx drejx init</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">Starting OpenSandbox in Docker...</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">OpenSandbox running at</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">http://localhost:8080 — ready.</span></span>`,
+      },
+      {
+        keyword: "Add.",
+        desc: "Fetch an agent spec from any URL, validate it, and save it locally — dependencies resolved recursively.",
+        filename: "terminal",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-punct">&#36;</span> <span class="tok-punct">bunx drejx add \\</span></span>
+<span class="block whitespace-pre text-sm">    <span class="tok-punct">https://example.com/specs/code-reviewer.json</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">Agent spec saved: agents/code-reviewer.json</span></span>`,
+      },
+      {
+        keyword: "Run.",
+        desc: "Load any saved spec with @drej/agent — the CLI only manages specs on disk; the sandbox work happens on load.",
+        filename: "run.ts",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">import</span> <span class="tok-punct">&#123;</span> <span class="tok-var">Agent</span><span class="tok-punct">,</span> <span class="tok-var">textOnly</span> <span class="tok-punct">&#125;</span> <span class="tok-kw">from</span> <span class="tok-str">"@drej/agent"</span><span class="tok-punct">;</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">agent</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">Agent</span><span class="tok-punct">.</span><span class="tok-fn">load</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-str">"agents/code-reviewer.json"</span><span class="tok-punct">,</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">for</span> <span class="tok-kw">await</span> <span class="tok-punct">(</span><span class="tok-kw">const</span> <span class="tok-var">chunk</span> <span class="tok-kw">of</span> <span class="tok-fn">textOnly</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">prompt</span><span class="tok-punct">(</span><span class="tok-str">"Review this repo."</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">))</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">process</span><span class="tok-punct">.</span><span class="tok-var">stdout</span><span class="tok-punct">.</span><span class="tok-fn">write</span><span class="tok-punct">(</span><span class="tok-var">chunk</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;</span></span>`,
+      },
+    ],
   },
 ];
 ---
 
-<section class="features-section">
-  <div class="features-grid">
-
-    <!-- Left: tabs + description -->
-    <div class="tabs-column">
-      <div class="tabs" role="tablist">
-        {features.map((f) => (
-          <button
-            class:list={["tab", { active: f.index === 0 }]}
-            data-feature={f.index}
-            role="tab"
-          >
-            {f.keyword}
-          </button>
-        ))}
-      </div>
-
-      <div class="tab-descs">
-        {features.map((f) => (
-          <p class:list={["tab-desc", { active: f.index === 0 }]} data-desc={f.index}>
-            {f.desc}
-          </p>
-        ))}
-      </div>
-
-      <div class="ctas">
-        <a href="https://docs.drej.dev" class="btn-primary">Read the docs</a>
-        <a href="https://github.com/DrejT/drej" class="btn-secondary">GitHub →</a>
-      </div>
+<section class="pt-14 min-h-screen flex items-center">
+  <div class="max-w-[var(--max-width)] w-full mx-auto px-8 py-12">
+    <div class="package-tabs flex gap-7 border-b border-[var(--color-border)] mb-10" role="tablist">
+      {packages.map((pkg, i) => (
+        <button
+          class:list={[
+            "package-tab bg-transparent border-0 border-b-2 border-transparent -mb-px cursor-pointer font-mono text-[0.8rem] font-medium tracking-[0.04em] uppercase text-[var(--color-muted)] pb-3 transition-colors duration-200 hover:text-[var(--color-fg)] [&.active]:text-[var(--color-fg)] [&.active]:border-[var(--color-accent)]",
+            { active: i === 0 },
+          ]}
+          data-package={i}
+          role="tab"
+          aria-selected={i === 0}
+        >
+          {pkg.label}
+        </button>
+      ))}
     </div>
 
-    <!-- Right: code -->
-    <div class="code-column">
-      <div class="code-wrapper">
-        <div class="code-header">
-          <div class="dots">
-            <span class="dot red"></span>
-            <span class="dot yellow"></span>
-            <span class="dot green"></span>
+    {packages.map((pkg, pi) => (
+      <div
+        class:list={["package-panel hidden [&.active]:block", { active: pi === 0 }]}
+        data-package-panel={pi}
+      >
+        <div class="grid grid-cols-[2fr_3fr] gap-20 items-center max-[680px]:grid-cols-1 max-[680px]:gap-10">
+
+          <!-- Left: tabs + description -->
+          <div>
+            <div class="tabs flex flex-col border-l-2 border-[var(--color-border)] mb-8 transition-colors duration-300" role="tablist">
+              {pkg.examples.map((ex, i) => (
+                <button
+                  class:list={[
+                    "tab bg-transparent border-0 border-l-2 border-transparent -ml-0.5 cursor-pointer font-mono text-base font-medium text-[var(--color-muted)] text-left py-[0.55rem] pl-4 leading-[1.3] transition-colors duration-200 hover:text-[var(--color-fg)] [&.active]:text-[var(--color-accent)] [&.active]:border-[var(--color-accent)]",
+                    { active: i === 0 },
+                  ]}
+                  data-feature={i}
+                  role="tab"
+                  aria-selected={i === 0}
+                >
+                  {ex.keyword}
+                </button>
+              ))}
+            </div>
+
+            <div class="grid pl-4 mb-10">
+              {pkg.examples.map((ex, i) => (
+                <p
+                  class:list={[
+                    "tab-desc [grid-area:1/1] text-[0.9rem] text-[var(--color-muted)] leading-[1.65] opacity-0 pointer-events-none transition-opacity duration-[250ms] [&.active]:opacity-100 [&.active]:pointer-events-auto",
+                    { active: i === 0 },
+                  ]}
+                  data-desc={i}
+                >
+                  {ex.desc}
+                </p>
+              ))}
+            </div>
+
+            <div class="flex gap-4 items-center pl-4">
+              <a
+                href="https://docs.drej.dev"
+                class="inline-flex items-center px-[1.2rem] py-[0.6rem] bg-[var(--color-accent)] text-white text-sm font-medium rounded-[var(--radius-btn)] transition-colors duration-150 hover:bg-[var(--color-accent-hover)]"
+              >
+                Read the docs
+              </a>
+              <a
+                href="https://github.com/DrejT/drej"
+                class="text-sm text-[var(--color-muted)] border-b border-transparent pb-px transition-colors duration-150 hover:text-[var(--color-accent)] hover:border-[var(--color-accent)]"
+              >
+                GitHub →
+              </a>
+            </div>
           </div>
-          <span class="filename">index.ts</span>
-          <div class="dots-spacer"></div>
-        </div>
-        <div class="code-panels">
 
-          <!-- Panel 0: Spawn -->
-          <pre class="code-panel active" data-panel="0"><code
-><span class="line"><span class="kw">const</span> <span class="var">sb</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">client</span><span class="p">.</span><span class="fn">sandbox</span><span class="p">(&#123;</span></span>
-<span class="line">  <span class="prop">image</span><span class="p">:</span> <span class="str">"node:22"</span><span class="p">,</span></span>
-<span class="line">  <span class="prop">resources</span><span class="p">: &#123;</span></span>
-<span class="line">    <span class="prop">cpu</span><span class="p">:</span>    <span class="str">"500m"</span><span class="p">,</span></span>
-<span class="line">    <span class="prop">memory</span><span class="p">:</span> <span class="str">"256Mi"</span><span class="p">,</span></span>
-<span class="line">  <span class="p">&#125;,</span></span>
-<span class="line"><span class="p">&#125;);</span></span>
-</code></pre>
-
-          <!-- Panel 1: Exec -->
-          <pre class="code-panel" data-panel="1"><code
-><span class="line"><span class="kw">const</span> <span class="p">&#123;</span> <span class="prop">stdout</span> <span class="p">&#125;</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span></span>
-<span class="line">  <span class="str">"node index.js"</span><span class="p">,</span></span>
-<span class="line"><span class="p">);</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="cmt">// stream live output</span></span>
-<span class="line"><span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm test"</span><span class="p">)</span></span>
-<span class="line">  <span class="p">.</span><span class="fn">pipe</span><span class="p">(</span><span class="var">process</span><span class="p">.</span><span class="prop">stdout</span><span class="p">);</span></span>
-</code></pre>
-
-          <!-- Panel 2: Files -->
-          <pre class="code-panel" data-panel="2"><code
-><span class="line"><span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">writeFile</span><span class="p">(</span><span class="str">"/app/main.py"</span><span class="p">,</span> <span class="var">src</span><span class="p">);</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="kw">const</span> <span class="var">logs</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">readFile</span><span class="p">(</span></span>
-<span class="line">  <span class="str">"/var/log/app.log"</span><span class="p">,</span></span>
-<span class="line"><span class="p">);</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="kw">const</span> <span class="var">entries</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">listDirectory</span><span class="p">(</span></span>
-<span class="line">  <span class="str">"/app"</span><span class="p">,</span> <span class="p">&#123;</span> <span class="prop">depth</span><span class="p">:</span> <span class="var">1</span> <span class="p">&#125;,</span></span>
-<span class="line"><span class="p">);</span></span>
-</code></pre>
-
-          <!-- Panel 3: Checkpoint -->
-          <pre class="code-panel" data-panel="3"><code
-><span class="line"><span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">checkpoint</span><span class="p">(</span><span class="str">"before-tests"</span><span class="p">);</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="cmt">// restore exact state later</span></span>
-<span class="line"><span class="kw">const</span> <span class="var">resumed</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">client</span><span class="p">.</span><span class="fn">resume</span><span class="p">(</span></span>
-<span class="line">  <span class="var">sandboxId</span><span class="p">,</span></span>
-<span class="line"><span class="p">);</span></span>
-<span class="line"><span class="kw">await</span> <span class="var">resumed</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm test"</span><span class="p">);</span></span>
-</code></pre>
-
-          <!-- Panel 4: Fork -->
-          <pre class="code-panel" data-panel="4"><code
-><span class="line"><span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">checkpoint</span><span class="p">();</span></span>
-<span class="line"><span class="kw">const</span> <span class="var">fork</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">fork</span><span class="p">();</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="cmt">// two independent containers, same state</span></span>
-<span class="line"><span class="kw">await</span> <span class="fn">Promise</span><span class="p">.</span><span class="fn">all</span><span class="p">([</span></span>
-<span class="line">  <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm test -- --shard=1/2"</span><span class="p">),</span></span>
-<span class="line">  <span class="var">fork</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm test -- --shard=2/2"</span><span class="p">),</span></span>
-<span class="line"><span class="p">]);</span></span>
-</code></pre>
-
-          <!-- Panel 5: Environments -->
-          <pre class="code-panel" data-panel="5"><code
-><span class="line"><span class="kw">const</span> <span class="var">env</span> <span class="op">=</span> <span class="var">client</span><span class="p">.</span><span class="fn">environment</span><span class="p">(</span><span class="str">"ci"</span><span class="p">,</span> <span class="p">&#123;</span></span>
-<span class="line">  <span class="prop">image</span><span class="p">:</span> <span class="str">"node:22"</span><span class="p">,</span></span>
-<span class="line">  <span class="prop">resources</span><span class="p">:</span> <span class="p">&#123;</span> <span class="prop">cpu</span><span class="p">:</span> <span class="str">"500m"</span><span class="p">,</span> <span class="prop">memory</span><span class="p">:</span> <span class="str">"512Mi"</span> <span class="p">&#125;,</span></span>
-<span class="line">  <span class="prop">setup</span><span class="p">:</span> <span class="kw">async</span> <span class="p">(</span><span class="var">sb</span><span class="p">)</span> <span class="op">=&gt;</span> <span class="p">&#123;</span></span>
-<span class="line">    <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm ci"</span><span class="p">);</span></span>
-<span class="line">  <span class="p">&#125;,</span></span>
-<span class="line"><span class="p">&#125;);</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="cmt">// builds once, restores from snapshot</span></span>
-<span class="line"><span class="kw">const</span> <span class="var">sb</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">env</span><span class="p">.</span><span class="fn">sandbox</span><span class="p">();</span></span>
-<span class="line"><span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm test"</span><span class="p">);</span></span>
-</code></pre>
-
-          <!-- Panel 6: Workflow -->
-          <pre class="code-panel" data-panel="6"><code
-><span class="line"><span class="kw">await</span> <span class="fn">workflow</span><span class="p">(</span><span class="var">client</span><span class="p">)</span></span>
-<span class="line">  <span class="p">.</span><span class="fn">sandbox</span><span class="p">(</span></span>
-<span class="line">    <span class="p">&#123;</span> <span class="prop">image</span><span class="p">:</span> <span class="str">"node:22"</span><span class="p">,</span> <span class="prop">resources</span> <span class="p">&#125;,</span></span>
-<span class="line">    <span class="kw">async</span> <span class="p">(</span><span class="var">sb</span><span class="p">)</span> <span class="op">=&gt;</span> <span class="p">&#123;</span></span>
-<span class="line">      <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm ci"</span><span class="p">);</span></span>
-<span class="line">      <span class="kw">await</span> <span class="var">sb</span><span class="p">.</span><span class="fn">exec</span><span class="p">(</span><span class="str">"npm test"</span><span class="p">);</span></span>
-<span class="line">    <span class="p">&#125;,</span></span>
-<span class="line">  <span class="p">)</span></span>
-<span class="line">  <span class="p">.</span><span class="fn">result</span><span class="p">();</span></span>
-</code></pre>
-
-          <!-- Panel 7: History -->
-          <pre class="code-panel" data-panel="7"><code
-><span class="line"><span class="kw">const</span> <span class="var">sessions</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">client</span><span class="p">.</span><span class="var">sandboxes</span><span class="p">.</span><span class="fn">list</span><span class="p">(&#123;</span></span>
-<span class="line">  <span class="prop">status</span><span class="p">:</span> <span class="var">SandboxStatus</span><span class="p">.</span><span class="prop">Running</span><span class="p">,</span></span>
-<span class="line">  <span class="prop">limit</span><span class="p">:</span> <span class="var">20</span><span class="p">,</span></span>
-<span class="line"><span class="p">&#125;);</span></span>
-<span class="line empty"> </span>
-<span class="line"><span class="kw">const</span> <span class="var">details</span> <span class="op">=</span> <span class="kw">await</span> <span class="var">client</span><span class="p">.</span><span class="var">sandboxes</span><span class="p">.</span><span class="fn">get</span><span class="p">(</span></span>
-<span class="line">  <span class="str">"ci"</span><span class="p">,</span> <span class="var">sandboxId</span><span class="p">,</span></span>
-<span class="line"><span class="p">);</span></span>
-<span class="line"><span class="cmt">// &#123; status, execCount, startedAt &#125;</span></span>
-</code></pre>
+          <!-- Right: code -->
+          <div>
+            <div class="rounded-xl overflow-hidden border border-[oklch(0.24_0.05_270)] shadow-[0_0_0_1px_oklch(0.17_0.04_266),0_16px_48px_oklch(0.17_0.04_266_/_0.28),0_2px_8px_oklch(0_0_0_/_0.1)]">
+              <div class="flex items-center h-[38px] px-4 bg-[oklch(0.13_0.03_270)] border-b border-[oklch(0.24_0.05_270)]">
+                <div class="flex gap-1.5 items-center flex-1">
+                  <span class="w-[11px] h-[11px] rounded-full bg-[oklch(0.63_0.22_25)]"></span>
+                  <span class="w-[11px] h-[11px] rounded-full bg-[oklch(0.84_0.17_84)]"></span>
+                  <span class="w-[11px] h-[11px] rounded-full bg-[oklch(0.73_0.22_142)]"></span>
+                </div>
+                <span class="filename font-mono text-[0.72rem] text-[oklch(0.41_0_0)] tracking-[0.01em]">
+                  {pkg.examples[0].filename ?? "index.ts"}
+                </span>
+                <div class="flex-1"></div>
+              </div>
+              <div class="grid bg-[oklch(0.17_0.04_266)]">
+                {pkg.examples.map((ex, i) => (
+                  <pre
+                    class:list={[
+                      "code-panel [grid-area:1/1] m-0 px-6 py-5 font-mono text-sm leading-[1.5] whitespace-normal overflow-x-auto opacity-0 pointer-events-none transition-opacity duration-[250ms] [&.active]:opacity-100 [&.active]:pointer-events-auto",
+                      { active: i === 0 },
+                    ]}
+                    data-panel={i}
+                    data-filename={ex.filename ?? "index.ts"}
+                  ><code class="font-mono" set:html={ex.code} /></pre>
+                ))}
+              </div>
+            </div>
+          </div>
 
         </div>
       </div>
-    </div>
-
+    ))}
   </div>
 </section>
 
-<style>
-  .features-section {
-    padding-top: 56px;
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-  }
-
-  .features-grid {
-    max-width: var(--max-width);
-    width: 100%;
-    margin: 0 auto;
-    padding: 3rem 2rem;
-    display: grid;
-    grid-template-columns: 2fr 3fr;
-    gap: 5rem;
-    align-items: center;
-  }
-
-  /* ── Left column ── */
-  .tabs {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-    border-left: 2px solid var(--color-border);
-    margin-bottom: 2rem;
-    transition: border-color 0.3s;
-  }
-
-  .tab {
-    background: none;
-    border: none;
-    border-left: 2px solid transparent;
-    margin-left: -2px;
-    cursor: pointer;
-    font-family: var(--font-mono);
-    font-size: 1rem;
-    font-weight: 500;
-    color: var(--color-muted);
-    text-align: left;
-    padding: 0.55rem 0 0.55rem 1rem;
-    transition: color 0.2s, border-color 0.2s;
-    line-height: 1.3;
-  }
-
-  .tab:hover:not(.active) {
-    color: var(--color-fg);
-  }
-
-  .tab.active {
-    color: var(--color-accent);
-    border-left-color: var(--color-accent);
-  }
-
-  /* Descriptions stacked in same grid cell */
-  .tab-descs {
-    display: grid;
-    padding-left: 1rem;
-    margin-bottom: 2.5rem;
-  }
-
-  .tab-desc {
-    grid-column: 1;
-    grid-row: 1;
-    font-size: 0.9rem;
-    color: var(--color-muted);
-    line-height: 1.65;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.25s;
-  }
-
-  .tab-desc.active {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  /* CTAs */
-  .ctas {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    padding-left: 1rem;
-  }
-
-  .btn-primary {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.6rem 1.2rem;
-    background: var(--color-accent);
-    color: oklch(1 0 0);
-    font-size: 0.875rem;
-    font-weight: 500;
-    border-radius: var(--radius-btn);
-    transition: background 0.15s;
-  }
-
-  .btn-primary:hover {
-    background: var(--color-accent-hover);
-  }
-
-  .btn-secondary {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    border-bottom: 1px solid transparent;
-    padding-bottom: 1px;
-    transition: color 0.15s, border-color 0.15s;
-  }
-
-  .btn-secondary:hover {
-    color: var(--color-accent);
-    border-color: var(--color-accent);
-  }
-
-  /* ── Right column ── */
-  .code-wrapper {
-    border: 1px solid oklch(0.24 0.05 270);
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow:
-      0 0 0 1px oklch(0.17 0.04 266),
-      0 16px 48px oklch(0.17 0.04 266 / 0.28),
-      0 2px 8px oklch(0 0 0 / 0.1);
-  }
-
-  .code-header {
-    background: oklch(0.13 0.03 270);
-    padding: 0 1rem;
-    height: 38px;
-    display: flex;
-    align-items: center;
-    border-bottom: 1px solid oklch(0.24 0.05 270);
-  }
-
-  .dots { display: flex; gap: 6px; align-items: center; flex: 1; }
-  .dots-spacer { flex: 1; }
-
-  .dot { width: 11px; height: 11px; border-radius: 50%; }
-  .dot.red    { background: oklch(0.63 0.22 25); }
-  .dot.yellow { background: oklch(0.84 0.17 84); }
-  .dot.green  { background: oklch(0.73 0.22 142); }
-
-  .filename {
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    color: oklch(0.41 0 0);
-    letter-spacing: 0.01em;
-  }
-
-  .code-panels {
-    display: grid;
-    background: oklch(0.17 0.04 266);
-  }
-
-  .code-panel {
-    grid-column: 1;
-    grid-row: 1;
-    margin: 0;
-    padding: 1.25rem 1.5rem;
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.5;
-    white-space: normal;
-    overflow-x: auto;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.25s ease;
-  }
-
-  .code-panel.active {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  code { font-family: inherit; }
-
-  .line {
-    display: block;
-    font-size: 0.875rem;
-    white-space: pre;
-  }
-
-  .line.empty { min-height: 1.5em; }
-
-  .kw   { color: oklch(0.73 0.18 294); }
-  .var  { color: oklch(0.78 0.07 278); }
-  .fn   { color: oklch(0.67 0.16 255); }
-  .str  { color: oklch(0.79 0.17 135); }
-  .prop { color: oklch(0.83 0.12 186); }
-  .op   { color: oklch(0.78 0.07 278); }
-  .p    { color: oklch(0.68 0.07 262); }
-  .cmt  { color: oklch(0.50 0.05 266); }
-
-  @media (max-width: 680px) {
-    .features-grid {
-      grid-template-columns: 1fr;
-      gap: 2.5rem;
-    }
-  }
-</style>
-
 <script>
-  const tabs  = document.querySelectorAll<HTMLElement>(".tab");
-  const panels = document.querySelectorAll<HTMLElement>(".code-panel");
-  const descs  = document.querySelectorAll<HTMLElement>(".tab-desc");
+  const packageTabs = document.querySelectorAll<HTMLElement>(".package-tab");
+  const packagePanels = document.querySelectorAll<HTMLElement>(".package-panel");
 
   const themes = [
     { accent: "oklch(0.50 0.26 292)", hover: "oklch(0.44 0.24 292)", bg: "oklch(0.985 0.005 292)" },
@@ -411,19 +393,53 @@ const features = [
     { accent: "oklch(0.55 0.14 228)", hover: "oklch(0.49 0.12 228)", bg: "oklch(0.985 0.005 228)" },
   ];
 
-  function activate(index: number) {
-    tabs.forEach((t, i)   => t.classList.toggle("active", i === index));
-    panels.forEach((p, i) => p.classList.toggle("active", i === index));
-    descs.forEach((d, i)  => d.classList.toggle("active", i === index));
-
-    const t = themes[index];
+  function applyTheme(index: number) {
+    const t = themes[index % themes.length];
     const root = document.documentElement;
     root.style.setProperty("--color-accent", t.accent);
     root.style.setProperty("--color-accent-hover", t.hover);
     root.style.setProperty("--color-bg", t.bg);
   }
 
-  tabs.forEach((tab, i) => tab.addEventListener("click", () => activate(i)));
+  function activateFeature(panel: HTMLElement, index: number) {
+    const tabs = panel.querySelectorAll<HTMLElement>(".tab");
+    const panels = panel.querySelectorAll<HTMLElement>(".code-panel");
+    const descs = panel.querySelectorAll<HTMLElement>(".tab-desc");
+    const filename = panel.querySelector<HTMLElement>(".filename");
 
-  activate(0);
+    tabs.forEach((t, i) => {
+      t.classList.toggle("active", i === index);
+      t.setAttribute("aria-selected", String(i === index));
+    });
+    panels.forEach((p, i) => p.classList.toggle("active", i === index));
+    descs.forEach((d, i) => d.classList.toggle("active", i === index));
+
+    if (filename) {
+      const active = panels[index];
+      filename.textContent = active?.dataset.filename ?? "index.ts";
+    }
+
+    applyTheme(index);
+  }
+
+  function activatePackage(index: number) {
+    packageTabs.forEach((t, i) => {
+      t.classList.toggle("active", i === index);
+      t.setAttribute("aria-selected", String(i === index));
+    });
+    packagePanels.forEach((p, i) => p.classList.toggle("active", i === index));
+
+    const active = packagePanels[index];
+    if (active) activateFeature(active, 0);
+  }
+
+  packageTabs.forEach((tab, i) => tab.addEventListener("click", () => activatePackage(i)));
+
+  packagePanels.forEach((panel) => {
+    panel.querySelectorAll<HTMLElement>(".tab").forEach((tab, i) => {
+      tab.addEventListener("click", () => activateFeature(panel, i));
+    });
+  });
+
+  activatePackage(0);
 </script>

--- a/apps/www/src/components/Features.astro
+++ b/apps/www/src/components/Features.astro
@@ -189,6 +189,21 @@ const packages: Pkg[] = [
 <span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;</span></span>`,
       },
       {
+        keyword: "Steer.",
+        desc: "Redirect the agent mid-response — it adjusts course immediately, without waiting for the current turn to finish.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">stream</span> <span class="tok-op">=</span> <span class="tok-fn">textOnly</span><span class="tok-punct">(</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">prompt</span><span class="tok-punct">(</span><span class="tok-str">"Write a very long essay..."</span><span class="tok-punct">),</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-fn">setTimeout</span><span class="tok-punct">(()</span> <span class="tok-op">=&gt;</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">steer</span><span class="tok-punct">(</span><span class="tok-str">"Stop — give me 3 bullets instead."</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;,</span> <span class="tok-var">1500</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">for</span> <span class="tok-kw">await</span> <span class="tok-punct">(</span><span class="tok-kw">const</span> <span class="tok-var">chunk</span> <span class="tok-kw">of</span> <span class="tok-var">stream</span><span class="tok-punct">)</span> <span class="tok-punct">&#123;</span></span>
+<span class="block whitespace-pre text-sm">  <span class="tok-var">process</span><span class="tok-punct">.</span><span class="tok-var">stdout</span><span class="tok-punct">.</span><span class="tok-fn">write</span><span class="tok-punct">(</span><span class="tok-var">chunk</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;</span></span>`,
+      },
+      {
         keyword: "Tool events.",
         desc: "Watch Pi's tool calls as they happen — not just the final text — for full visibility into what the agent is doing.",
         code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">for</span> <span class="tok-kw">await</span> <span class="tok-punct">(</span><span class="tok-kw">const</span> <span class="tok-var">ev</span> <span class="tok-kw">of</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">prompt</span><span class="tok-punct">(</span></span>
@@ -201,15 +216,14 @@ const packages: Pkg[] = [
 <span class="block whitespace-pre text-sm"><span class="tok-punct">&#125;</span></span>`,
       },
       {
-        keyword: "Files.",
-        desc: "Read and write files directly inside the agent's sandbox, alongside its own edits — no extra tooling needed.",
-        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-var">sandbox</span><span class="tok-punct">.</span><span class="tok-fn">writeFile</span><span class="tok-punct">(</span></span>
-<span class="block whitespace-pre text-sm">  <span class="tok-str">"/workspace/data.csv"</span><span class="tok-punct">,</span> <span class="tok-var">csv</span><span class="tok-punct">,</span></span>
-<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>
+        keyword: "Sessions.",
+        desc: "Branch from any earlier message in the conversation, or wipe the slate clean — the sandbox filesystem stays untouched either way.",
+        code: `<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">points</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">getForkMessages</span><span class="tok-punct">();</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">forked</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">fork</span><span class="tok-punct">(</span><span class="tok-var">points</span><span class="tok-punct">[</span><span class="tok-var">0</span><span class="tok-punct">].</span><span class="tok-prop">entryId</span><span class="tok-punct">);</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-var">console</span><span class="tok-punct">.</span><span class="tok-fn">log</span><span class="tok-punct">(</span><span class="tok-var">forked</span><span class="tok-punct">.</span><span class="tok-prop">text</span><span class="tok-punct">.</span><span class="tok-fn">slice</span><span class="tok-punct">(</span><span class="tok-var">0</span><span class="tok-punct">,</span> <span class="tok-var">40</span><span class="tok-punct">));</span></span>
 <span class="block whitespace-pre text-sm min-h-[1.5em]"> </span>
-<span class="block whitespace-pre text-sm"><span class="tok-kw">const</span> <span class="tok-var">summary</span> <span class="tok-op">=</span> <span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-var">sandbox</span><span class="tok-punct">.</span><span class="tok-fn">readFile</span><span class="tok-punct">(</span></span>
-<span class="block whitespace-pre text-sm">  <span class="tok-str">"/workspace/summary.txt"</span><span class="tok-punct">,</span></span>
-<span class="block whitespace-pre text-sm"><span class="tok-punct">);</span></span>`,
+<span class="block whitespace-pre text-sm"><span class="tok-cmt">// or wipe the slate clean</span></span>
+<span class="block whitespace-pre text-sm"><span class="tok-kw">await</span> <span class="tok-var">agent</span><span class="tok-punct">.</span><span class="tok-fn">newSession</span><span class="tok-punct">();</span></span>`,
       },
       {
         keyword: "Snapshot.",
@@ -293,11 +307,11 @@ const packages: Pkg[] = [
         class:list={["package-panel hidden [&.active]:block", { active: pi === 0 }]}
         data-package-panel={pi}
       >
-        <div class="grid grid-cols-[2fr_3fr] gap-20 items-center max-[680px]:grid-cols-1 max-[680px]:gap-10">
+        <div class="grid grid-cols-[2fr_3fr] gap-20 items-start max-[680px]:grid-cols-1 max-[680px]:gap-10">
 
           <!-- Left: tabs + description -->
           <div>
-            <div class="tabs flex flex-col border-l-2 border-[var(--color-border)] mb-8 transition-colors duration-300" role="tablist">
+            <div class="tabs flex flex-col min-h-[17rem] border-l-2 border-[var(--color-border)] mb-8 transition-colors duration-300" role="tablist">
               {pkg.examples.map((ex, i) => (
                 <button
                   class:list={[
@@ -313,7 +327,7 @@ const packages: Pkg[] = [
               ))}
             </div>
 
-            <div class="grid pl-4 mb-10">
+            <div class="grid min-h-[4.95rem] pl-4 mb-10">
               {pkg.examples.map((ex, i) => (
                 <p
                   class:list={[
@@ -357,7 +371,7 @@ const packages: Pkg[] = [
                 </span>
                 <div class="flex-1"></div>
               </div>
-              <div class="grid bg-[oklch(0.17_0.04_266)]">
+              <div class="grid min-h-[19rem] bg-[oklch(0.17_0.04_266)]">
                 {pkg.examples.map((ex, i) => (
                   <pre
                     class:list={[

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -1,42 +1,54 @@
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+@import "tailwindcss";
 
-:root {
-  --color-bg: oklch(0.985 0 0);
-  --color-fg: oklch(0.16 0.005 286);
-  --color-muted: oklch(0.52 0.013 286);
-  --color-border: oklch(0.92 0.005 286);
-  --color-accent: oklch(0.5 0.26 292);
-  --color-accent-hover: oklch(0.44 0.24 292);
-  --font-sans: "Geist Variable", "Inter", system-ui, sans-serif;
-  --font-mono: "Geist Mono Variable", "Fira Code", ui-monospace, monospace;
-  --max-width: 860px;
-  --radius-btn: 6px;
-}
+/*
+ * Tailwind emits its own rules inside `@layer theme, base, components, utilities`.
+ * Per the CSS cascade-layers spec, unlayered rules always beat layered ones
+ * regardless of specificity or source order — so anything here that should be
+ * overridable by a Tailwind utility class MUST live in `@layer base`, matching
+ * Tailwind's own Preflight, or utilities like `mx-auto`/`text-white`/`px-4`
+ * silently lose to whatever's declared below.
+ */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
 
-html {
-  background: var(--color-bg);
-  color: var(--color-fg);
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  scroll-behavior: smooth;
-  transition: background-color 0.4s ease;
-}
+  :root {
+    --color-bg: oklch(0.985 0 0);
+    --color-fg: oklch(0.16 0.005 286);
+    --color-muted: oklch(0.52 0.013 286);
+    --color-border: oklch(0.92 0.005 286);
+    --color-accent: oklch(0.5 0.26 292);
+    --color-accent-hover: oklch(0.44 0.24 292);
+    --font-sans: "Geist Variable", "Inter", system-ui, sans-serif;
+    --font-mono: "Geist Mono Variable", "Fira Code", ui-monospace, monospace;
+    --max-width: 860px;
+    --radius-btn: 6px;
+  }
 
-body {
-  min-height: 100vh;
-}
+  html {
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    scroll-behavior: smooth;
+    transition: background-color 0.4s ease;
+  }
 
-a {
-  color: inherit;
-  text-decoration: none;
+  body {
+    min-height: 100vh;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -47,4 +59,30 @@ a {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
+}
+
+/* Syntax-highlighting tokens for hand-marked-up code snippets (Tokyo Night palette). */
+@utility tok-kw {
+  color: oklch(0.73 0.18 294);
+}
+@utility tok-var {
+  color: oklch(0.78 0.07 278);
+}
+@utility tok-fn {
+  color: oklch(0.67 0.16 255);
+}
+@utility tok-str {
+  color: oklch(0.79 0.17 135);
+}
+@utility tok-prop {
+  color: oklch(0.83 0.12 186);
+}
+@utility tok-op {
+  color: oklch(0.78 0.07 278);
+}
+@utility tok-punct {
+  color: oklch(0.68 0.07 262);
+}
+@utility tok-cmt {
+  color: oklch(0.5 0.05 266);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/docs": {
       "name": "docs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "fumadocs-core": "^16.10.5",
         "fumadocs-mdx": "^15.0.12",
@@ -43,10 +43,14 @@
         "animejs": "^4.5.0",
         "astro": "^6.4.8",
       },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.3.2",
+        "tailwindcss": "^4.3.2",
+      },
     },
     "examples/cancellation": {
       "name": "drej-example-cancellation",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -54,7 +58,7 @@
     },
     "examples/capture": {
       "name": "drej-example-capture",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -62,7 +66,7 @@
     },
     "examples/control-flow": {
       "name": "drej-example-control-flow",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "@drej/workflow": "workspace:*",
@@ -71,7 +75,7 @@
     },
     "examples/environments": {
       "name": "drej-example-environments",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -79,7 +83,7 @@
     },
     "examples/error-handling": {
       "name": "drej-example-error-handling",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -87,7 +91,7 @@
     },
     "examples/exec-code": {
       "name": "drej-example-exec-code",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -95,7 +99,7 @@
     },
     "examples/file-ops": {
       "name": "drej-example-file-ops",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -103,7 +107,7 @@
     },
     "examples/hello-world": {
       "name": "drej-example-hello-world",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -111,7 +115,7 @@
     },
     "examples/pi-agent": {
       "name": "drej-example-pi-agent",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -120,7 +124,7 @@
     },
     "examples/ports": {
       "name": "drej-example-ports",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -128,7 +132,7 @@
     },
     "examples/read-file": {
       "name": "drej-example-read-file",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -136,7 +140,7 @@
     },
     "examples/run-bash-script": {
       "name": "drej-example-run-bash-script",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -144,7 +148,7 @@
     },
     "examples/sandbox-extensions": {
       "name": "drej-example-sandbox-extensions",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -153,7 +157,7 @@
     },
     "examples/sandbox-fork": {
       "name": "drej-example-sandbox-fork",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -161,7 +165,7 @@
     },
     "examples/snapshot-replay": {
       "name": "drej-example-snapshot-replay",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -169,7 +173,7 @@
     },
     "packages/adapters/flue": {
       "name": "@drej/flue",
-      "version": "2.0.0",
+      "version": "2.0.3",
       "devDependencies": {
         "@flue/runtime": "1.0.0-beta.9",
         "bun-types": "1.3.14",
@@ -179,12 +183,12 @@
       },
       "peerDependencies": {
         "@flue/runtime": ">=1.0.0-beta",
-        "drej": ">=0.9.0",
+        "drej": ">=0.9.3",
       },
     },
     "packages/adapters/otel": {
       "name": "@drej/otel",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "dependencies": {
         "@drej/core": "workspace:*",
       },
@@ -200,7 +204,7 @@
     },
     "packages/adapters/postgres": {
       "name": "@drej/postgres",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "dependencies": {
         "@drej/core": "workspace:*",
         "postgres": "3.4.9",
@@ -213,7 +217,7 @@
     },
     "packages/adapters/sqlite": {
       "name": "@drej/sqlite",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "dependencies": {
         "@drej/core": "workspace:*",
       },
@@ -225,7 +229,7 @@
     },
     "packages/agent": {
       "name": "@drej/agent",
-      "version": "0.2.0",
+      "version": "0.3.2",
       "dependencies": {
         "@drej/core": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -239,7 +243,7 @@
     },
     "packages/cli": {
       "name": "drejx",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "bin": {
         "drejx": "./dist/index.mjs",
       },
@@ -256,7 +260,7 @@
     },
     "packages/core": {
       "name": "@drej/core",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "dependencies": {
         "@drej/opensandbox": "workspace:*",
       },
@@ -269,7 +273,7 @@
     },
     "packages/opensandbox": {
       "name": "@drej/opensandbox",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "devDependencies": {
         "bun-types": "1.3.14",
         "tsdown": "0.22.3",
@@ -278,7 +282,7 @@
     },
     "packages/sdks/typescript": {
       "name": "drej",
-      "version": "0.9.0",
+      "version": "0.9.3",
       "dependencies": {
         "@drej/core": "workspace:*",
         "@drej/opensandbox": "workspace:*",
@@ -292,7 +296,7 @@
     },
     "packages/workflow": {
       "name": "@drej/workflow",
-      "version": "1.1.1",
+      "version": "1.1.4",
       "dependencies": {
         "drej": "workspace:*",
       },
@@ -305,7 +309,7 @@
     },
     "tests/integration": {
       "name": "@drej/integration-tests",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -321,6 +325,9 @@
     "esbuild",
     "unrs-resolver",
   ],
+  "overrides": {
+    "vite": "7.3.6",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -1018,35 +1025,37 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.3.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.1" } }, "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.1", "@tailwindcss/oxide-darwin-arm64": "4.3.1", "@tailwindcss/oxide-darwin-x64": "4.3.1", "@tailwindcss/oxide-freebsd-x64": "4.3.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1", "@tailwindcss/oxide-linux-arm64-musl": "4.3.1", "@tailwindcss/oxide-linux-x64-gnu": "4.3.1", "@tailwindcss/oxide-linux-x64-musl": "4.3.1", "@tailwindcss/oxide-wasm32-wasi": "4.3.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1", "@tailwindcss/oxide-win32-x64-msvc": "4.3.1" } }, "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.2", "@tailwindcss/oxide-darwin-arm64": "4.3.2", "@tailwindcss/oxide-darwin-x64": "4.3.2", "@tailwindcss/oxide-freebsd-x64": "4.3.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2", "@tailwindcss/oxide-linux-arm64-musl": "4.3.2", "@tailwindcss/oxide-linux-x64-gnu": "4.3.2", "@tailwindcss/oxide-linux-x64-musl": "4.3.2", "@tailwindcss/oxide-wasm32-wasi": "4.3.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2", "@tailwindcss/oxide-win32-x64-msvc": "4.3.2" } }, "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.1", "", { "os": "android", "cpu": "arm64" }, "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.2", "", { "os": "android", "cpu": "arm64" }, "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.1", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.2", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.1", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "postcss": "8.5.15", "tailwindcss": "4.3.1" } }, "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -2520,7 +2529,7 @@
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
-    "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
+    "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -2656,7 +2665,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
@@ -2772,17 +2781,23 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/postcss/@tailwindcss/node": ["@tailwindcss/node@4.3.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.1" } }, "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.1", "@tailwindcss/oxide-darwin-arm64": "4.3.1", "@tailwindcss/oxide-darwin-x64": "4.3.1", "@tailwindcss/oxide-freebsd-x64": "4.3.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1", "@tailwindcss/oxide-linux-arm64-musl": "4.3.1", "@tailwindcss/oxide-linux-x64-gnu": "4.3.1", "@tailwindcss/oxide-linux-x64-musl": "4.3.1", "@tailwindcss/oxide-wasm32-wasi": "4.3.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1", "@tailwindcss/oxide-win32-x64-msvc": "4.3.1" } }, "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA=="],
+
+    "@tailwindcss/postcss/tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "@types/sax/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
@@ -2797,8 +2812,6 @@
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "astro/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
-
-    "astro/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
@@ -2882,7 +2895,7 @@
 
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
-    "vite/rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+    "vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
@@ -2896,13 +2909,35 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.1", "", { "os": "android", "cpu": "arm64" }, "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.1", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg=="],
+
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA=="],
+
     "@types/sax/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "astro/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
@@ -3018,93 +3053,73 @@
 
     "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "astro/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
-    "astro/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
-    "astro/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "astro/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
-    "astro/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
-    "astro/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
-
-    "astro/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
-
-    "astro/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
-
-    "astro/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
-
-    "astro/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
-
-    "astro/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
-
-    "astro/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
-
-    "astro/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
-
-    "astro/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
-
-    "astro/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
-
-    "astro/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
-
-    "astro/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
-
-    "astro/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
-
-    "astro/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
-
-    "astro/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
-
-    "astro/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
-
-    "astro/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
-
-    "astro/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
-
-    "astro/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
-
-    "astro/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
-
-    "astro/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+    "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "eslint-plugin-import/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -3120,12 +3135,6 @@
 
     "read-yaml-file/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
-
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "@changesets/cli": "2.31.0",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.71.0"
+  },
+  "overrides": {
+    "vite": "7.3.6"
   }
 }


### PR DESCRIPTION
## Summary

The landing page's features section only ever showed `drej` (core SDK) code snippets in its vertical example sidebar. Added a horizontal package tab bar — **Core / Workflow / Agent / CLI** — above the existing vertical example list. Switching package tabs swaps both the vertical example list and the code panels to that package's own snippets. Content is sourced from real, doc-verified API usage (workflow control-flow, `@drej/agent`'s streaming/session API, `drejx`'s actual CLI surface).

Per request, also migrated `Features.astro` to Tailwind (installed fresh into `apps/www`, which didn't have it) instead of the scoped `<style>` block pattern the other components (`Hero`, `Nav`, `Pillars`, `Footer`) use — those are intentionally left untouched for this PR.

## Two real bugs found and fixed getting this to actually work

**1. `bun run build` failed outright.** `@tailwindcss/vite@4.3.2` resolves its own `vite@8.0.16` (the newest release on npm), while Astro 6.4.8 bundles `vite@7.3.6` internally — two incompatible Vite copies loaded side by side, breaking a native plugin binding (`Missing field tsconfigPaths on BindingViteResolvePluginConfig.resolveOptions`). Dev mode uses a different code path that happened to route around it, which is why it looked fine until a production build was attempted. Fixed by pinning `vite` to `7.3.6` via a root `overrides` field so the whole workspace resolves to the single version Astro actually uses.

**2. Even after the build succeeded, the page was visibly broken** — content wasn't centered, and the primary CTA button rendered as unreadable dark text on a purple background. Root cause: `global.css`'s hand-written reset (`*, *::before, *::after { margin: 0; padding: 0; }`, plus `a { color: inherit }`) sat outside any `@layer`. Per the CSS cascade-layers spec, unlayered rules always beat layered ones regardless of specificity or source order — and everything Tailwind generates lives inside `@layer utilities`. That one reset was silently zeroing out *every* margin/padding utility on the page and overriding `text-white` site-wide. Fixed by moving these into `@layer base`, which is exactly what Tailwind's own Preflight already does (this reset is now redundant with Preflight but kept for the custom CSS variables it's grouped with).

Verified with `bun run build` + headless Chrome screenshots (both dev and the actual built `dist/` output): confirmed content is centered, the CTA button is genuinely white-on-purple (checked via `getComputedStyle`, not just eyeballing a screenshot), and clicking through all 4 package tabs × their feature sub-tabs correctly swaps code panels and updates the per-example filename label.

## Test plan

- [x] `bun run build` succeeds (previously failed)
- [x] `bun run typecheck && bun run format:check` pass
- [x] `bunx changeset status --since origin/main` — no changeset needed (apps/www isn't a changesets-tracked publishable package)
- [x] Headless Chrome screenshots of dev server and production `dist/` build, confirmed centering and button contrast
- [x] Puppeteer-driven click-through of all package tabs and their feature sub-tabs, confirmed panel/filename swaps
- [ ] CI green