### PR TITLE
ci: add deploy pipeline + typecheck for apps/sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
         run: bunx tsc --noEmit --strict
         working-directory: packages/adapters/otel
 
+      - name: Typecheck sandbox
+        run: bun run typecheck
+        working-directory: apps/sandbox
+
       - name: Lint
         run: bun run lint
 

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -1,0 +1,49 @@
+name: Deploy sandbox
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/sandbox/**"
+      - "packages/agent/**"
+      - "packages/core/**"
+      - "packages/opensandbox/**"
+      - "packages/sdks/typescript/**"
+      - "packages/adapters/sqlite/**"
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install
+
+      # apps/sandbox depends on @drej/agent, @drej/core, @drej/sqlite, and drej via
+      # workspace:* — each resolves to its dist/ output, so those packages must be
+      # built before astro build can bundle them.
+      - name: Build workspace packages
+        run: bun run build
+
+      - name: Build sandbox frontend
+        run: bun run build
+        working-directory: apps/sandbox
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: drej-sandbox
+          directory: apps/sandbox/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`apps/www`, `apps/registry`, and `apps/docs` each auto-deploy to Cloudflare Pages via a `deploy-*.yml` workflow on push to `main`. `apps/sandbox` had none — every deploy so far has been manual (`astro build && wrangler pages deploy`), and `ci.yml` didn't even typecheck it.

- **`deploy-sandbox.yml`** (new): same shape as `deploy-www.yml`/`deploy-registry.yml` — checkout, install, build, `cloudflare/pages-action@v1` targeting the `drej-sandbox` Pages project (per `apps/sandbox/wrangler.toml`). Triggers on `apps/sandbox/**` plus the workspace packages the frontend actually imports (`@drej/agent`, `@drej/core`, `@drej/opensandbox`, `packages/sdks/typescript`, `@drej/sqlite`) — unlike www/registry/docs, sandbox depends on these via `workspace:*`, which resolve to `dist/`, so a `bun run build` (workspace packages) step runs before `astro build`.
- **`ci.yml`**: added a "Typecheck sandbox" step (`bun run typecheck` → `astro check` + server `tsconfig`) next to the existing per-package typecheck steps, so sandbox regressions get caught on PRs, not just at deploy time.

## Out of scope

The Bun backend (`apps/sandbox/server`) still deploys manually via SSH to the VPS (no systemd service, no CI path) — this PR only covers the Cloudflare Pages frontend, matching what the other three app deploy workflows already do.

## Test plan

- [x] Validated both workflow YAML files parse correctly
- [x] `bun run build` (workspace packages) + `bun run typecheck` in `apps/sandbox` pass locally
- [ ] First real run of `deploy-sandbox.yml` on merge to `main` (requires `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` secrets, already used by the other three deploy workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)