### PR TITLE
feat(sandbox): markdown rendering + tool call detail in agent chat

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -18,7 +18,9 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "astro": "^6.4.8",
-    "drej": "workspace:*"
+    "dompurify": "^3.4.11",
+    "drej": "workspace:*",
+    "marked": "^18.0.5"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/apps/sandbox/src/components/AgentPanel.astro
+++ b/apps/sandbox/src/components/AgentPanel.astro
@@ -23,7 +23,10 @@
         autocomplete="off"
       />
       <button type="submit" class="btn btn-primary">Send</button>
-      <button type="button" id="chat-steer-btn" class="btn" disabled>Steer</button>
+      <span class="relative">
+        <button type="button" id="chat-steer-btn" class="btn" disabled>Steer</button>
+        <span id="chat-queue-badge" class="queue-badge mono"></span>
+      </span>
       <button type="button" id="chat-abort-btn" class="btn btn-danger" disabled>Abort</button>
     </form>
   </div>
@@ -43,5 +46,110 @@
   .tab-btn.active {
     color: var(--color-fg);
     border-bottom-color: var(--color-accent);
+  }
+
+  .queue-badge {
+    position: absolute;
+    top: -0.6rem;
+    right: -0.5rem;
+    font-size: 0.65rem;
+    color: var(--color-muted);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.05rem 0.4rem;
+    line-height: 1.3;
+  }
+  .queue-badge:empty {
+    display: none;
+  }
+
+  .system-note {
+    padding-left: 0.25rem;
+  }
+
+  .tool-call summary {
+    list-style: none;
+  }
+  .tool-call summary::-webkit-details-marker {
+    display: none;
+  }
+  .tool-call pre {
+    max-height: 260px;
+    overflow: auto;
+  }
+
+  .chat-markdown :global(p) {
+    margin-bottom: 0.6rem;
+  }
+  .chat-markdown :global(p:last-child) {
+    margin-bottom: 0;
+  }
+  .chat-markdown :global(ul),
+  .chat-markdown :global(ol) {
+    margin: 0.4rem 0 0.6rem 1.25rem;
+  }
+  .chat-markdown :global(li) {
+    margin-bottom: 0.2rem;
+  }
+  .chat-markdown :global(a) {
+    color: var(--color-accent);
+    text-decoration: underline;
+  }
+  .chat-markdown :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.1rem 0.3rem;
+  }
+  .chat-markdown :global(pre) {
+    position: relative;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 0.6rem 0.7rem;
+    margin: 0.5rem 0;
+    overflow-x: auto;
+  }
+  .chat-markdown :global(pre code) {
+    background: none;
+    border: none;
+    padding: 0;
+  }
+  .chat-markdown :global(table) {
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+    font-size: 0.85em;
+  }
+  .chat-markdown :global(th),
+  .chat-markdown :global(td) {
+    border: 1px solid var(--color-border);
+    padding: 0.3rem 0.5rem;
+  }
+  .chat-markdown :global(blockquote) {
+    border-left: 2px solid var(--color-border);
+    padding-left: 0.6rem;
+    color: var(--color-muted);
+    margin: 0.5rem 0;
+  }
+
+  .copy-btn {
+    position: absolute;
+    top: 0.3rem;
+    right: 0.4rem;
+    font-size: 0.65rem;
+    color: var(--color-muted);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+  }
+  .copy-btn:hover {
+    border-color: var(--color-accent);
+    color: var(--color-fg);
   }
 </style>

--- a/apps/sandbox/src/scripts/agentChat.ts
+++ b/apps/sandbox/src/scripts/agentChat.ts
@@ -1,13 +1,28 @@
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+import type { AgentEvent } from "@drej/agent";
 import { wsUrl } from "./api";
 
