### PR TITLE
fix(sdk): forward all client.ts exports from the drej entry point

### DIFF
--- a/.changeset/fix-sdk-missing-exports.md
+++ b/.changeset/fix-sdk-missing-exports.md
@@ -1,0 +1,5 @@
+---
+"drej": patch
+---
+
+Fix `drej`'s public entry point (`src/index.ts`) silently omitting several types that were already re-exported from `client.ts` — `BashSession`, `InteractiveExecHandle`, `PendingInteractiveExec`, `CheckpointInfo`, `EnvironmentRecord`, `FileInfo`, `DiagnosticLog`, `DiagnosticEvent`, `Metrics`, `ResumeOptions`, `Environment`, `EnvironmentOptions`, and `EnvironmentSandboxOptions` never reached the built package because `index.ts` re-declared `client.ts`'s exports one by one instead of forwarding them, and had drifted out of sync across several past features (most recently the `interactive: true` PTY exec support). `index.ts` now does `export * from "./client"`, so this class of drift can't recur.

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -1,24 +1,2 @@
-export { Drej } from "./client";
-export { Sandbox } from "@drej/core";
-export { ExecHandle } from "@drej/core";
-export type { ExecResult, ExecOptions, ExecCodeOptions } from "@drej/core";
-export { LedgerEvent, SandboxStatus } from "@drej/core";
-export {
-  WorkflowError,
-  SandboxError,
-  ExecConnectionError,
-  CommandError,
-  StepTimeoutError,
-} from "@drej/core";
-export { ConsoleLogger, LogLevel, noopLogger } from "@drej/core";
-export type { ILogger } from "@drej/core";
-export type {
-  IStorageAdapter,
-  LedgerEntry,
-  SandboxDetails,
-  ListSandboxOptions,
-  SandboxHooks,
-} from "@drej/core";
-export { DrejError } from "./types";
-export type { DrejOptions, SandboxOptions } from "./types";
+export * from "./client";
 export { CodeLanguage } from "@drej/opensandbox";


### PR DESCRIPTION
src/index.ts hand-duplicated client.ts's export list instead of forwarding it, and had drifted out of sync across several features. BashSession, InteractiveExecHandle, PendingInteractiveExec, CheckpointInfo, EnvironmentRecord, FileInfo, DiagnosticLog, DiagnosticEvent, Metrics, ResumeOptions, Environment, EnvironmentOptions, and EnvironmentSandboxOptions were all exported from client.ts but never reached consumers of the published package.

Switch to `export * from "./client"` so this can't drift again.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
