### PR TITLE
feat: add sandbox.drej.dev — live dashboard for sandboxes and Pi agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ plans/
 .drej
 apps/www/.astro/
 apps/registry/.astro/
+apps/sandbox/.astro/

--- a/apps/README.md
+++ b/apps/README.md
@@ -2,11 +2,11 @@
 
 Deployable sites for drej, separate from the publishable SDK packages in `packages/`.
 
-| App | Description | Stack | Deploy |
-|---|---|---|---|
-| [`www`](www) | Marketing landing page ([drej.dev](https://drej.dev)) | Astro | Cloudflare Pages (`drej-www`) |
-| [`docs`](docs) | Documentation site ([docs.drej.dev](https://docs.drej.dev)) | Next.js + Fumadocs | Cloudflare Pages (`drej-docs`) |
-| [`registry`](registry) | Curated `AgentSpec` examples for `drejx add` ([registry.drej.dev](https://registry.drej.dev)) | Astro | Cloudflare Pages (`drej-registry`) |
+| App                    | Description                                                                                   | Stack              | Deploy                             |
+| ---------------------- | --------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------- |
+| [`www`](www)           | Marketing landing page ([drej.dev](https://drej.dev))                                         | Astro              | Cloudflare Pages (`drej-www`)      |
+| [`docs`](docs)         | Documentation site ([docs.drej.dev](https://docs.drej.dev))                                   | Next.js + Fumadocs | Cloudflare Pages (`drej-docs`)     |
+| [`registry`](registry) | Curated `AgentSpec` examples for `drejx add` ([registry.drej.dev](https://registry.drej.dev)) | Astro              | Cloudflare Pages (`drej-registry`) |
 
 ## Commands
 

--- a/apps/sandbox/agents/hello-agent.json
+++ b/apps/sandbox/agents/hello-agent.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://registry.drej.dev/spec/agent.json",
+  "name": "hello-agent",
+  "title": "Hello Agent",
+  "description": "A minimal Pi agent on node:22. Demonstrates the @drej/agent API.",
+  "author": "drej",
+  "categories": ["agent", "starter"],
+  "cli": "pi",
+  "model": "gemini-flash-latest",
+  "packages": ["git", "python3"],
+  "env": {
+    "GEMINI_API_KEY": "${GEMINI_API_KEY}"
+  },
+  "resources": { "cpu": "500m", "memory": "1Gi" }
+}

--- a/apps/sandbox/agents/python-data.json
+++ b/apps/sandbox/agents/python-data.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://registry.drej.dev/spec/agent.json",
+  "name": "python-data",
+  "title": "Python Data Agent",
+  "description": "A Pi agent on node:22 with Python 3 and pandas/numpy pre-installed for data analysis tasks.",
+  "author": "drej",
+  "categories": ["agent", "python", "data"],
+  "cli": "pi",
+  "model": "gemini-flash-latest",
+  "packages": ["python3", "python3-pip"],
+  "env": {
+    "GEMINI_API_KEY": "${GEMINI_API_KEY}"
+  },
+  "resources": { "cpu": "500m", "memory": "1Gi" },
+  "setup": [
+    {
+      "name": "Install pandas + numpy",
+      "run": "pip install --break-system-packages pandas numpy"
+    }
+  ]
+}

--- a/apps/sandbox/astro.config.mjs
+++ b/apps/sandbox/astro.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from "astro/config";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  output: "static",
+  site: "https://sandbox.drej.dev",
+  vite: {
+    plugins: [tailwindcss()],
+  },
+});

--- a/apps/sandbox/drej.config.json
+++ b/apps/sandbox/drej.config.json
@@ -1,0 +1,10 @@
+{
+  "serverUrl": "http://localhost:8080",
+  "apiKey": "",
+  "adapterPath": "./data/ledger.db",
+  "useServerProxy": true,
+  "agentsDir": "./agents",
+  "defaults": {
+    "resources": { "cpu": "500m", "memory": "1Gi" }
+  }
+}

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@drej/sandbox",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "start": "bun server/index.ts",
+    "typecheck": "astro check && tsc --noEmit --project tsconfig.server.json"
+  },
+  "dependencies": {
+    "@drej/agent": "workspace:*",
+    "@drej/core": "workspace:*",
+    "@drej/sqlite": "workspace:*",
+    "@fontsource-variable/geist": "^5.1.1",
+    "@fontsource-variable/geist-mono": "^5.2.2",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
+    "astro": "^6.4.8",
+    "drej": "workspace:*"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.4",
+    "@tailwindcss/vite": "^4.3.2",
+    "bun-types": "1.3.14",
+    "tailwindcss": "^4.3.2",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/sandbox/public/favicon.svg
+++ b/apps/sandbox/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#0a0a0a"/>
+  <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, monospace" font-size="18" font-weight="600" fill="white">d</text>
+</svg>

--- a/apps/sandbox/server/config.ts
+++ b/apps/sandbox/server/config.ts
@@ -1,0 +1,25 @@
+/**
+ * Hardcoded, non-negotiable resource governance for the public, unauthenticated dashboard.
+ * Nothing here is ever accepted as a client-supplied request field — see plans/sandbox-dashboard.md
+ * ("Hard limits") for why.
+ */
+
+export const OPENSANDBOX_URL = process.env.OPENSANDBOX_URL ?? "http://localhost:8080";
+export const OPENSANDBOX_API_KEY = process.env.OPENSANDBOX_API_KEY ?? "";
+export const USE_SERVER_PROXY = true;
+export const LEDGER_PATH = process.env.LEDGER_PATH ?? "./data/ledger.db";
+
+export const MAX_SANDBOXES = 3;
+export const SANDBOX_IMAGE = "node:22";
+export const SANDBOX_RESOURCES = { cpu: "250m", memory: "500Mi" };
+/** Safety-net auto-expiry (seconds) in case a sandbox is left open indefinitely. */
+export const SANDBOX_TIMEOUT_SECONDS = 60 * 60 * 4;
+
+export const MAX_AGENTS = 2;
+export const AGENTS_DIR = "./agents";
+/** The only spec names `POST /api/agents` will accept — never an arbitrary URL or spec body. */
+export const ALLOWED_AGENT_SPECS = ["hello-agent", "python-data"] as const;
+export type AllowedAgentSpec = (typeof ALLOWED_AGENT_SPECS)[number];
+
+export const PORT = Number(process.env.PORT ?? 3000);
+export const DIST_DIR = "./dist";

--- a/apps/sandbox/server/index.ts
+++ b/apps/sandbox/server/index.ts
@@ -1,0 +1,120 @@
+import { join, extname } from "path";
+import * as config from "./config";
+import * as registry from "./registry";
+import * as sandboxRoutes from "./routes/sandboxes";
+import * as agentRoutes from "./routes/agents";
+import * as terminal from "./ws/terminal";
+import * as metrics from "./ws/metrics";
+import * as chat from "./ws/chat";
+import type { WSData } from "./ws/types";
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+};
+
+async function serveStatic(pathname: string): Promise<Response> {
+  const safePath = pathname === "/" ? "/index.html" : pathname;
+  const filePath = join(config.DIST_DIR, safePath);
+  let file = Bun.file(filePath);
+  if (!(await file.exists())) {
+    file = Bun.file(join(config.DIST_DIR, "index.html"));
+    if (!(await file.exists())) return new Response("Not found", { status: 404 });
+  }
+  const type = CONTENT_TYPES[extname(filePath)];
+  return new Response(file, type ? { headers: { "Content-Type": type } } : undefined);
+}
+
+const server = Bun.serve({
+  port: config.PORT,
+  routes: {
+    "/api/sandboxes": {
+      GET: () => sandboxRoutes.listSandboxes(),
+      POST: () => sandboxRoutes.createSandbox(),
+    },
+    "/api/sandboxes/:id": {
+      DELETE: (req) => sandboxRoutes.deleteSandbox(req.params.id),
+    },
+    "/api/sandboxes/:id/files": {
+      GET: (req) =>
+        sandboxRoutes.listDirectory(
+          req.params.id,
+          new URL(req.url).searchParams.get("path") ?? "/",
+        ),
+    },
+    "/api/sandboxes/:id/file": {
+      GET: (req) => {
+        const path = new URL(req.url).searchParams.get("path");
+        if (!path) return Response.json({ error: "missing ?path=" }, { status: 400 });
+        return sandboxRoutes.readFile(req.params.id, path);
+      },
+      PUT: async (req) => {
+        const path = new URL(req.url).searchParams.get("path");
+        if (!path) return Response.json({ error: "missing ?path=" }, { status: 400 });
+        const content = await req.text();
+        return sandboxRoutes.writeFile(req.params.id, path, content);
+      },
+    },
+    "/api/sandboxes/:id/metrics": {
+      GET: (req) => sandboxRoutes.getMetrics(req.params.id),
+    },
+    "/api/sandboxes/:id/checkpoints": {
+      GET: (req) => sandboxRoutes.listCheckpoints(req.params.id),
+    },
+    "/api/sandboxes/:id/checkpoint": {
+      POST: (req) => sandboxRoutes.createCheckpoint(req.params.id),
+    },
+    "/api/sandboxes/:id/preview": {
+      GET: (req) => {
+        const port = Number(new URL(req.url).searchParams.get("port"));
+        if (!port) return Response.json({ error: "missing ?port=" }, { status: 400 });
+        return sandboxRoutes.getPreview(req.params.id, port);
+      },
+    },
+    "/api/agents": {
+      GET: () => agentRoutes.listAgents(),
+      POST: async (req) => {
+        const body = (await req.json().catch(() => ({}))) as { specName?: string };
+        if (!body.specName) return Response.json({ error: "missing specName" }, { status: 400 });
+        return agentRoutes.createAgent(body.specName);
+      },
+    },
+    "/api/agents/:id": {
+      DELETE: (req) => agentRoutes.deleteAgent(req.params.id),
+    },
+    "/api/agents/:id/messages": {
+      GET: (req) => agentRoutes.getMessages(req.params.id),
+    },
+    "/ws/sandboxes/:id/terminal": (req, srv) => terminal.upgradeTerminal(req, srv, req.params.id),
+    "/ws/sandboxes/:id/metrics": (req, srv) => metrics.upgradeMetrics(req, srv, req.params.id),
+    "/ws/agents/:id/chat": (req, srv) => chat.upgradeChat(req, srv, req.params.id),
+    "/ws/agents/:id/shell": (req, srv) => terminal.upgradeAgentShell(req, srv, req.params.id),
+  },
+  websocket: {
+    data: {} as WSData,
+    open(ws) {
+      if (ws.data.kind === "terminal") void terminal.onOpen(ws);
+      else if (ws.data.kind === "metrics") void metrics.onOpen(ws);
+    },
+    message(ws, message) {
+      if (ws.data.kind === "terminal") terminal.onMessage(ws, message);
+      else if (ws.data.kind === "chat") chat.onMessage(ws, message);
+    },
+    close(ws) {
+      if (ws.data.kind === "terminal") void terminal.onClose(ws);
+      else if (ws.data.kind === "metrics") metrics.onClose(ws);
+      else if (ws.data.kind === "chat") chat.onClose(ws);
+    },
+  },
+  fetch: (req) => serveStatic(new URL(req.url).pathname),
+});
+
+await registry.reconcile();
+
+console.log(`[sandbox] listening on http://localhost:${server.port}`);

--- a/apps/sandbox/server/registry.ts
+++ b/apps/sandbox/server/registry.ts
@@ -1,0 +1,105 @@
+import { Drej, SandboxStatus, type Sandbox } from "drej";
+import { SQLiteAdapter } from "@drej/sqlite";
+import { Agent } from "@drej/agent";
+import * as config from "./config";
+
+export class CapacityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CapacityError";
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+const adapter = new SQLiteAdapter(config.LEDGER_PATH);
+
+export const client = new Drej({
+  baseUrl: config.OPENSANDBOX_URL,
+  apiKey: config.OPENSANDBOX_API_KEY,
+  adapter,
+  useServerProxy: config.USE_SERVER_PROXY,
+  maxConcurrency: config.MAX_SANDBOXES,
+});
+
+/** Live handles for plain sandboxes, keyed by sandboxId. */
+export const sandboxes = new Map<string, Sandbox>();
+/** Live handles for Pi agents, keyed by sandboxId (an agent's sandboxId IS its id here). */
+export const agents = new Map<string, Agent>();
+
+function isAllowedAgentSpec(name: string): name is config.AllowedAgentSpec {
+  return (config.ALLOWED_AGENT_SPECS as readonly string[]).includes(name);
+}
+
+export async function createSandbox(): Promise<Sandbox> {
+  if (sandboxes.size >= config.MAX_SANDBOXES) {
+    throw new CapacityError(`Sandbox limit reached (${config.MAX_SANDBOXES})`);
+  }
+  const sb = await client.sandbox({
+    image: config.SANDBOX_IMAGE,
+    resources: config.SANDBOX_RESOURCES,
+    name: `plain-${crypto.randomUUID().slice(0, 8)}`,
+    timeout: config.SANDBOX_TIMEOUT_SECONDS,
+  });
+  sandboxes.set(sb.sandboxId, sb);
+  return sb;
+}
+
+export async function deleteSandbox(id: string): Promise<void> {
+  const sb = sandboxes.get(id);
+  if (!sb) throw new NotFoundError(`Unknown sandbox ${id}`);
+  await sb.close();
+  sandboxes.delete(id);
+}
+
+export async function createAgent(specName: string): Promise<Agent> {
+  if (agents.size >= config.MAX_AGENTS) {
+    throw new CapacityError(`Agent limit reached (${config.MAX_AGENTS})`);
+  }
+  if (!isAllowedAgentSpec(specName)) {
+    throw new NotFoundError(`Unknown agent spec "${specName}"`);
+  }
+  const agent = await Agent.load(`${config.AGENTS_DIR}/${specName}.json`, { adapter });
+  agents.set(agent.sandboxId, agent);
+  return agent;
+}
+
+export async function deleteAgent(id: string): Promise<void> {
+  const agent = agents.get(id);
+  if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+  await agent.close();
+  agents.delete(id);
+}
+
+/**
+ * Rebuild the in-memory registries from the ledger on boot, so a backend
+ * restart never leaves running containers orphaned/untracked. Agent sandboxes
+ * are identified by ledger `name` matching an allowed spec name (`Agent.load()`
+ * names the sandbox after `spec.name`) — `SandboxOptions.metadata` is not
+ * surfaced back through `SandboxDetails`, so it can't be used for this.
+ */
+export async function reconcile(): Promise<void> {
+  const records = await client.sandboxes.list({ status: SandboxStatus.Running });
+  for (const record of records) {
+    try {
+      if (isAllowedAgentSpec(record.name)) {
+        const agent = await Agent.resume(record.sandboxId, {
+          adapter,
+          specPath: `${config.AGENTS_DIR}/${record.name}.json`,
+        });
+        agents.set(agent.sandboxId, agent);
+      } else {
+        const sb = await client.connect(record.sandboxId, record.name);
+        sandboxes.set(sb.sandboxId, sb);
+      }
+    } catch (err) {
+      console.error(`[reconcile] failed to reattach ${record.sandboxId} (${record.name}):`, err);
+    }
+  }
+  console.log(`[reconcile] reattached ${sandboxes.size} sandbox(es), ${agents.size} agent(s)`);
+}

--- a/apps/sandbox/server/routes/agents.ts
+++ b/apps/sandbox/server/routes/agents.ts
@@ -1,0 +1,51 @@
+import * as registry from "../registry";
+import { CapacityError, NotFoundError } from "../registry";
+import * as config from "../config";
+
+function errorResponse(err: unknown): Response {
+  if (err instanceof CapacityError) return Response.json({ error: err.message }, { status: 409 });
+  if (err instanceof NotFoundError) return Response.json({ error: err.message }, { status: 404 });
+  const message = err instanceof Error ? err.message : String(err);
+  return Response.json({ error: message }, { status: 500 });
+}
+
+export async function listAgents(): Promise<Response> {
+  const list = Array.from(registry.agents.values()).map((agent) => ({
+    id: agent.sandboxId,
+    name: agent.name,
+  }));
+  return Response.json({
+    agents: list,
+    max: config.MAX_AGENTS,
+    allowedSpecs: config.ALLOWED_AGENT_SPECS,
+  });
+}
+
+export async function createAgent(specName: string): Promise<Response> {
+  try {
+    const agent = await registry.createAgent(specName);
+    return Response.json({ id: agent.sandboxId, name: agent.name }, { status: 201 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function deleteAgent(id: string): Promise<Response> {
+  try {
+    await registry.deleteAgent(id);
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function getMessages(id: string): Promise<Response> {
+  try {
+    const agent = registry.agents.get(id);
+    if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+    const messages = await agent.getMessages();
+    return Response.json({ messages });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}

--- a/apps/sandbox/server/routes/sandboxes.ts
+++ b/apps/sandbox/server/routes/sandboxes.ts
@@ -1,0 +1,112 @@
+import * as registry from "../registry";
+import { CapacityError, NotFoundError } from "../registry";
+import * as config from "../config";
+
+function errorResponse(err: unknown): Response {
+  if (err instanceof CapacityError) return Response.json({ error: err.message }, { status: 409 });
+  if (err instanceof NotFoundError) return Response.json({ error: err.message }, { status: 404 });
+  const message = err instanceof Error ? err.message : String(err);
+  return Response.json({ error: message }, { status: 500 });
+}
+
+export async function listSandboxes(): Promise<Response> {
+  const list = Array.from(registry.sandboxes.values()).map((sb) => ({
+    id: sb.sandboxId,
+    name: sb.name,
+  }));
+  return Response.json({ sandboxes: list, max: config.MAX_SANDBOXES });
+}
+
+export async function createSandbox(): Promise<Response> {
+  try {
+    const sb = await registry.createSandbox();
+    return Response.json({ id: sb.sandboxId, name: sb.name }, { status: 201 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function deleteSandbox(id: string): Promise<Response> {
+  try {
+    await registry.deleteSandbox(id);
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+function getSandboxOr404(id: string) {
+  const sb = registry.sandboxes.get(id);
+  if (!sb) throw new NotFoundError(`Unknown sandbox ${id}`);
+  return sb;
+}
+
+export async function listDirectory(id: string, path: string): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    const entries = await sb.listDirectory(path || "/");
+    return Response.json({ entries });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function readFile(id: string, path: string): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    const content = await sb.readFile(path);
+    return Response.json({ path, content });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function writeFile(id: string, path: string, content: string): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    await sb.writeFile(path, content);
+    return Response.json({ path });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function getMetrics(id: string): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    const metrics = await sb.metrics();
+    return Response.json(metrics);
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function listCheckpoints(id: string): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    const checkpoints = await sb.listCheckpoints();
+    return Response.json({ checkpoints });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function createCheckpoint(id: string): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    const snapshotId = await sb.checkpoint();
+    return Response.json({ snapshotId });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function getPreview(id: string, port: number): Promise<Response> {
+  try {
+    const sb = getSandboxOr404(id);
+    const proxy = await sb.proxy(port);
+    return Response.json(proxy);
+  } catch (err) {
+    return errorResponse(err);
+  }
+}

--- a/apps/sandbox/server/ws/chat.ts
+++ b/apps/sandbox/server/ws/chat.ts
@@ -1,0 +1,77 @@
+import type { Server, ServerWebSocket } from "bun";
+import type { AgentStream } from "@drej/agent";
+import * as registry from "../registry";
+import type { WSData } from "./types";
+
+type ChatCommand =
+  | { type: "prompt"; text: string }
+  | { type: "steer"; text: string }
+  | { type: "followUp"; text: string }
+  | { type: "abort" };
+
+/** Route handler for `/ws/agents/:id/chat` — call from the routes table. */
+export function upgradeChat(
+  req: Request,
+  server: Server<WSData>,
+  agentId: string,
+): Response | undefined {
+  if (!registry.agents.has(agentId)) {
+    return Response.json({ error: `Unknown agent ${agentId}` }, { status: 404 });
+  }
+  const ok = server.upgrade(req, { data: { kind: "chat", agentId, streaming: false } });
+  return ok ? undefined : new Response("Upgrade failed", { status: 400 });
+}
+
+async function streamEvents(
+  ws: ServerWebSocket<WSData>,
+  data: Extract<WSData, { kind: "chat" }>,
+  stream: AgentStream,
+): Promise<void> {
+  data.streaming = true;
+  try {
+    for await (const event of stream) {
+      ws.send(JSON.stringify(event));
+    }
+  } catch (err) {
+    ws.send(JSON.stringify({ type: "bridge_error", message: String(err) }));
+  } finally {
+    data.streaming = false;
+  }
+}
+
+export function onMessage(
+  ws: ServerWebSocket<WSData>,
+  message: string | Buffer<ArrayBuffer>,
+): void {
+  if (ws.data.kind !== "chat") return;
+  const data = ws.data;
+  const agent = registry.agents.get(data.agentId);
+  if (!agent) {
+    ws.close(1011, "agent no longer exists");
+    return;
+  }
+  const text = typeof message === "string" ? message : message.toString("utf-8");
+  let cmd: ChatCommand;
+  try {
+    cmd = JSON.parse(text) as ChatCommand;
+  } catch {
+    return;
+  }
+
+  if (cmd.type === "prompt") {
+    if (data.streaming) return; // use steer()/followUp() to interject, not a second prompt()
+    void streamEvents(ws, data, agent.prompt(cmd.text));
+  } else if (cmd.type === "steer") {
+    void agent.steer(cmd.text);
+  } else if (cmd.type === "followUp") {
+    void agent.followUp(cmd.text);
+  } else if (cmd.type === "abort") {
+    void agent.abort();
+  }
+}
+
+export function onClose(ws: ServerWebSocket<WSData>): void {
+  if (ws.data.kind !== "chat" || !ws.data.streaming) return;
+  const agent = registry.agents.get(ws.data.agentId);
+  void agent?.abort();
+}

--- a/apps/sandbox/server/ws/metrics.ts
+++ b/apps/sandbox/server/ws/metrics.ts
@@ -1,0 +1,47 @@
+import type { Server, ServerWebSocket } from "bun";
+import * as registry from "../registry";
+import type { WSData } from "./types";
+
+/** Route handler for `/ws/sandboxes/:id/metrics` — call from the routes table. */
+export function upgradeMetrics(
+  req: Request,
+  server: Server<WSData>,
+  sandboxId: string,
+): Response | undefined {
+  if (!registry.sandboxes.has(sandboxId)) {
+    return Response.json({ error: `Unknown sandbox ${sandboxId}` }, { status: 404 });
+  }
+  const ok = server.upgrade(req, { data: { kind: "metrics", sandboxId, stop: null } });
+  return ok ? undefined : new Response("Upgrade failed", { status: 400 });
+}
+
+export async function onOpen(ws: ServerWebSocket<WSData>): Promise<void> {
+  if (ws.data.kind !== "metrics") return;
+  const sb = registry.sandboxes.get(ws.data.sandboxId);
+  if (!sb) {
+    ws.close(1011, "sandbox no longer exists");
+    return;
+  }
+  const gen = sb.watchMetrics();
+  let stopped = false;
+  ws.data.stop = () => {
+    stopped = true;
+    void gen.return(undefined);
+  };
+
+  (async () => {
+    try {
+      for await (const metrics of gen) {
+        if (stopped) break;
+        ws.send(JSON.stringify(metrics));
+      }
+    } catch {
+      // connection to execd dropped — let the client reconnect
+    }
+  })();
+}
+
+export function onClose(ws: ServerWebSocket<WSData>): void {
+  if (ws.data.kind !== "metrics") return;
+  ws.data.stop?.();
+}

--- a/apps/sandbox/server/ws/terminal.ts
+++ b/apps/sandbox/server/ws/terminal.ts
@@ -1,0 +1,85 @@
+import type { Server, ServerWebSocket } from "bun";
+import type { Sandbox } from "drej";
+import * as registry from "../registry";
+import type { WSData } from "./types";
+
+function resolveSandbox(data: Extract<WSData, { kind: "terminal" }>): Sandbox | undefined {
+  if (data.source === "sandbox") return registry.sandboxes.get(data.id);
+  return registry.agents.get(data.id)?.sandbox;
+}
+
+/** Route handler for `/ws/sandboxes/:id/terminal` — call from the routes table. */
+export function upgradeTerminal(
+  req: Request,
+  server: Server<WSData>,
+  sandboxId: string,
+): Response | undefined {
+  if (!registry.sandboxes.has(sandboxId)) {
+    return Response.json({ error: `Unknown sandbox ${sandboxId}` }, { status: 404 });
+  }
+  const ok = server.upgrade(req, {
+    data: { kind: "terminal", source: "sandbox", id: sandboxId, handle: null },
+  });
+  return ok ? undefined : new Response("Upgrade failed", { status: 400 });
+}
+
+/** Route handler for `/ws/agents/:id/shell` — bridges to `agent.sandbox`, not the chat/Pi session. */
+export function upgradeAgentShell(
+  req: Request,
+  server: Server<WSData>,
+  agentId: string,
+): Response | undefined {
+  if (!registry.agents.has(agentId)) {
+    return Response.json({ error: `Unknown agent ${agentId}` }, { status: 404 });
+  }
+  const ok = server.upgrade(req, {
+    data: { kind: "terminal", source: "agent", id: agentId, handle: null },
+  });
+  return ok ? undefined : new Response("Upgrade failed", { status: 400 });
+}
+
+export async function onOpen(ws: ServerWebSocket<WSData>): Promise<void> {
+  if (ws.data.kind !== "terminal") return;
+  const sb = resolveSandbox(ws.data);
+  if (!sb) {
+    ws.close(1011, "sandbox no longer exists");
+    return;
+  }
+  const handle = sb.exec("bash", { interactive: true });
+  ws.data.handle = handle;
+
+  (async () => {
+    try {
+      for await (const chunk of handle.stdout()) {
+        ws.send(chunk);
+      }
+    } catch {
+      // session ended with an error — fall through and close below
+    }
+    ws.close(1000, "shell exited");
+  })();
+}
+
+export function onMessage(
+  ws: ServerWebSocket<WSData>,
+  message: string | Buffer<ArrayBuffer>,
+): void {
+  if (ws.data.kind !== "terminal" || !ws.data.handle) return;
+  const text = typeof message === "string" ? message : message.toString("utf-8");
+  try {
+    const msg = JSON.parse(text) as
+      | { type: "input"; data: string }
+      | { type: "resize"; cols: number; rows: number }
+      | { type: "signal"; name: string };
+    if (msg.type === "input") ws.data.handle.write(msg.data);
+    else if (msg.type === "resize") ws.data.handle.resize(msg.cols, msg.rows);
+    else if (msg.type === "signal") ws.data.handle.signal(msg.name);
+  } catch {
+    // ignore malformed frames
+  }
+}
+
+export async function onClose(ws: ServerWebSocket<WSData>): Promise<void> {
+  if (ws.data.kind !== "terminal" || !ws.data.handle) return;
+  await ws.data.handle.close();
+}

--- a/apps/sandbox/server/ws/types.ts
+++ b/apps/sandbox/server/ws/types.ts
@@ -1,0 +1,15 @@
+// Imported from @drej/core rather than `drej` — the `drej` package's built dist currently
+// drops this type-only re-export (a bundling gap in packages/sdks/typescript, not something
+// this app should work around by duplicating the type).
+import type { InteractiveExecHandle } from "@drej/core";
+
+export type WSData =
+  | {
+      kind: "terminal";
+      /** Which registry map `id` is looked up in — plain sandboxes vs. an agent's `.sandbox`. */
+      source: "sandbox" | "agent";
+      id: string;
+      handle: InteractiveExecHandle | null;
+    }
+  | { kind: "metrics"; sandboxId: string; stop: (() => void) | null }
+  | { kind: "chat"; agentId: string; streaming: boolean };

--- a/apps/sandbox/src/components/AgentPanel.astro
+++ b/apps/sandbox/src/components/AgentPanel.astro
@@ -1,0 +1,47 @@
+---
+---
+
+<section id="agent-panel" class="mx-auto max-w-[var(--max-width)] px-6 pt-[96px] pb-16" hidden>
+  <button id="agent-panel-back" class="btn mb-4">&larr; Back</button>
+  <h2 id="agent-panel-title" class="mono mb-4 text-lg font-semibold"></h2>
+
+  <div class="mb-4 flex gap-1 border-b border-[var(--color-border)]">
+    <button class="tab-btn" data-tab="chat">Chat</button>
+    <button class="tab-btn" data-tab="shell">Shell</button>
+  </div>
+
+  <div class="tab-content" data-tab-content="chat">
+    <div
+      id="chat-messages"
+      class="mb-3 flex h-[380px] flex-col gap-3 overflow-y-auto rounded-lg border border-[var(--color-border)] p-3 text-sm"
+    ></div>
+    <form id="chat-form" class="flex gap-2">
+      <input
+        id="chat-input"
+        class="btn flex-1"
+        placeholder="Ask the agent something…"
+        autocomplete="off"
+      />
+      <button type="submit" class="btn btn-primary">Send</button>
+      <button type="button" id="chat-steer-btn" class="btn" disabled>Steer</button>
+      <button type="button" id="chat-abort-btn" class="btn btn-danger" disabled>Abort</button>
+    </form>
+  </div>
+
+  <div class="tab-content" data-tab-content="shell" hidden>
+    <div id="agent-terminal-container" class="h-[420px] overflow-hidden rounded-lg bg-[#111]"></div>
+  </div>
+</section>
+
+<style>
+  .tab-btn {
+    padding: 0.5rem 0.9rem;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    border-bottom: 2px solid transparent;
+  }
+  .tab-btn.active {
+    color: var(--color-fg);
+    border-bottom-color: var(--color-accent);
+  }
+</style>

--- a/apps/sandbox/src/components/Dashboard.astro
+++ b/apps/sandbox/src/components/Dashboard.astro
@@ -1,0 +1,40 @@
+---
+// Kept in sync by hand with server/config.ts's ALLOWED_AGENT_SPECS — small, fixed list.
+const ALLOWED_AGENT_SPECS = ["hello-agent", "python-data"] as const;
+---
+
+<section id="dashboard" class="mx-auto max-w-[var(--max-width)] px-6 pt-[96px] pb-16">
+  <p class="mb-8 max-w-[60ch] text-sm text-[var(--color-muted)]">
+    A live showcase of <code class="mono">drej</code> — every sandbox and agent here is a real
+    container running on this box. Hard capped at 3 sandboxes and 2 agents; no login, so be kind.
+  </p>
+
+  <div class="grid gap-10 md:grid-cols-2">
+    <div>
+      <div class="mb-3 flex items-center justify-between">
+        <h2 class="text-lg font-semibold">
+          Sandboxes <span id="sandbox-count" class="mono text-sm text-[var(--color-muted)]"></span>
+        </h2>
+        <button id="new-sandbox-btn" class="btn btn-primary">+ New sandbox</button>
+      </div>
+      <ul id="sandbox-list" class="flex flex-col gap-2"></ul>
+      <p id="sandbox-empty" class="text-sm text-[var(--color-muted)]" hidden>No sandboxes running.</p>
+    </div>
+
+    <div>
+      <div class="mb-3 flex items-center justify-between">
+        <h2 class="text-lg font-semibold">
+          Agents <span id="agent-count" class="mono text-sm text-[var(--color-muted)]"></span>
+        </h2>
+        <div class="flex items-center gap-2">
+          <select id="agent-spec-select" class="btn">
+            {ALLOWED_AGENT_SPECS.map((name) => <option value={name}>{name}</option>)}
+          </select>
+          <button id="new-agent-btn" class="btn btn-primary">+ New agent</button>
+        </div>
+      </div>
+      <ul id="agent-list" class="flex flex-col gap-2"></ul>
+      <p id="agent-empty" class="text-sm text-[var(--color-muted)]" hidden>No agents running.</p>
+    </div>
+  </div>
+</section>

--- a/apps/sandbox/src/components/Nav.astro
+++ b/apps/sandbox/src/components/Nav.astro
@@ -1,0 +1,53 @@
+---
+---
+
+<nav>
+  <a href="https://drej.dev" class="logo">sandbox</a>
+  <div class="links">
+    <a href="https://docs.drej.dev">Docs</a>
+    <a href="https://registry.drej.dev">Registry</a>
+    <a href="https://github.com/DrejT/drej">GitHub</a>
+  </div>
+</nav>
+
+<style>
+  nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 2rem;
+    height: 56px;
+    background: oklch(0.985 0 0 / 0.88);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .logo {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+  }
+
+  .links {
+    display: flex;
+    gap: 1.75rem;
+    align-items: center;
+  }
+
+  .links a {
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    transition: color 0.15s;
+  }
+
+  .links a:hover {
+    color: var(--color-fg);
+  }
+</style>

--- a/apps/sandbox/src/components/SandboxPanel.astro
+++ b/apps/sandbox/src/components/SandboxPanel.astro
@@ -1,0 +1,71 @@
+---
+---
+
+<section id="sandbox-panel" class="mx-auto max-w-[var(--max-width)] px-6 pt-[96px] pb-16" hidden>
+  <button id="sandbox-panel-back" class="btn mb-4">&larr; Back</button>
+  <h2 id="sandbox-panel-title" class="mono mb-4 text-lg font-semibold"></h2>
+
+  <div class="mb-4 flex gap-1 border-b border-[var(--color-border)]">
+    <button class="tab-btn" data-tab="terminal">Terminal</button>
+    <button class="tab-btn" data-tab="files">Files</button>
+    <button class="tab-btn" data-tab="preview">Preview</button>
+    <button class="tab-btn" data-tab="metrics">Metrics</button>
+    <button class="tab-btn" data-tab="checkpoints">Checkpoints</button>
+  </div>
+
+  <div class="tab-content" data-tab-content="terminal">
+    <div id="terminal-container" class="h-[420px] overflow-hidden rounded-lg bg-[#111]"></div>
+  </div>
+
+  <div class="tab-content" data-tab-content="files" hidden>
+    <div class="grid gap-4 md:grid-cols-[220px_1fr]">
+      <div>
+        <div class="mb-2 flex gap-2">
+          <input id="file-path-input" class="btn mono flex-1" value="/" />
+          <button id="file-list-btn" class="btn">List</button>
+        </div>
+        <ul id="file-tree" class="mono flex flex-col gap-1 text-sm"></ul>
+      </div>
+      <div>
+        <textarea
+          id="file-editor"
+          class="mono h-[360px] w-full resize-none rounded-lg border border-[var(--color-border)] p-3 text-sm"
+          placeholder="Select a file to view/edit its contents…"></textarea>
+        <button id="file-save-btn" class="btn btn-primary mt-2">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab-content" data-tab-content="preview" hidden>
+    <div class="mb-2 flex gap-2">
+      <input id="preview-port-input" class="btn mono w-32" placeholder="port" />
+      <button id="preview-load-btn" class="btn">Load</button>
+    </div>
+    <iframe id="preview-frame" class="h-[420px] w-full rounded-lg border border-[var(--color-border)]"
+    ></iframe>
+  </div>
+
+  <div class="tab-content" data-tab-content="metrics" hidden>
+    <div id="metrics-readout" class="mono mb-3 text-sm text-[var(--color-muted)]"></div>
+    <canvas id="metrics-chart" class="h-[240px] w-full rounded-lg border border-[var(--color-border)]"
+    ></canvas>
+  </div>
+
+  <div class="tab-content" data-tab-content="checkpoints" hidden>
+    <button id="checkpoint-create-btn" class="btn btn-primary mb-3">Create checkpoint</button>
+    <ul id="checkpoint-list" class="mono flex flex-col gap-1 text-sm"></ul>
+  </div>
+</section>
+
+<style>
+  .tab-btn {
+    padding: 0.5rem 0.9rem;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    border-bottom: 2px solid transparent;
+  }
+  .tab-btn.active {
+    color: var(--color-fg);
+    border-bottom-color: var(--color-accent);
+  }
+</style>

--- a/apps/sandbox/src/layouts/Base.astro
+++ b/apps/sandbox/src/layouts/Base.astro
@@ -1,0 +1,29 @@
+---
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
+import "../styles/global.css";
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = "sandbox — live drej dashboard",
+  description = "Create, use, and destroy live sandboxes and Pi agents.",
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/apps/sandbox/src/pages/index.astro
+++ b/apps/sandbox/src/pages/index.astro
@@ -1,0 +1,15 @@
+---
+import Base from "../layouts/Base.astro";
+import Nav from "../components/Nav.astro";
+import Dashboard from "../components/Dashboard.astro";
+import SandboxPanel from "../components/SandboxPanel.astro";
+import AgentPanel from "../components/AgentPanel.astro";
+---
+
+<Base>
+  <Nav />
+  <Dashboard />
+  <SandboxPanel />
+  <AgentPanel />
+  <script src="../scripts/app.ts"></script>
+</Base>

--- a/apps/sandbox/src/scripts/agentChat.ts
+++ b/apps/sandbox/src/scripts/agentChat.ts
@@ -1,0 +1,97 @@
+import { wsUrl } from "./api";
+
+type AgentEvent =
+  | { type: "text"; text: string }
+  | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
+  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: "agent_start" }
+  | { type: "agent_end" }
+  | { type: "bridge_error"; message: string }
+  | { type: string; [key: string]: unknown };
+
+export function mountAgentChat(agentId: string): { dispose(): void } {
+  const messages = document.getElementById("chat-messages") as HTMLDivElement;
+  const form = document.getElementById("chat-form") as HTMLFormElement;
+  const input = document.getElementById("chat-input") as HTMLInputElement;
+  const steerBtn = document.getElementById("chat-steer-btn") as HTMLButtonElement;
+  const abortBtn = document.getElementById("chat-abort-btn") as HTMLButtonElement;
+
+  let streaming = false;
+  let assistantBubble: HTMLDivElement | null = null;
+
+  function setStreaming(value: boolean) {
+    streaming = value;
+    steerBtn.disabled = !streaming;
+    abortBtn.disabled = !streaming;
+    assistantBubble = null;
+  }
+
+  function addBubble(role: "you" | "agent" | "tool" | "error", text: string): HTMLDivElement {
+    const bubble = document.createElement("div");
+    bubble.className =
+      role === "you"
+        ? "self-end rounded-lg bg-[var(--color-accent)] px-3 py-2 text-white"
+        : role === "error"
+          ? "rounded-lg border border-[var(--color-danger)] px-3 py-2 text-[var(--color-danger)]"
+          : role === "tool"
+            ? "mono rounded-lg bg-[var(--color-bg)] px-3 py-2 text-xs text-[var(--color-muted)]"
+            : "rounded-lg border border-[var(--color-border)] px-3 py-2";
+    bubble.textContent = text;
+    messages.appendChild(bubble);
+    messages.scrollTop = messages.scrollHeight;
+    return bubble;
+  }
+
+  const ws = new WebSocket(wsUrl(`/ws/agents/${agentId}/chat`));
+
+  ws.addEventListener("message", (ev) => {
+    if (typeof ev.data !== "string") return;
+    const event = JSON.parse(ev.data) as AgentEvent;
+    if (event.type === "agent_start") {
+      setStreaming(true);
+    } else if (event.type === "agent_end") {
+      setStreaming(false);
+    } else if (event.type === "text") {
+      if (!assistantBubble) assistantBubble = addBubble("agent", "");
+      assistantBubble.textContent += (event as { text: string }).text;
+      messages.scrollTop = messages.scrollHeight;
+    } else if (event.type === "tool_start") {
+      const e = event as Extract<AgentEvent, { type: "tool_start" }>;
+      addBubble("tool", `▶ ${e.toolName}`);
+    } else if (event.type === "tool_end") {
+      const e = event as Extract<AgentEvent, { type: "tool_end" }>;
+      addBubble("tool", `${e.isError ? "✗" : "✓"} ${e.toolName}`);
+    } else if (event.type === "bridge_error") {
+      addBubble("error", (event as { message: string }).message);
+      setStreaming(false);
+    }
+  });
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    addBubble("you", text);
+    ws.send(JSON.stringify({ type: streaming ? "followUp" : "prompt", text }));
+    input.value = "";
+    if (!streaming) setStreaming(true);
+  });
+
+  steerBtn.addEventListener("click", () => {
+    const text = input.value.trim();
+    if (!text) return;
+    addBubble("you", `(steer) ${text}`);
+    ws.send(JSON.stringify({ type: "steer", text }));
+    input.value = "";
+  });
+
+  abortBtn.addEventListener("click", () => {
+    ws.send(JSON.stringify({ type: "abort" }));
+  });
+
+  return {
+    dispose() {
+      ws.close();
+    },
+  };
+}

--- a/apps/sandbox/src/scripts/api.ts
+++ b/apps/sandbox/src/scripts/api.ts
@@ -1,0 +1,76 @@
+export interface SandboxSummary {
+  id: string;
+  name: string;
+}
+
+export interface AgentSummary {
+  id: string;
+  name: string;
+}
+
+export interface FileEntry {
+  path: string;
+  type: "file" | "directory" | "symlink";
+  size: number;
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, init);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error((body as { error?: string }).error ?? `${res.status} ${res.statusText}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export const api = {
+  listSandboxes: () => request<{ sandboxes: SandboxSummary[]; max: number }>("/api/sandboxes"),
+  createSandbox: () => request<SandboxSummary>("/api/sandboxes", { method: "POST" }),
+  deleteSandbox: (id: string) => request<void>(`/api/sandboxes/${id}`, { method: "DELETE" }),
+
+  listDirectory: (id: string, path: string) =>
+    request<{ entries: FileEntry[] }>(
+      `/api/sandboxes/${id}/files?path=${encodeURIComponent(path)}`,
+    ),
+  readFile: (id: string, path: string) =>
+    request<{ path: string; content: string }>(
+      `/api/sandboxes/${id}/file?path=${encodeURIComponent(path)}`,
+    ),
+  writeFile: (id: string, path: string, content: string) =>
+    request<{ path: string }>(`/api/sandboxes/${id}/file?path=${encodeURIComponent(path)}`, {
+      method: "PUT",
+      body: content,
+    }),
+
+  getMetrics: (id: string) =>
+    request<{ cpu: number; memory: number; timestamp: string }>(`/api/sandboxes/${id}/metrics`),
+  listCheckpoints: (id: string) =>
+    request<{ checkpoints: { snapshotId: string; tag?: string; createdAt: number }[] }>(
+      `/api/sandboxes/${id}/checkpoints`,
+    ),
+  createCheckpoint: (id: string) =>
+    request<{ snapshotId: string }>(`/api/sandboxes/${id}/checkpoint`, { method: "POST" }),
+  getPreview: (id: string, port: number) =>
+    request<{ url: string; headers: Record<string, string> }>(
+      `/api/sandboxes/${id}/preview?port=${port}`,
+    ),
+
+  listAgents: () =>
+    request<{ agents: AgentSummary[]; max: number; allowedSpecs: readonly string[] }>(
+      "/api/agents",
+    ),
+  createAgent: (specName: string) =>
+    request<AgentSummary>("/api/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ specName }),
+    }),
+  deleteAgent: (id: string) => request<void>(`/api/agents/${id}`, { method: "DELETE" }),
+  getMessages: (id: string) => request<{ messages: unknown[] }>(`/api/agents/${id}/messages`),
+};
+
+export function wsUrl(path: string): string {
+  const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${location.host}${path}`;
+}

--- a/apps/sandbox/src/scripts/app.ts
+++ b/apps/sandbox/src/scripts/app.ts
@@ -1,0 +1,269 @@
+import { api, type SandboxSummary, type AgentSummary } from "./api";
+import { mountTerminal, type TerminalHandle } from "./terminal";
+import { mountFileBrowser } from "./fileBrowser";
+import { mountMetricsChart, type MetricsHandle } from "./metricsChart";
+import { mountAgentChat } from "./agentChat";
+
+const dashboard = document.getElementById("dashboard") as HTMLElement;
+const sandboxPanel = document.getElementById("sandbox-panel") as HTMLElement;
+const agentPanel = document.getElementById("agent-panel") as HTMLElement;
+
+const sandboxList = document.getElementById("sandbox-list") as HTMLUListElement;
+const sandboxCount = document.getElementById("sandbox-count") as HTMLElement;
+const sandboxEmpty = document.getElementById("sandbox-empty") as HTMLElement;
+const newSandboxBtn = document.getElementById("new-sandbox-btn") as HTMLButtonElement;
+
+const agentList = document.getElementById("agent-list") as HTMLUListElement;
+const agentCount = document.getElementById("agent-count") as HTMLElement;
+const agentEmpty = document.getElementById("agent-empty") as HTMLElement;
+const newAgentBtn = document.getElementById("new-agent-btn") as HTMLButtonElement;
+const agentSpecSelect = document.getElementById("agent-spec-select") as HTMLSelectElement;
+
+let currentTerminal: TerminalHandle | null = null;
+let currentMetrics: MetricsHandle | null = null;
+let disposeFileBrowser: (() => void) | null = null;
+let disposeAgentChat: (() => void) | null = null;
+let currentAgentShell: TerminalHandle | null = null;
+
+async function refreshDashboard(): Promise<void> {
+  const [sandboxesRes, agentsRes] = await Promise.all([api.listSandboxes(), api.listAgents()]);
+
+  sandboxCount.textContent = `${sandboxesRes.sandboxes.length}/${sandboxesRes.max}`;
+  sandboxList.innerHTML = "";
+  sandboxEmpty.hidden = sandboxesRes.sandboxes.length > 0;
+  newSandboxBtn.disabled = sandboxesRes.sandboxes.length >= sandboxesRes.max;
+  for (const sb of sandboxesRes.sandboxes) sandboxList.appendChild(renderSandboxCard(sb));
+
+  agentCount.textContent = `${agentsRes.agents.length}/${agentsRes.max}`;
+  agentList.innerHTML = "";
+  agentEmpty.hidden = agentsRes.agents.length > 0;
+  newAgentBtn.disabled = agentsRes.agents.length >= agentsRes.max;
+  for (const agent of agentsRes.agents) agentList.appendChild(renderAgentCard(agent));
+}
+
+function renderCard(
+  name: string,
+  onOpen: () => void,
+  onDelete: () => Promise<void>,
+): HTMLLIElement {
+  const li = document.createElement("li");
+  li.className = "card flex items-center justify-between";
+
+  const left = document.createElement("div");
+  const dot = document.createElement("span");
+  dot.className = "status-dot mr-2";
+  const label = document.createElement("span");
+  label.className = "mono text-sm";
+  label.textContent = name;
+  left.append(dot, label);
+
+  const right = document.createElement("div");
+  right.className = "flex gap-2";
+  const openBtn = document.createElement("button");
+  openBtn.className = "btn";
+  openBtn.textContent = "Open";
+  openBtn.addEventListener("click", onOpen);
+  const delBtn = document.createElement("button");
+  delBtn.className = "btn btn-danger";
+  delBtn.textContent = "Delete";
+  delBtn.addEventListener("click", () => {
+    delBtn.disabled = true;
+    void onDelete().catch((err) => {
+      alert(String(err));
+      delBtn.disabled = false;
+    });
+  });
+  right.append(openBtn, delBtn);
+
+  li.append(left, right);
+  return li;
+}
+
+function renderSandboxCard(sb: SandboxSummary): HTMLLIElement {
+  return renderCard(
+    sb.name,
+    () => openSandboxPanel(sb),
+    async () => {
+      await api.deleteSandbox(sb.id);
+      await refreshDashboard();
+    },
+  );
+}
+
+function renderAgentCard(agent: AgentSummary): HTMLLIElement {
+  return renderCard(
+    agent.name,
+    () => openAgentPanel(agent),
+    async () => {
+      await api.deleteAgent(agent.id);
+      await refreshDashboard();
+    },
+  );
+}
+
+function disposeSandboxPanel(): void {
+  currentTerminal?.dispose();
+  currentTerminal = null;
+  currentMetrics?.dispose();
+  currentMetrics = null;
+  disposeFileBrowser?.();
+  disposeFileBrowser = null;
+}
+
+function disposeAgentPanel(): void {
+  disposeAgentChat?.();
+  disposeAgentChat = null;
+  currentAgentShell?.dispose();
+  currentAgentShell = null;
+}
+
+function showDashboard(): void {
+  disposeSandboxPanel();
+  disposeAgentPanel();
+  dashboard.hidden = false;
+  sandboxPanel.hidden = true;
+  agentPanel.hidden = true;
+  void refreshDashboard();
+}
+
+function wireTabs(panel: HTMLElement, onShow: (tab: string) => void): void {
+  const buttons = Array.from(panel.querySelectorAll<HTMLButtonElement>(".tab-btn"));
+  const contents = Array.from(panel.querySelectorAll<HTMLElement>("[data-tab-content]"));
+  for (const btn of buttons) {
+    btn.addEventListener("click", () => {
+      for (const b of buttons) b.classList.toggle("active", b === btn);
+      for (const c of contents) c.hidden = c.dataset.tabContent !== btn.dataset.tab;
+      onShow(btn.dataset.tab ?? "");
+    });
+  }
+  buttons[0]?.classList.add("active");
+  onShow(buttons[0]?.dataset.tab ?? "");
+}
+
+function wireCheckpoints(sandboxId: string): void {
+  const list = document.getElementById("checkpoint-list") as HTMLUListElement;
+  const createBtn = document.getElementById("checkpoint-create-btn") as HTMLButtonElement;
+
+  async function refresh() {
+    list.innerHTML = "";
+    const { checkpoints } = await api.listCheckpoints(sandboxId);
+    for (const cp of checkpoints) {
+      const li = document.createElement("li");
+      li.textContent = `${new Date(cp.createdAt).toLocaleString()} — ${cp.snapshotId}${cp.tag ? ` (${cp.tag})` : ""}`;
+      list.appendChild(li);
+    }
+  }
+
+  const freshCreateBtn = createBtn.cloneNode(true) as HTMLButtonElement;
+  createBtn.replaceWith(freshCreateBtn);
+  freshCreateBtn.addEventListener("click", async () => {
+    freshCreateBtn.disabled = true;
+    try {
+      await api.createCheckpoint(sandboxId);
+      await refresh();
+    } finally {
+      freshCreateBtn.disabled = false;
+    }
+  });
+
+  void refresh();
+}
+
+function wirePreview(sandboxId: string): void {
+  const portInput = document.getElementById("preview-port-input") as HTMLInputElement;
+  const loadBtn = document.getElementById("preview-load-btn") as HTMLButtonElement;
+  const frame = document.getElementById("preview-frame") as HTMLIFrameElement;
+
+  const freshLoadBtn = loadBtn.cloneNode(true) as HTMLButtonElement;
+  loadBtn.replaceWith(freshLoadBtn);
+  freshLoadBtn.addEventListener("click", async () => {
+    const port = Number(portInput.value);
+    if (!port) return;
+    const { url } = await api.getPreview(sandboxId, port);
+    frame.src = url;
+  });
+}
+
+function openSandboxPanel(sb: SandboxSummary): void {
+  disposeSandboxPanel();
+  dashboard.hidden = true;
+  agentPanel.hidden = true;
+  sandboxPanel.hidden = false;
+
+  const title = document.getElementById("sandbox-panel-title") as HTMLElement;
+  title.textContent = `${sb.name} — ${sb.id}`;
+
+  const terminalContainer = document.getElementById("terminal-container") as HTMLElement;
+  currentTerminal = mountTerminal(terminalContainer, `/ws/sandboxes/${sb.id}/terminal`);
+  disposeFileBrowser = mountFileBrowser(sb.id).dispose;
+
+  const metricsCanvas = document.getElementById("metrics-chart") as HTMLCanvasElement;
+  const metricsReadout = document.getElementById("metrics-readout") as HTMLElement;
+  currentMetrics = mountMetricsChart(metricsCanvas, metricsReadout, sb.id);
+
+  wireCheckpoints(sb.id);
+  wirePreview(sb.id);
+
+  wireTabs(sandboxPanel, (tab) => {
+    if (tab === "terminal") currentTerminal?.fit();
+    if (tab === "metrics") currentMetrics?.resize();
+  });
+}
+
+function openAgentPanel(agent: AgentSummary): void {
+  disposeAgentPanel();
+  dashboard.hidden = true;
+  sandboxPanel.hidden = true;
+  agentPanel.hidden = false;
+
+  const title = document.getElementById("agent-panel-title") as HTMLElement;
+  title.textContent = `${agent.name} — ${agent.id}`;
+
+  document.getElementById("chat-messages")!.innerHTML = "";
+  disposeAgentChat = mountAgentChat(agent.id).dispose;
+
+  const shellContainer = document.getElementById("agent-terminal-container") as HTMLElement;
+
+  wireTabs(agentPanel, (tab) => {
+    if (tab === "shell" && !currentAgentShell) {
+      currentAgentShell = mountTerminal(shellContainer, `/ws/agents/${agent.id}/shell`);
+    } else if (tab === "shell") {
+      currentAgentShell?.fit();
+    }
+  });
+}
+
+(document.getElementById("sandbox-panel-back") as HTMLButtonElement).addEventListener(
+  "click",
+  showDashboard,
+);
+(document.getElementById("agent-panel-back") as HTMLButtonElement).addEventListener(
+  "click",
+  showDashboard,
+);
+
+newSandboxBtn.addEventListener("click", async () => {
+  newSandboxBtn.disabled = true;
+  try {
+    await api.createSandbox();
+    await refreshDashboard();
+  } catch (err) {
+    alert(String(err));
+  } finally {
+    newSandboxBtn.disabled = false;
+  }
+});
+
+newAgentBtn.addEventListener("click", async () => {
+  newAgentBtn.disabled = true;
+  try {
+    await api.createAgent(agentSpecSelect.value);
+    await refreshDashboard();
+  } catch (err) {
+    alert(String(err));
+  } finally {
+    newAgentBtn.disabled = false;
+  }
+});
+
+void refreshDashboard();

--- a/apps/sandbox/src/scripts/fileBrowser.ts
+++ b/apps/sandbox/src/scripts/fileBrowser.ts
@@ -1,0 +1,67 @@
+import { api } from "./api";
+
+export function mountFileBrowser(sandboxId: string): { dispose(): void } {
+  const pathInput = document.getElementById("file-path-input") as HTMLInputElement;
+  const listBtn = document.getElementById("file-list-btn") as HTMLButtonElement;
+  const tree = document.getElementById("file-tree") as HTMLUListElement;
+  const editor = document.getElementById("file-editor") as HTMLTextAreaElement;
+  const saveBtn = document.getElementById("file-save-btn") as HTMLButtonElement;
+
+  let currentFile: string | null = null;
+
+  async function refresh() {
+    tree.innerHTML = "";
+    editor.value = "";
+    currentFile = null;
+    try {
+      const { entries } = await api.listDirectory(sandboxId, pathInput.value || "/");
+      for (const entry of entries) {
+        const li = document.createElement("li");
+        li.textContent = entry.type === "directory" ? `${entry.path}/` : entry.path;
+        li.className = "cursor-pointer hover:text-[var(--color-accent)]";
+        li.addEventListener("click", () => {
+          if (entry.type === "directory") {
+            pathInput.value = entry.path;
+            void refresh();
+          } else {
+            void openFile(entry.path);
+          }
+        });
+        tree.appendChild(li);
+      }
+    } catch (err) {
+      tree.innerHTML = `<li class="text-[var(--color-danger)]">${String(err)}</li>`;
+    }
+  }
+
+  async function openFile(path: string) {
+    try {
+      const { content } = await api.readFile(sandboxId, path);
+      editor.value = content;
+      currentFile = path;
+    } catch (err) {
+      editor.value = `# failed to read ${path}: ${String(err)}`;
+    }
+  }
+
+  async function save() {
+    if (!currentFile) return;
+    saveBtn.disabled = true;
+    try {
+      await api.writeFile(sandboxId, currentFile, editor.value);
+    } finally {
+      saveBtn.disabled = false;
+    }
+  }
+
+  listBtn.addEventListener("click", () => void refresh());
+  saveBtn.addEventListener("click", () => void save());
+  void refresh();
+
+  return {
+    dispose() {
+      listBtn.replaceWith(listBtn.cloneNode(true));
+      saveBtn.replaceWith(saveBtn.cloneNode(true));
+    },
+  };
+}

--- a/apps/sandbox/src/scripts/metricsChart.ts
+++ b/apps/sandbox/src/scripts/metricsChart.ts
@@ -1,0 +1,59 @@
+import { wsUrl } from "./api";
+
+export interface MetricsHandle {
+  resize(): void;
+  dispose(): void;
+}
+
+/** Mounts a minimal live CPU/memory sparkline, wired to the metrics WS. */
+export function mountMetricsChart(
+  canvas: HTMLCanvasElement,
+  readout: HTMLElement,
+  sandboxId: string,
+): MetricsHandle {
+  const ctx = canvas.getContext("2d")!;
+  const cpuSamples: number[] = [];
+  const memSamples: number[] = [];
+
+  function resize() {
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.floor(rect.width));
+    canvas.height = Math.max(1, Math.floor(rect.height));
+    draw();
+  }
+
+  function drawSeries(samples: number[], color: string) {
+    if (samples.length < 2) return;
+    const max = Math.max(...samples, 0.001);
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    samples.forEach((v, i) => {
+      const x = (i / (samples.length - 1)) * canvas.width;
+      const y = canvas.height - (v / max) * (canvas.height - 8) - 4;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawSeries(cpuSamples, "#7c5cff");
+    drawSeries(memSamples, "#22c55e");
+  }
+
+  const ws = new WebSocket(wsUrl(`/ws/sandboxes/${sandboxId}/metrics`));
+  ws.addEventListener("message", (ev) => {
+    if (typeof ev.data !== "string") return;
+    const m = JSON.parse(ev.data) as { cpu: number; memory: number; timestamp: string };
+    cpuSamples.push(m.cpu);
+    memSamples.push(m.memory);
+    if (cpuSamples.length > 120) cpuSamples.shift();
+    if (memSamples.length > 120) memSamples.shift();
+    readout.textContent = `cpu ${m.cpu.toFixed(3)} (violet)  ·  memory ${m.memory.toFixed(1)} (green)  ·  ${m.timestamp}`;
+    draw();
+  });
+
+  return { resize, dispose: () => ws.close() };
+}

--- a/apps/sandbox/src/scripts/terminal.ts
+++ b/apps/sandbox/src/scripts/terminal.ts
@@ -1,0 +1,55 @@
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { wsUrl } from "./api";
+
+export interface TerminalHandle {
+  fit(): void;
+  dispose(): void;
+}
+
+/** Mounts an xterm.js terminal in `container`, bridged to the interactive-exec WS at `wsPath`. */
+export function mountTerminal(container: HTMLElement, wsPath: string): TerminalHandle {
+  const term = new Terminal({
+    convertEol: true,
+    fontSize: 13,
+    fontFamily: "var(--font-mono)",
+    theme: { background: "#111111" },
+  });
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+
+  const ws = new WebSocket(wsUrl(wsPath));
+
+  const sendResize = () => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+    }
+  };
+
+  ws.addEventListener("open", () => {
+    fitAddon.fit();
+    sendResize();
+  });
+  ws.addEventListener("message", (ev) => {
+    if (typeof ev.data === "string") term.write(ev.data);
+  });
+  ws.addEventListener("close", () => {
+    term.write("\r\n\x1b[90m[connection closed]\x1b[0m\r\n");
+  });
+
+  term.onData((data) => {
+    if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "input", data }));
+  });
+
+  return {
+    fit() {
+      fitAddon.fit();
+      sendResize();
+    },
+    dispose() {
+      ws.close();
+      term.dispose();
+    },
+  };
+}

--- a/apps/sandbox/src/styles/global.css
+++ b/apps/sandbox/src/styles/global.css
@@ -1,0 +1,117 @@
+@import "tailwindcss";
+@import "@xterm/xterm/css/xterm.css";
+
+/*
+ * Tailwind emits its own rules inside `@layer theme, base, components, utilities`.
+ * Per the CSS cascade-layers spec, unlayered rules always beat layered ones
+ * regardless of specificity or source order — so anything here that should be
+ * overridable by a Tailwind utility class MUST live in `@layer base`, matching
+ * Tailwind's own Preflight, or utilities like `mx-auto`/`text-white`/`px-4`
+ * silently lose to whatever's declared below.
+ */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  :root {
+    --color-bg: oklch(0.985 0 0);
+    --color-fg: oklch(0.16 0.005 286);
+    --color-muted: oklch(0.52 0.013 286);
+    --color-border: oklch(0.92 0.005 286);
+    --color-accent: oklch(0.5 0.26 292);
+    --color-accent-hover: oklch(0.44 0.24 292);
+    --color-danger: oklch(0.55 0.22 25);
+    --color-ok: oklch(0.6 0.17 145);
+    --font-sans: "Geist Variable", "Inter", system-ui, sans-serif;
+    --font-mono: "Geist Mono Variable", "Fira Code", ui-monospace, monospace;
+    --max-width: 1080px;
+    --radius-btn: 6px;
+  }
+
+  html {
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+    min-height: 100vh;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  button {
+    font: inherit;
+    cursor: pointer;
+  }
+}
+
+@utility btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: var(--radius-btn);
+  border: 1px solid var(--color-border);
+  padding: 0.4rem 0.8rem;
+  font-size: 0.875rem;
+  background: white;
+  transition: border-color 0.15s;
+}
+@utility btn-primary {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+@utility btn-danger {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+/* Pseudo-class states can't be expressed inside `@utility` names — plain rules instead. */
+@layer components {
+  .btn:hover:not(:disabled) {
+    border-color: var(--color-accent);
+  }
+  .btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .btn-primary:hover:not(:disabled) {
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
+  }
+}
+
+@utility card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+  background: white;
+}
+
+@utility status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-ok);
+}
+
+@utility mono {
+  font-family: var(--font-mono);
+}
+
+.xterm {
+  padding: 0.5rem;
+}

--- a/apps/sandbox/tsconfig.json
+++ b/apps/sandbox/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src", ".astro"],
+  "exclude": ["server", "dist"]
+}

--- a/apps/sandbox/tsconfig.server.json
+++ b/apps/sandbox/tsconfig.server.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun-types"]
+  },
+  "include": ["server"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,27 @@
         "tailwindcss": "^4.3.2",
       },
     },
+    "apps/sandbox": {
+      "name": "@drej/sandbox",
+      "dependencies": {
+        "@drej/agent": "workspace:*",
+        "@drej/core": "workspace:*",
+        "@drej/sqlite": "workspace:*",
+        "@fontsource-variable/geist": "^5.1.1",
+        "@fontsource-variable/geist-mono": "^5.2.2",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
+        "astro": "^6.4.8",
+        "drej": "workspace:*",
+      },
+      "devDependencies": {
+        "@astrojs/check": "^0.9.4",
+        "@tailwindcss/vite": "^4.3.2",
+        "bun-types": "1.3.14",
+        "tailwindcss": "^4.3.2",
+        "typescript": "^5.7.0",
+      },
+    },
     "apps/www": {
       "name": "@drej/www",
       "dependencies": {
@@ -354,9 +375,13 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
+    "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
+
     "@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
+
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.11", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.71", "volar-service-emmet": "0.0.71", "volar-service-html": "0.0.71", "volar-service-prettier": "0.0.71", "volar-service-typescript": "0.0.71", "volar-service-typescript-twoslash-queries": "0.0.71", "volar-service-yaml": "0.0.71", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-sJ/EfnFp0+gurTrkvONtd9qRqmMZLT9bHelfI1SA35CaQVTrRrA74qteOcNT/al1b9Atg3IiH1Jk/qfckyC+fg=="],
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw=="],
 
@@ -365,6 +390,8 @@
     "@astrojs/sitemap": ["@astrojs/sitemap@3.7.3", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
+
+    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
@@ -508,6 +535,8 @@
 
     "@drej/registry": ["@drej/registry@workspace:apps/registry"],
 
+    "@drej/sandbox": ["@drej/sandbox@workspace:apps/sandbox"],
+
     "@drej/sqlite": ["@drej/sqlite@workspace:packages/adapters/sqlite"],
 
     "@drej/workflow": ["@drej/workflow@workspace:packages/workflow"],
@@ -517,6 +546,20 @@
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ=="],
 
     "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
+
+    "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
+
+    "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
+
+    "@emmetio/css-parser": ["@emmetio/css-parser@0.4.1", "", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ=="],
+
+    "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
+
+    "@emmetio/scanner": ["@emmetio/scanner@1.0.4", "", {}, "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="],
+
+    "@emmetio/stream-reader": ["@emmetio/stream-reader@2.2.0", "", {}, "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="],
+
+    "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -1210,6 +1253,26 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
 
+    "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
+
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
+
+    "@volar/language-server": ["@volar/language-server@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "path-browserify": "^1.0.1", "request-light": "^0.7.0", "vscode-languageserver": "^9.0.1", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw=="],
+
+    "@volar/language-service": ["@volar/language-service@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
+    "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
+
+    "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+
+    "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
@@ -1220,7 +1283,11 @@
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
+
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ajv-i18n": ["ajv-i18n@4.2.0", "", { "peerDependencies": { "ajv": "^8.0.0-beta.0" } }, "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg=="],
 
     "animejs": ["animejs@4.5.0", "", { "peerDependencies": { "@types/three": ">=0.150.0", "three": ">=0.150.0" }, "optionalPeers": ["@types/three", "three"] }, "sha512-NQimYX+lz8WaXonGS9zVVoviCIAjONeJayxacUditaivYLqyXgGjFKjuyl0aUUhFKm5MriX9ty1TGovNzoJQWA=="],
 
@@ -1348,7 +1415,7 @@
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
-    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
@@ -1357,6 +1424,8 @@
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -1509,6 +1578,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.377", "", {}, "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g=="],
+
+    "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1708,6 +1779,8 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
@@ -1860,6 +1933,8 @@
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
@@ -1949,6 +2024,8 @@
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
@@ -2148,6 +2225,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
     "nanoid": ["nanoid@3.3.14", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
@@ -2266,6 +2345,8 @@
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.6.1", "", {}, "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ=="],
@@ -2352,7 +2433,7 @@
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
@@ -2395,6 +2476,10 @@
     "remark-smartypants": ["remark-smartypants@3.0.2", "", { "dependencies": { "retext": "^9.0.0", "retext-smartypants": "^6.0.0", "unified": "^11.0.4", "unist-util-visit": "^5.0.0" } }, "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -2514,6 +2599,8 @@
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
 
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
@@ -2618,7 +2705,11 @@
 
     "typed-array-length": ["typed-array-length@1.0.8", "", { "dependencies": { "call-bind": "^1.0.9", "for-each": "^0.3.5", "gopd": "^1.2.0", "is-typed-array": "^1.1.15", "possible-typed-array-names": "^1.1.0", "reflect.getprototypeof": "^1.0.10" } }, "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g=="],
 
+    "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "typescript-eslint": ["typescript-eslint@8.62.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.62.0", "@typescript-eslint/parser": "8.62.0", "@typescript-eslint/typescript-estree": "8.62.0", "@typescript-eslint/utils": "8.62.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q=="],
 
@@ -2696,6 +2787,40 @@
 
     "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
 
+    "volar-service-css": ["volar-service-css@0.0.71", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw=="],
+
+    "volar-service-emmet": ["volar-service-emmet@0.0.71", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA=="],
+
+    "volar-service-html": ["volar-service-html@0.0.71", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw=="],
+
+    "volar-service-prettier": ["volar-service-prettier@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg=="],
+
+    "volar-service-typescript": ["volar-service-typescript@0.0.71", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw=="],
+
+    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A=="],
+
+    "volar-service-yaml": ["volar-service-yaml@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.23.0" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q=="],
+
+    "vscode-css-languageservice": ["vscode-css-languageservice@6.3.10", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA=="],
+
+    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg=="],
+
+    "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@9.0.1", "", {}, "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.18.2", "", { "dependencies": { "vscode-jsonrpc": "9.0.1", "vscode-languageserver-types": "3.18.0" } }, "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
+
+    "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -2716,6 +2841,8 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
@@ -2724,9 +2851,15 @@
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yaml-language-server": ["yaml-language-server@1.23.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "ajv-i18n": "^4.2.0", "prettier": "^3.8.1", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.8.3" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
@@ -2739,6 +2872,8 @@
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
     "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ=="],
 
@@ -2773,6 +2908,8 @@
     "@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@drej/sandbox/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@earendil-works/pi-agent-core/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -2832,7 +2969,11 @@
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
+
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-i18n/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -2878,6 +3019,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fumadocs-mdx/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "fumadocs-mdx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "fumadocs-ui/lucide-react": ["lucide-react@1.21.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ=="],
@@ -2916,11 +3059,29 @@
 
     "sitemap/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
+    "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
+    "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "vscode-css-languageservice/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "yaml-language-server/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "yaml-language-server/prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+
+    "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
+
+    "yaml-language-server/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
@@ -2963,6 +3124,8 @@
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "ajv-i18n/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
@@ -3015,6 +3178,8 @@
     "eslint-plugin-react/eslint/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "fumadocs-mdx/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "fumadocs-mdx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -3078,6 +3243,8 @@
 
     "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
     "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
@@ -3129,6 +3296,12 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "yaml-language-server/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "tests/integration",
     "apps/docs",
     "apps/www",
-    "apps/registry"
+    "apps/registry",
+    "apps/sandbox"
   ],
   "scripts": {
     "setup": "bash scripts/setup.sh",


### PR DESCRIPTION
## Summary
- New app `apps/sandbox` (`@drej/sandbox`) — a Bun backend + Astro/Tailwind frontend showcasing drej as an interactive product, not just an SDK: create/delete sandboxes and Pi agents from the browser, a real terminal via `sb.exec(cmd, { interactive: true })`, a file browser, live CPU/memory metrics, checkpoint management, and a streaming agent chat with steer/followUp/abort controls.
- Designed for unauthenticated deployment on a small VPS: hard caps (3 sandboxes @ 250m/500Mi, 2 agents @ 500m/1Gi) enforced server-side — no client-supplied resource/image fields anywhere in the API — plus startup reconciliation so a backend restart never orphans running containers.
- Full design/rationale in `plans/sandbox-dashboard.md` (gitignored locally, not part of this diff, but described the intent this implements).

## Test plan
- [x] `bun install` at root
- [x] `bunx tsc --noEmit --project apps/sandbox/tsconfig.server.json` (backend, strict) — clean
- [x] `bunx astro check` (frontend) — 0 errors/warnings/hints
- [x] `bunx astro build` — succeeds, bundles xterm.js etc.
- [x] Booted `bun server/index.ts` against a real SQLite ledger and hit `/api/sandboxes`, `/api/agents`, static `/`, and a 404 case with curl — all correct
- [x] Root `bun run typecheck` / `bun run test` (existing packages) — unaffected, still green
- [x] `oxfmt` / `oxlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)