### PR TITLE
feat(sandbox): deploy frontend to Cloudflare Pages, add CORS to the API

### DIFF
--- a/apps/sandbox/.env.production
+++ b/apps/sandbox/.env.production
@@ -1,0 +1,1 @@
+PUBLIC_API_BASE_URL=https://sandbox-api.drej.dev

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -6,7 +6,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "bun server/index.ts",
-    "typecheck": "astro check && tsc --noEmit --project tsconfig.server.json"
+    "typecheck": "astro check && tsc --noEmit --project tsconfig.server.json",
+    "deploy": "astro build && wrangler pages deploy"
   },
   "dependencies": {
     "@drej/agent": "workspace:*",

--- a/apps/sandbox/server/config.ts
+++ b/apps/sandbox/server/config.ts
@@ -22,4 +22,10 @@ export const ALLOWED_AGENT_SPECS = ["hello-agent", "python-data"] as const;
 export type AllowedAgentSpec = (typeof ALLOWED_AGENT_SPECS)[number];
 
 export const PORT = Number(process.env.PORT ?? 3000);
-export const DIST_DIR = "./dist";
+
+/**
+ * The frontend is deployed separately to Cloudflare Pages (a different origin
+ * from this API), so CORS is required. Override for local dev against
+ * `astro dev` (typically http://localhost:4321).
+ */
+export const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? "https://sandbox.drej.dev";

--- a/apps/sandbox/server/cors.ts
+++ b/apps/sandbox/server/cors.ts
@@ -1,0 +1,38 @@
+import * as config from "./config";
+
+function headers(): Headers {
+  return new Headers({
+    "Access-Control-Allow-Origin": config.ALLOWED_ORIGIN,
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+}
+
+function withCors(res: Response): Response {
+  const merged = new Headers(res.headers);
+  for (const [key, value] of headers()) merged.set(key, value);
+  return new Response(res.body, { status: res.status, headers: merged });
+}
+
+type RouteHandler = (...args: never[]) => Response | Promise<Response>;
+
+/**
+ * Wraps a Bun route method-map so every response carries CORS headers and
+ * `OPTIONS` preflight requests are answered automatically. The frontend is
+ * deployed to Cloudflare Pages (a different origin from this API), so every
+ * `/api/*` route needs this.
+ */
+export function cors<T extends Record<string, RouteHandler>>(
+  handlers: T,
+): T & { OPTIONS: () => Response } {
+  const wrapped = {
+    OPTIONS: () => new Response(null, { status: 204, headers: headers() }),
+  } as T & {
+    OPTIONS: () => Response;
+  };
+  for (const [method, handler] of Object.entries(handlers)) {
+    (wrapped as Record<string, RouteHandler>)[method] = async (...args: never[]) =>
+      withCors(await handler(...args));
+  }
+  return wrapped;
+}

--- a/apps/sandbox/server/index.ts
+++ b/apps/sandbox/server/index.ts
@@ -1,4 +1,3 @@
-import { join, extname } from "path";
 import * as config from "./config";
 import * as registry from "./registry";
 import * as sandboxRoutes from "./routes/sandboxes";
@@ -6,91 +5,75 @@ import * as agentRoutes from "./routes/agents";
 import * as terminal from "./ws/terminal";
 import * as metrics from "./ws/metrics";
 import * as chat from "./ws/chat";
+import { cors } from "./cors";
 import type { WSData } from "./ws/types";
-
-const CONTENT_TYPES: Record<string, string> = {
-  ".html": "text/html; charset=utf-8",
-  ".js": "text/javascript; charset=utf-8",
-  ".css": "text/css; charset=utf-8",
-  ".json": "application/json; charset=utf-8",
-  ".svg": "image/svg+xml",
-  ".woff2": "font/woff2",
-  ".png": "image/png",
-  ".ico": "image/x-icon",
-};
-
-async function serveStatic(pathname: string): Promise<Response> {
-  const safePath = pathname === "/" ? "/index.html" : pathname;
-  const filePath = join(config.DIST_DIR, safePath);
-  let file = Bun.file(filePath);
-  if (!(await file.exists())) {
-    file = Bun.file(join(config.DIST_DIR, "index.html"));
-    if (!(await file.exists())) return new Response("Not found", { status: 404 });
-  }
-  const type = CONTENT_TYPES[extname(filePath)];
-  return new Response(file, type ? { headers: { "Content-Type": type } } : undefined);
-}
 
 const server = Bun.serve({
   port: config.PORT,
   routes: {
-    "/api/sandboxes": {
+    "/health": new Response("ok"),
+    "/api/sandboxes": cors({
       GET: () => sandboxRoutes.listSandboxes(),
       POST: () => sandboxRoutes.createSandbox(),
-    },
-    "/api/sandboxes/:id": {
-      DELETE: (req) => sandboxRoutes.deleteSandbox(req.params.id),
-    },
-    "/api/sandboxes/:id/files": {
-      GET: (req) =>
+    }),
+    "/api/sandboxes/:id": cors({
+      DELETE: (req: Bun.BunRequest<"/api/sandboxes/:id">) =>
+        sandboxRoutes.deleteSandbox(req.params.id),
+    }),
+    "/api/sandboxes/:id/files": cors({
+      GET: (req: Bun.BunRequest<"/api/sandboxes/:id/files">) =>
         sandboxRoutes.listDirectory(
           req.params.id,
           new URL(req.url).searchParams.get("path") ?? "/",
         ),
-    },
-    "/api/sandboxes/:id/file": {
-      GET: (req) => {
+    }),
+    "/api/sandboxes/:id/file": cors({
+      GET: (req: Bun.BunRequest<"/api/sandboxes/:id/file">) => {
         const path = new URL(req.url).searchParams.get("path");
         if (!path) return Response.json({ error: "missing ?path=" }, { status: 400 });
         return sandboxRoutes.readFile(req.params.id, path);
       },
-      PUT: async (req) => {
+      PUT: async (req: Bun.BunRequest<"/api/sandboxes/:id/file">) => {
         const path = new URL(req.url).searchParams.get("path");
         if (!path) return Response.json({ error: "missing ?path=" }, { status: 400 });
         const content = await req.text();
         return sandboxRoutes.writeFile(req.params.id, path, content);
       },
-    },
-    "/api/sandboxes/:id/metrics": {
-      GET: (req) => sandboxRoutes.getMetrics(req.params.id),
-    },
-    "/api/sandboxes/:id/checkpoints": {
-      GET: (req) => sandboxRoutes.listCheckpoints(req.params.id),
-    },
-    "/api/sandboxes/:id/checkpoint": {
-      POST: (req) => sandboxRoutes.createCheckpoint(req.params.id),
-    },
-    "/api/sandboxes/:id/preview": {
-      GET: (req) => {
+    }),
+    "/api/sandboxes/:id/metrics": cors({
+      GET: (req: Bun.BunRequest<"/api/sandboxes/:id/metrics">) =>
+        sandboxRoutes.getMetrics(req.params.id),
+    }),
+    "/api/sandboxes/:id/checkpoints": cors({
+      GET: (req: Bun.BunRequest<"/api/sandboxes/:id/checkpoints">) =>
+        sandboxRoutes.listCheckpoints(req.params.id),
+    }),
+    "/api/sandboxes/:id/checkpoint": cors({
+      POST: (req: Bun.BunRequest<"/api/sandboxes/:id/checkpoint">) =>
+        sandboxRoutes.createCheckpoint(req.params.id),
+    }),
+    "/api/sandboxes/:id/preview": cors({
+      GET: (req: Bun.BunRequest<"/api/sandboxes/:id/preview">) => {
         const port = Number(new URL(req.url).searchParams.get("port"));
         if (!port) return Response.json({ error: "missing ?port=" }, { status: 400 });
         return sandboxRoutes.getPreview(req.params.id, port);
       },
-    },
-    "/api/agents": {
+    }),
+    "/api/agents": cors({
       GET: () => agentRoutes.listAgents(),
-      POST: async (req) => {
+      POST: async (req: Request) => {
         const body = (await req.json().catch(() => ({}))) as { specName?: string };
         if (!body.specName) return Response.json({ error: "missing specName" }, { status: 400 });
         return agentRoutes.createAgent(body.specName);
       },
-    },
-    "/api/agents/:id": {
-      DELETE: (req) => agentRoutes.deleteAgent(req.params.id),
-    },
-    "/api/agents/:id/messages": {
-      GET: (req) => agentRoutes.getMessages(req.params.id),
-    },
+    }),
+    "/api/agents/:id": cors({
+      DELETE: (req: Bun.BunRequest<"/api/agents/:id">) => agentRoutes.deleteAgent(req.params.id),
+    }),
+    "/api/agents/:id/messages": cors({
+      GET: (req: Bun.BunRequest<"/api/agents/:id/messages">) =>
+        agentRoutes.getMessages(req.params.id),
+    }),
     "/ws/sandboxes/:id/terminal": (req, srv) => terminal.upgradeTerminal(req, srv, req.params.id),
     "/ws/sandboxes/:id/metrics": (req, srv) => metrics.upgradeMetrics(req, srv, req.params.id),
     "/ws/agents/:id/chat": (req, srv) => chat.upgradeChat(req, srv, req.params.id),
@@ -112,9 +95,9 @@ const server = Bun.serve({
       else if (ws.data.kind === "chat") chat.onClose(ws);
     },
   },
-  fetch: (req) => serveStatic(new URL(req.url).pathname),
+  fetch: () => Response.json({ error: "not found" }, { status: 404 }),
 });
 
 await registry.reconcile();
 
-console.log(`[sandbox] listening on http://localhost:${server.port}`);
+console.log(`[sandbox] API listening on http://localhost:${server.port}`);

--- a/apps/sandbox/src/env.d.ts
+++ b/apps/sandbox/src/env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  /**
+   * Base URL for the Bun API/WS backend, e.g. "https://sandbox-api.drej.dev".
+   * Leave unset for local dev, where the frontend and backend share an origin.
+   */
+  readonly PUBLIC_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/sandbox/src/scripts/api.ts
+++ b/apps/sandbox/src/scripts/api.ts
@@ -14,8 +14,16 @@ export interface FileEntry {
   size: number;
 }
 
+/**
+ * Base URL for the API/WS backend. Empty string means same-origin (local dev,
+ * where the Bun backend serves both the API and the built frontend). Set to
+ * e.g. "https://sandbox-api.drej.dev" for the Cloudflare Pages deployment,
+ * where the frontend and backend are on different origins.
+ */
+const API_BASE = import.meta.env.PUBLIC_API_BASE_URL ?? "";
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, init);
+  const res = await fetch(`${API_BASE}${path}`, init);
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error((body as { error?: string }).error ?? `${res.status} ${res.statusText}`);
@@ -71,6 +79,11 @@ export const api = {
 };
 
 export function wsUrl(path: string): string {
+  if (API_BASE) {
+    const base = new URL(API_BASE);
+    const protocol = base.protocol === "https:" ? "wss:" : "ws:";
+    return `${protocol}//${base.host}${path}`;
+  }
   const protocol = location.protocol === "https:" ? "wss:" : "ws:";
   return `${protocol}//${location.host}${path}`;
 }

--- a/apps/sandbox/wrangler.toml
+++ b/apps/sandbox/wrangler.toml
@@ -1,0 +1,3 @@
+name = "drej-sandbox"
+compatibility_date = "2024-09-23"
+pages_build_output_dir = "dist"


### PR DESCRIPTION
## Summary
- Splits `apps/sandbox` across two origins to fit the actual VPS capacity available: the Astro frontend now deploys to Cloudflare Pages (`drej-sandbox` → `sandbox.drej.dev`) instead of being served by the Bun backend. The VPS only needs to run OpenSandbox/Docker plus a lightweight API/WS process now.
- `src/scripts/api.ts`: REST + WS calls go through a configurable `PUBLIC_API_BASE_URL` instead of assuming same-origin — same-origin for local dev, `https://sandbox-api.drej.dev` for the Cloudflare build.
- `server/cors.ts`: wraps every `/api/*` route's method-map so responses carry CORS headers and `OPTIONS` preflight requests are answered automatically.
- `server/index.ts`: drops static file serving (no longer needed) in favor of a minimal `/health` check and a plain 404 fallback.
- `wrangler.toml` + `package.json` `deploy` script mirror `apps/www`/`apps/registry`'s existing Cloudflare Pages setup.

**DNS**: `sandbox-api.drej.dev` A record → VPS already added (DNS-only, not proxied, so Caddy can auto-provision its own cert and avoid Cloudflare's WebSocket proxy quirks).

**Deployed**: pushed a preview deploy from this branch — https://9792188d.drej-sandbox.pages.dev (Cloudflare Pages wasn't given Git integration, so this shows as a "Preview" deployment tied to the branch; a production deploy from `main` after merge, plus attaching the `sandbox.drej.dev` custom domain in the dashboard, will make it live at the real domain).

## Test plan
- [x] `bunx tsc --noEmit --project apps/sandbox/tsconfig.server.json` — clean
- [x] `bunx astro check` — 0 errors/warnings/hints
- [x] `bunx astro build` — succeeds; confirmed `sandbox-api.drej.dev` is baked into the bundle via `.env.production`
- [x] Booted the backend locally and curl-tested `/health`, a real `/api/sandboxes` request with an `Origin` header (CORS headers present), and an `OPTIONS` preflight (204 + correct headers)
- [x] `wrangler pages deploy` succeeded, confirmed live via `wrangler pages deployment list`
- [x] Root `bun run typecheck` (existing packages) — unaffected, still green
- [x] `oxfmt`/`oxlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)