### PR TITLE
fix(sandbox): resolve 502s, crashes, and localhost/IPv6 failures

### DIFF
--- a/.changeset/fix-agent-localhost-default.md
+++ b/.changeset/fix-agent-localhost-default.md
@@ -1,0 +1,5 @@
+---
+"@drej/agent": patch
+---
+
+Default `serverUrl` (in `drej.config.json` / `readProjectConfig`) is now `http://127.0.0.1:8080` instead of `http://localhost:8080`. On hosts where `localhost` resolves to `::1` first but OpenSandbox only listens on IPv4, the old default caused every request — including `Agent.load()`'s sandbox creation — to fail with a socket error instead of connecting.

--- a/apps/sandbox/drej.config.json
+++ b/apps/sandbox/drej.config.json
@@ -1,5 +1,5 @@
 {
-  "serverUrl": "http://localhost:8080",
+  "serverUrl": "http://127.0.0.1:8080",
   "apiKey": "",
   "adapterPath": "./data/ledger.db",
   "useServerProxy": true,

--- a/apps/sandbox/server/config.ts
+++ b/apps/sandbox/server/config.ts
@@ -4,7 +4,9 @@
  * ("Hard limits") for why.
  */
 
-export const OPENSANDBOX_URL = process.env.OPENSANDBOX_URL ?? "http://localhost:8080";
+// 127.0.0.1, not "localhost" — some hosts resolve "localhost" to ::1 first, and
+// OpenSandbox (and its proxied execd endpoints, via eip) only listen on IPv4.
+export const OPENSANDBOX_URL = process.env.OPENSANDBOX_URL ?? "http://127.0.0.1:8080";
 export const OPENSANDBOX_API_KEY = process.env.OPENSANDBOX_API_KEY ?? "";
 export const USE_SERVER_PROXY = true;
 export const LEDGER_PATH = process.env.LEDGER_PATH ?? "./data/ledger.db";

--- a/apps/sandbox/server/index.ts
+++ b/apps/sandbox/server/index.ts
@@ -10,6 +10,9 @@ import type { WSData } from "./ws/types";
 
 const server = Bun.serve({
   port: config.PORT,
+  // Bun's default is 10s. Sandbox/agent creation (image pulls, package installs)
+  // routinely takes longer, so use Bun's max to avoid killing the connection mid-request.
+  idleTimeout: 255,
   routes: {
     "/health": new Response("ok"),
     "/api/sandboxes": cors({

--- a/apps/sandbox/server/index.ts
+++ b/apps/sandbox/server/index.ts
@@ -8,6 +8,15 @@ import * as chat from "./ws/chat";
 import { cors } from "./cors";
 import type { WSData } from "./ws/types";
 
+// A single bad/racy session (e.g. a WS exec resolving against a sandbox deleted
+// mid-connection) must never take down the whole process for every other user.
+process.on("uncaughtException", (err) => {
+  console.error("[sandbox] uncaught exception", err);
+});
+process.on("unhandledRejection", (reason) => {
+  console.error("[sandbox] unhandled rejection", reason);
+});
+
 const server = Bun.serve({
   port: config.PORT,
   // Bun's default is 10s. Sandbox/agent creation (image pulls, package installs)

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync } from "fs";
 
 /** Shape of `drej.config.json` in the project root, merged with built-in defaults. */
 export interface DrejAgentConfig {
-  /** OpenSandbox server URL. Default: `http://localhost:8080`. */
+  /** OpenSandbox server URL. Default: `http://127.0.0.1:8080`. */
   serverUrl: string;
   /** OpenSandbox API key. Pass an empty string for local dev with no auth. */
   apiKey: string;
@@ -31,7 +31,9 @@ export interface DrejAgentConfig {
 const CONFIG_FILE = "drej.config.json";
 
 const DEFAULT_CONFIG: DrejAgentConfig = {
-  serverUrl: "http://localhost:8080",
+  // 127.0.0.1, not "localhost" — some hosts resolve "localhost" to ::1 first,
+  // and OpenSandbox typically only listens on IPv4.
+  serverUrl: "http://127.0.0.1:8080",
   apiKey: "",
   adapterPath: "./.drej/ledger.db",
   useServerProxy: true,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,7 +16,9 @@ import {
 } from "../config.js";
 
 const CONTAINER_NAME = "drejx-opensandbox";
-const SERVER_URL = "http://localhost:8080";
+// 127.0.0.1, not "localhost" — some hosts resolve "localhost" to ::1 first,
+// and OpenSandbox only listens on IPv4.
+const SERVER_URL = "http://127.0.0.1:8080";
 
 export async function init(): Promise<void> {
   console.log("Checking Docker...");

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -26,7 +26,7 @@ export async function readConfig(): Promise<DrejxConfig> {
   if (!(await file.exists())) throw new Error("No drej.config.json found — run 'drejx init' first");
   const data = (await file.json()) as Partial<DrejxConfig>;
   return {
-    serverUrl: data.serverUrl ?? "http://localhost:8080",
+    serverUrl: data.serverUrl ?? "http://127.0.0.1:8080",
     useServerProxy: data.useServerProxy ?? true,
     apiKey: data.apiKey ?? "",
     adapterPath: data.adapterPath ?? "./.drej/ledger.db",
@@ -57,7 +57,7 @@ export function serverConfigContent(): string {
   return `[server]
 host = "0.0.0.0"
 port = 8080
-eip = "http://localhost:8080"
+eip = "http://127.0.0.1:8080"
 
 [runtime]
 type = "docker"

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -14,8 +14,8 @@ describe("serverConfigContent", () => {
     expect(serverConfigContent()).toContain("[docker]");
   });
 
-  it('contains eip = "http://localhost:8080"', () => {
-    expect(serverConfigContent()).toContain(`eip = "http://localhost:8080"`);
+  it('contains eip = "http://127.0.0.1:8080"', () => {
+    expect(serverConfigContent()).toContain(`eip = "http://127.0.0.1:8080"`);
   });
 
   it('contains type = "docker"', () => {


### PR DESCRIPTION
## What
Four related stability fixes, all reproduced live on `sandbox-api.drej.dev`:

1. Raises `Bun.serve`'s `idleTimeout` from the default 10s to Bun's max (255s).
2. Adds top-level `uncaughtException`/`unhandledRejection` handlers so one bad session can't take the whole process down.
3. Defaults every OpenSandbox URL in the dashboard/agent/CLI (`drejx init`'s generated `eip`/`server.toml` template, `@drej/agent`'s `drej.config.json` default, and the sandbox dashboard's own `OPENSANDBOX_URL` default) to `127.0.0.1` instead of `localhost`.
4. Same fix applied to every `examples/*` script, the root README's quick-start snippet, and the `ports` example's proxy-URL doc line — same bug, same root cause, just the "manual uvx" side of the setup instead of the "drejx init" side.

## Why
1. Sandbox/agent creation (image pulls, package installs) routinely takes longer than 10 seconds. Bun was killing the connection mid-request, which Caddy reported to the client as a 502 — even though the resource was actually created successfully server-side.
2. A racy WS session (exec resolution against a sandbox deleted mid-connection) threw uncaught and crashed the entire process, taking the whole public, unauthenticated dashboard down for every user. One bad session should degrade gracefully, not crash the server.
3&4. On hosts where `localhost` resolves to `::1` before `127.0.0.1`, every request against OpenSandbox (IPv4-only) fails outright with a raw socket error. This is a genuine, recurring class of bug, not a one-off: it independently bit the dashboard's own config, `@drej/agent`'s separate config file, and `drejx init`'s own generated server config — three different files, same root cause. Auditing the rest of the repo turned up the same default baked into every example script and the top-level README, which would hit new users following the documented manual (`uvx opensandbox-server`) setup on an affected machine. Fixed at the root everywhere instead of patching each downstream symptom.

## Test plan
- [x] `bun run typecheck` / `bun run test` — all clean, all passing
- [x] `oxfmt`/`oxlint` — clean
- [x] Applied all changes on the VPS: `POST /api/sandboxes` and `POST /api/agents` both complete end-to-end with no 502s; confirmed the process survives a create-then-immediately-delete race that previously crashed it; confirmed a full agent creation (Pi CLI install, checkpoint, bridge) succeeds and the agent is listed and reachable afterward