### PR TITLE
style(sandbox): custom-styled agent spec dropdown

### DIFF
--- a/apps/sandbox/src/components/Dashboard.astro
+++ b/apps/sandbox/src/components/Dashboard.astro
@@ -27,7 +27,7 @@ const ALLOWED_AGENT_SPECS = ["hello-agent", "python-data"] as const;
           Agents <span id="agent-count" class="mono text-sm text-[var(--color-muted)]"></span>
         </h2>
         <div class="flex items-center gap-2">
-          <select id="agent-spec-select" class="btn">
+          <select id="agent-spec-select" class="btn spec-select">
             {ALLOWED_AGENT_SPECS.map((name) => <option value={name}>{name}</option>)}
           </select>
           <button id="new-agent-btn" class="btn btn-primary">+ New agent</button>
@@ -38,3 +38,23 @@ const ALLOWED_AGENT_SPECS = ["hello-agent", "python-data"] as const;
     </div>
   </div>
 </section>
+
+<style>
+  .spec-select {
+    appearance: none;
+    -webkit-appearance: none;
+    padding-right: 1.9rem;
+    background-repeat: no-repeat;
+    background-position: right 0.6rem center;
+    background-size: 0.65rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23767680' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  }
+  .spec-select:hover {
+    border-color: var(--color-accent);
+  }
+  .spec-select:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px oklch(0.5 0.26 292 / 15%);
+  }
+</style>


### PR DESCRIPTION
## Summary

The "New agent" spec `<select>` on the dashboard just reused the plain `.btn` class, so it rendered with the browser's default select appearance/chevron sitting inside a button-styled box — inconsistent with the rest of the UI.

- New `.spec-select` class (scoped to `Dashboard.astro`): removes native `appearance`, adds a custom inline-SVG chevron (no extra asset/request), and hover/focus-visible states matching the accent color already used for buttons and the chat tab underline.
- Light-mode only, no gradients, consistent with the existing `var(--color-*)` tokens — no new colors introduced.

## Test plan

- [x] `bun run typecheck` (astro check + tsc) — clean
- [x] `bun run build` (astro build) — clean, confirmed `.spec-select` CSS made it into the compiled bundle
- [x] `bunx oxlint apps/sandbox` — clean
- [ ] Visual check in a browser — not run this session; small enough CSS-only change to review from the diff/screenshot in the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)