-type AgentEvent =
-  | { type: "text"; text: string }
-  | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
-  | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
-  | { type: "agent_start" }
-  | { type: "agent_end" }
-  | { type: "bridge_error"; message: string }
-  | { type: string; [key: string]: unknown };
+type BridgeErrorEvent = { type: "bridge_error"; message: string };
+type ChatEvent = AgentEvent | BridgeErrorEvent;
+
+marked.setOptions({ breaks: true });
+
+function renderMarkdown(raw: string): string {
+  return DOMPurify.sanitize(marked.parse(raw, { async: false }) as string);
+}
+
+function isNearBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+}
+
+interface ToolCallEntry {
+  details: HTMLDetailsElement;
+  summary: HTMLElement;
+  argsEl: HTMLElement;
+  resultEl: HTMLElement;
+  toolName: string;
+}
 
 export function mountAgentChat(agentId: string): { dispose(): void } {
   const messages = document.getElementById("chat-messages") as HTMLDivElement;
@@ -15,55 +30,203 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
   const input = document.getElementById("chat-input") as HTMLInputElement;
   const steerBtn = document.getElementById("chat-steer-btn") as HTMLButtonElement;
   const abortBtn = document.getElementById("chat-abort-btn") as HTMLButtonElement;
+  const queueBadge = document.getElementById("chat-queue-badge") as HTMLSpanElement | null;
 
   let streaming = false;
   let assistantBubble: HTMLDivElement | null = null;
+  let assistantRawText = "";
+  let renderScheduled = false;
+  const toolCalls = new Map<string, ToolCallEntry>();
 
   function setStreaming(value: boolean) {
     streaming = value;
     steerBtn.disabled = !streaming;
     abortBtn.disabled = !streaming;
     assistantBubble = null;
+    assistantRawText = "";
   }
 
-  function addBubble(role: "you" | "agent" | "tool" | "error", text: string): HTMLDivElement {
+  function scrollToBottomIfNear(wasNearBottom: boolean) {
+    if (wasNearBottom) messages.scrollTop = messages.scrollHeight;
+  }
+
+  function addBubble(role: "you" | "agent" | "error" | "system", text: string): HTMLDivElement {
+    const wasNearBottom = isNearBottom(messages);
     const bubble = document.createElement("div");
     bubble.className =
       role === "you"
         ? "self-end rounded-lg bg-[var(--color-accent)] px-3 py-2 text-white"
         : role === "error"
           ? "rounded-lg border border-[var(--color-danger)] px-3 py-2 text-[var(--color-danger)]"
-          : role === "tool"
-            ? "mono rounded-lg bg-[var(--color-bg)] px-3 py-2 text-xs text-[var(--color-muted)]"
-            : "rounded-lg border border-[var(--color-border)] px-3 py-2";
+          : role === "system"
+            ? "mono system-note px-1 text-xs text-[var(--color-muted)] italic"
+            : "chat-markdown rounded-lg border border-[var(--color-border)] px-3 py-2";
     bubble.textContent = text;
     messages.appendChild(bubble);
-    messages.scrollTop = messages.scrollHeight;
+    scrollToBottomIfNear(wasNearBottom);
     return bubble;
+  }
+
+  function addCopyButtons(container: HTMLElement) {
+    for (const pre of container.querySelectorAll("pre")) {
+      if (pre.querySelector(".copy-btn")) continue;
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "copy-btn";
+      btn.textContent = "Copy";
+      btn.addEventListener("click", () => {
+        const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
+        void navigator.clipboard.writeText(code).then(() => {
+          btn.textContent = "Copied";
+          setTimeout(() => (btn.textContent = "Copy"), 1200);
+        });
+      });
+      pre.appendChild(btn);
+    }
+  }
+
+  function scheduleAssistantRender() {
+    if (renderScheduled) return;
+    renderScheduled = true;
+    requestAnimationFrame(() => {
+      renderScheduled = false;
+      if (!assistantBubble) return;
+      const wasNearBottom = isNearBottom(messages);
+      assistantBubble.innerHTML = renderMarkdown(assistantRawText);
+      addCopyButtons(assistantBubble);
+      scrollToBottomIfNear(wasNearBottom);
+    });
+  }
+
+  function appendText(text: string) {
+    if (!assistantBubble) {
+      assistantBubble = document.createElement("div");
+      assistantBubble.className =
+        "chat-markdown rounded-lg border border-[var(--color-border)] px-3 py-2";
+      messages.appendChild(assistantBubble);
+      assistantRawText = "";
+    }
+    assistantRawText += text;
+    scheduleAssistantRender();
+  }
+
+  function ensureToolCall(toolCallId: string, toolName: string, args: unknown): ToolCallEntry {
+    let entry = toolCalls.get(toolCallId);
+    if (entry) return entry;
+
+    const wasNearBottom = isNearBottom(messages);
+    const details = document.createElement("details");
+    details.className =
+      "tool-call rounded-lg border border-[var(--color-border)] px-3 py-2 text-xs";
+    const summary = document.createElement("summary");
+    summary.className = "mono cursor-pointer text-[var(--color-muted)]";
+    summary.textContent = `▶ ${toolName}`;
+    const argsEl = document.createElement("pre");
+    argsEl.className = "mono mt-2 whitespace-pre-wrap break-all text-[var(--color-muted)]";
+    argsEl.textContent = JSON.stringify(args, null, 2);
+    const resultEl = document.createElement("pre");
+    resultEl.className = "mono mt-2 hidden whitespace-pre-wrap break-all text-[var(--color-muted)]";
+    details.append(summary, argsEl, resultEl);
+    messages.appendChild(details);
+    scrollToBottomIfNear(wasNearBottom);
+
+    entry = { details, summary, argsEl, resultEl, toolName };
+    toolCalls.set(toolCallId, entry);
+    return entry;
+  }
+
+  function setQueueBadge(steering: number, followUp: number) {
+    if (!queueBadge) return;
+    const total = steering + followUp;
+    queueBadge.textContent = total > 0 ? `${total} queued` : "";
   }
 
   const ws = new WebSocket(wsUrl(`/ws/agents/${agentId}/chat`));
 
   ws.addEventListener("message", (ev) => {
     if (typeof ev.data !== "string") return;
-    const event = JSON.parse(ev.data) as AgentEvent;
-    if (event.type === "agent_start") {
-      setStreaming(true);
-    } else if (event.type === "agent_end") {
-      setStreaming(false);
-    } else if (event.type === "text") {
-      if (!assistantBubble) assistantBubble = addBubble("agent", "");
-      assistantBubble.textContent += (event as { text: string }).text;
-      messages.scrollTop = messages.scrollHeight;
-    } else if (event.type === "tool_start") {
-      const e = event as Extract<AgentEvent, { type: "tool_start" }>;
-      addBubble("tool", `▶ ${e.toolName}`);
-    } else if (event.type === "tool_end") {
-      const e = event as Extract<AgentEvent, { type: "tool_end" }>;
-      addBubble("tool", `${e.isError ? "✗" : "✓"} ${e.toolName}`);
-    } else if (event.type === "bridge_error") {
-      addBubble("error", (event as { message: string }).message);
-      setStreaming(false);
+    const event = JSON.parse(ev.data) as ChatEvent;
+
+    switch (event.type) {
+      case "agent_start": {
+        setStreaming(true);
+        break;
+      }
+      case "agent_end": {
+        setStreaming(false);
+        break;
+      }
+      case "text": {
+        appendText(event.text);
+        break;
+      }
+      case "tool_start": {
+        ensureToolCall(event.toolCallId, event.toolName, event.args);
+        break;
+      }
+      case "tool_update": {
+        const entry = ensureToolCall(event.toolCallId, event.toolName, {});
+        entry.resultEl.classList.remove("hidden");
+        entry.resultEl.textContent = `--- partial ---\n${JSON.stringify(event.partialResult, null, 2)}`;
+        break;
+      }
+      case "tool_end": {
+        const entry = ensureToolCall(event.toolCallId, event.toolName, {});
+        entry.summary.textContent = `${event.isError ? "✗" : "✓"} ${entry.toolName}`;
+        entry.resultEl.classList.remove("hidden");
+        entry.resultEl.textContent = `--- result ---\n${JSON.stringify(event.result, null, 2)}`;
+        break;
+      }
+      case "auto_retry_start": {
+        addBubble(
+          "system",
+          `Retrying (attempt ${event.attempt}/${event.maxAttempts})… ${event.errorMessage}`,
+        );
+        break;
+      }
+      case "auto_retry_end": {
+        addBubble(
+          "system",
+          event.success
+            ? "Retry succeeded"
+            : `Retry failed: ${event.finalError ?? "unknown error"}`,
+        );
+        break;
+      }
+      case "compaction_start": {
+        addBubble("system", "Compacting context…");
+        break;
+      }
+      case "compaction_end": {
+        if (!event.aborted && event.result) {
+          addBubble(
+            "system",
+            `Context compacted (${event.result.tokensBefore} → ${event.result.estimatedTokensAfter} tokens)`,
+          );
+        }
+        break;
+      }
+      case "extension_error": {
+        addBubble("error", `Extension error (${event.extensionPath}): ${event.error}`);
+        break;
+      }
+      case "extension_ui": {
+        if (event.isDialog) {
+          addBubble("system", `Agent requested UI (${event.method}), auto-dismissed`);
+        }
+        break;
+      }
+      case "queue_update": {
+        setQueueBadge(event.steering.length, event.followUp.length);
+        break;
+      }
+      case "bridge_error": {
+        addBubble("error", event.message);
+        setStreaming(false);
+        break;
+      }
+      default:
+        break;
     }
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,9 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "astro": "^6.4.8",
+        "dompurify": "^3.4.11",
         "drej": "workspace:*",
+        "marked": "^18.0.5",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
@@ -1169,6 +1171,8 @@
 
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.0", "@typescript-eslint/type-utils": "8.62.0", "@typescript-eslint/utils": "8.62.0", "@typescript-eslint/visitor-keys": "8.62.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw=="],
@@ -1528,6 +1532,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -2082,6 +2088,8 @@
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 


### PR DESCRIPTION
## Summary

Implements `plans/agent-chat-ux.md` in full: the agent chat panel on sandbox.drej.dev now renders assistant `text` as sanitized markdown instead of raw escaped characters, and tool calls are expandable/inspectable instead of collapsing to a one-line label.

- **Markdown rendering**: `marked` + `DOMPurify`, batched via `requestAnimationFrame` so fast token bursts don't thrash the DOM. Auto-scroll only forces to bottom if the user was already near it. Code blocks get a copy-to-clipboard button.
- **Tool calls**: `tool_start`/`tool_update`/`tool_end` now merge into one expandable `<details>` block per `toolCallId`, showing `args` and `result`/`partialResult`. Previously `tool_end` created a *second*, unlinked bubble — fixed.
- **Previously-dropped events surfaced**: `auto_retry_start/end`, `compaction_start/end`, and `extension_error` now render as quiet system notices instead of being silently discarded; `queue_update` shows a small badge next to the Steer button.
- No backend changes — `apps/sandbox/server/ws/chat.ts` already forwards every `AgentEvent` verbatim; the gap was entirely client-side in `agentChat.ts`.
- No changeset — `apps/sandbox` is private, not a published package.

## Test plan

- [x] `bun run typecheck` (astro check + tsc) — clean
- [x] `bunx oxfmt`/`bunx oxlint apps/sandbox` — clean
- [x] `bun run build` (astro build) — clean, confirms `marked`/`dompurify` bundle correctly for the browser
- [ ] Manual verification in a running browser against a live agent (markdown code blocks, tool call expansion, retry/compaction notices) — not run in this session (no local OpenSandbox/API key available); to be done by reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)