### PR TITLE
feat(sandbox): agent session, model/reasoning, and streaming controls

### DIFF
--- a/.changeset/agent-get-state.md
+++ b/.changeset/agent-get-state.md
@@ -1,0 +1,5 @@
+---
+"@drej/agent": minor
+---
+
+Add `agent.getState()`, wrapping Pi's `get_state` RPC command. Returns the current model, thinking level, streaming/compaction status, queue modes, and session identity — the only piece of Pi's RPC surface that wasn't already exposed (every other method already had an `Agent` wrapper). Needed to show live agent status (current model, thinking level, auto-compaction) without guessing from side effects of other calls.

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
+    "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.2",
     "bun-types": "1.3.14",
     "tailwindcss": "^4.3.2",

--- a/apps/sandbox/server/index.ts
+++ b/apps/sandbox/server/index.ts
@@ -86,6 +86,26 @@ const server = Bun.serve({
       GET: (req: Bun.BunRequest<"/api/agents/:id/messages">) =>
         agentRoutes.getMessages(req.params.id),
     }),
+    "/api/agents/:id/state": cors({
+      GET: (req: Bun.BunRequest<"/api/agents/:id/state">) => agentRoutes.getState(req.params.id),
+    }),
+    "/api/agents/:id/stats": cors({
+      GET: (req: Bun.BunRequest<"/api/agents/:id/stats">) => agentRoutes.getStats(req.params.id),
+    }),
+    "/api/agents/:id/models": cors({
+      GET: (req: Bun.BunRequest<"/api/agents/:id/models">) => agentRoutes.getModels(req.params.id),
+    }),
+    "/api/agents/:id/fork-points": cors({
+      GET: (req: Bun.BunRequest<"/api/agents/:id/fork-points">) =>
+        agentRoutes.getForkPoints(req.params.id),
+    }),
+    "/api/agents/:id/export": cors({
+      GET: (req: Bun.BunRequest<"/api/agents/:id/export">) => {
+        const path = new URL(req.url).searchParams.get("path");
+        if (!path) return Response.json({ error: "missing ?path=" }, { status: 400 });
+        return agentRoutes.getExport(req.params.id, path);
+      },
+    }),
     "/ws/sandboxes/:id/terminal": (req, srv) => terminal.upgradeTerminal(req, srv, req.params.id),
     "/ws/sandboxes/:id/metrics": (req, srv) => metrics.upgradeMetrics(req, srv, req.params.id),
     "/ws/agents/:id/chat": (req, srv) => chat.upgradeChat(req, srv, req.params.id),

--- a/apps/sandbox/server/routes/agents.ts
+++ b/apps/sandbox/server/routes/agents.ts
@@ -49,3 +49,62 @@ export async function getMessages(id: string): Promise<Response> {
     return errorResponse(err);
   }
 }
+
+export async function getState(id: string): Promise<Response> {
+  try {
+    const agent = registry.agents.get(id);
+    if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+    return Response.json(await agent.getState());
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function getStats(id: string): Promise<Response> {
+  try {
+    const agent = registry.agents.get(id);
+    if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+    return Response.json(await agent.getSessionStats());
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function getModels(id: string): Promise<Response> {
+  try {
+    const agent = registry.agents.get(id);
+    if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+    const models = await agent.getAvailableModels();
+    return Response.json({ models });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+export async function getForkPoints(id: string): Promise<Response> {
+  try {
+    const agent = registry.agents.get(id);
+    if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+    const forkPoints = await agent.getForkMessages();
+    return Response.json({ forkPoints });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+/** Download a session export previously written by `exportHtml()` (path lives in the sandbox). */
+export async function getExport(id: string, path: string): Promise<Response> {
+  try {
+    const agent = registry.agents.get(id);
+    if (!agent) throw new NotFoundError(`Unknown agent ${id}`);
+    const html = await agent.sandbox.readFile(path);
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text/html",
+        "Content-Disposition": `attachment; filename="${path.split("/").pop()}"`,
+      },
+    });
+  } catch (err) {
+    return errorResponse(err);
+  }
+}

--- a/apps/sandbox/server/ws/chat.ts
+++ b/apps/sandbox/server/ws/chat.ts
@@ -1,5 +1,5 @@
+import type { Agent, AgentStream, ThinkingLevel } from "@drej/agent";
 import type { Server, ServerWebSocket } from "bun";
-import type { AgentStream } from "@drej/agent";
 import * as registry from "../registry";
 import type { WSData } from "./types";
 
@@ -7,7 +7,85 @@ type ChatCommand =
   | { type: "prompt"; text: string }
   | { type: "steer"; text: string }
   | { type: "followUp"; text: string }
-  | { type: "abort" };
+  | { type: "abort" }
+  | { type: "newSession" }
+  | { type: "setSessionName"; name: string }
+  | { type: "clone" }
+  | { type: "fork"; entryId: string }
+  | { type: "switchSession"; path: string }
+  | { type: "exportHtml" }
+  | { type: "setModel"; provider: string; modelId: string }
+  | { type: "cycleModel" }
+  | { type: "setThinkingLevel"; level: ThinkingLevel }
+  | { type: "cycleThinkingLevel" }
+  | { type: "setAutoCompaction"; enabled: boolean }
+  | { type: "compact"; customInstructions?: string }
+  | { type: "setAutoRetry"; enabled: boolean }
+  | { type: "abortRetry" };
+
+type DataCommand = Exclude<ChatCommand, { type: "prompt" | "steer" | "followUp" | "abort" }>;
+
+/**
+ * Dispatch a one-shot agent command that isn't part of the prompt stream. Commands whose
+ * `Agent` method returns data are echoed back as `command_result` so the UI can update without
+ * a separate fetch; void ones just succeed silently.
+ */
+async function runCommand(
+  ws: ServerWebSocket<WSData>,
+  agent: Agent,
+  cmd: DataCommand,
+): Promise<void> {
+  try {
+    let result: unknown;
+    switch (cmd.type) {
+      case "newSession":
+        await agent.newSession();
+        break;
+      case "setSessionName":
+        await agent.setSessionName(cmd.name);
+        break;
+      case "clone":
+        result = await agent.clone();
+        break;
+      case "fork":
+        result = await agent.fork(cmd.entryId);
+        break;
+      case "switchSession":
+        result = await agent.switchSession(cmd.path);
+        break;
+      case "exportHtml":
+        result = await agent.exportHtml();
+        break;
+      case "setModel":
+        result = await agent.setModel(cmd.provider, cmd.modelId);
+        break;
+      case "cycleModel":
+        result = await agent.cycleModel();
+        break;
+      case "setThinkingLevel":
+        await agent.setThinkingLevel(cmd.level);
+        break;
+      case "cycleThinkingLevel":
+        result = await agent.cycleThinkingLevel();
+        break;
+      case "setAutoCompaction":
+        await agent.setAutoCompaction(cmd.enabled);
+        break;
+      case "compact":
+        result = await agent.compact(cmd.customInstructions);
+        break;
+      case "setAutoRetry":
+        await agent.setAutoRetry(cmd.enabled);
+        break;
+      case "abortRetry":
+        await agent.abortRetry();
+        break;
+    }
+    ws.send(JSON.stringify({ type: "command_result", command: cmd.type, result: result ?? null }));
+  } catch (err) {
+    ws.send(JSON.stringify({ type: "bridge_error", message: String(err) }));
+  }
+}
 
 /** Route handler for `/ws/agents/:id/chat` — call from the routes table. */
 export function upgradeChat(
@@ -67,6 +145,8 @@ export function onMessage(
     void agent.followUp(cmd.text);
   } else if (cmd.type === "abort") {
     void agent.abort();
+  } else {
+    void runCommand(ws, agent, cmd);
   }
 }
 

--- a/apps/sandbox/src/components/AgentPanel.astro
+++ b/apps/sandbox/src/components/AgentPanel.astro
@@ -12,6 +12,90 @@
 
   <div class="tab-content" data-tab-content="chat">
     <div
+      class="mono mb-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs text-[var(--color-muted)]"
+    >
+      <div class="flex flex-wrap items-center gap-3">
+        <details id="model-popover" class="relative">
+          <summary class="list-none cursor-pointer hover:text-[var(--color-fg)]">
+            <span id="stat-model">model —</span>
+          </summary>
+          <div
+            class="absolute z-20 mt-2 max-h-64 w-56 overflow-auto rounded-lg border border-[var(--color-border)] bg-white p-1 text-[var(--color-fg)] shadow-md"
+          >
+            <div id="model-list" class="flex flex-col"></div>
+          </div>
+        </details>
+
+        <details id="thinking-popover" class="relative">
+          <summary class="list-none cursor-pointer hover:text-[var(--color-fg)]">
+            <span id="stat-thinking">thinking —</span>
+          </summary>
+          <div
+            class="absolute z-20 mt-2 w-32 rounded-lg border border-[var(--color-border)] bg-white p-1 text-[var(--color-fg)] shadow-md"
+          >
+            <div id="thinking-list" class="flex flex-col"></div>
+          </div>
+        </details>
+
+        <details id="context-popover" class="relative">
+          <summary class="list-none cursor-pointer hover:text-[var(--color-fg)]">
+            <span id="stat-context">ctx —</span> · <span id="stat-cost">$—</span>
+          </summary>
+          <div
+            class="absolute z-20 mt-2 w-56 rounded-lg border border-[var(--color-border)] bg-white p-2 text-[var(--color-fg)] shadow-md"
+          >
+            <label class="mb-2 flex items-center gap-2">
+              <input type="checkbox" id="auto-compaction-toggle" />
+              Auto-compaction
+            </label>
+            <button type="button" id="compact-now-btn" class="btn w-full">Compact now</button>
+          </div>
+        </details>
+      </div>
+
+      <details id="session-menu" class="relative">
+        <summary class="btn list-none cursor-pointer">Session ▾</summary>
+        <div
+          class="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-[var(--color-border)] bg-white p-2 text-[var(--color-fg)] shadow-md"
+        >
+          <div class="flex flex-col gap-1">
+            <button type="button" id="session-new-btn" class="btn">New session</button>
+            <button type="button" id="session-clone-btn" class="btn">Clone</button>
+            <button type="button" id="session-export-btn" class="btn">Export HTML</button>
+          </div>
+          <form id="session-rename-form" class="mt-2 flex gap-1">
+            <input
+              id="session-rename-input"
+              class="btn flex-1"
+              placeholder="Session name…"
+              autocomplete="off"
+            />
+            <button type="submit" class="btn">Set</button>
+          </form>
+          <form id="session-switch-form" class="mt-1 flex gap-1">
+            <input
+              id="session-switch-input"
+              class="btn flex-1"
+              placeholder="Switch to path…"
+              autocomplete="off"
+            />
+            <button type="submit" class="btn">Go</button>
+          </form>
+          <details id="fork-submenu" class="mt-2">
+            <summary class="list-none cursor-pointer text-[var(--color-muted)] hover:text-[var(--color-fg)]">
+              Fork from…
+            </summary>
+            <div id="fork-list" class="mt-1 flex max-h-40 flex-col gap-1 overflow-auto"></div>
+          </details>
+          <label class="mt-2 flex items-center gap-2 border-t border-[var(--color-border)] pt-2">
+            <input type="checkbox" id="auto-retry-toggle" checked />
+            Auto-retry
+          </label>
+        </div>
+      </details>
+    </div>
+
+    <div
       id="chat-messages"
       class="mb-3 flex h-[380px] flex-col gap-3 overflow-y-auto rounded-lg border border-[var(--color-border)] p-3 text-sm"
     ></div>
@@ -25,7 +109,10 @@
       <button type="submit" class="btn btn-primary">Send</button>
       <span class="relative">
         <button type="button" id="chat-steer-btn" class="btn" disabled>Steer</button>
-        <span id="chat-queue-badge" class="queue-badge mono"></span>
+        <span
+          id="chat-queue-badge"
+          class="mono absolute -top-2.5 -right-2 rounded-full border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 leading-tight text-[0.65rem] text-[var(--color-muted)] empty:hidden"
+        ></span>
       </span>
       <button type="button" id="chat-abort-btn" class="btn btn-danger" disabled>Abort</button>
     </form>
@@ -46,110 +133,5 @@
   .tab-btn.active {
     color: var(--color-fg);
     border-bottom-color: var(--color-accent);
-  }
-
-  .queue-badge {
-    position: absolute;
-    top: -0.6rem;
-    right: -0.5rem;
-    font-size: 0.65rem;
-    color: var(--color-muted);
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    padding: 0.05rem 0.4rem;
-    line-height: 1.3;
-  }
-  .queue-badge:empty {
-    display: none;
-  }
-
-  .system-note {
-    padding-left: 0.25rem;
-  }
-
-  .tool-call summary {
-    list-style: none;
-  }
-  .tool-call summary::-webkit-details-marker {
-    display: none;
-  }
-  .tool-call pre {
-    max-height: 260px;
-    overflow: auto;
-  }
-
-  .chat-markdown :global(p) {
-    margin-bottom: 0.6rem;
-  }
-  .chat-markdown :global(p:last-child) {
-    margin-bottom: 0;
-  }
-  .chat-markdown :global(ul),
-  .chat-markdown :global(ol) {
-    margin: 0.4rem 0 0.6rem 1.25rem;
-  }
-  .chat-markdown :global(li) {
-    margin-bottom: 0.2rem;
-  }
-  .chat-markdown :global(a) {
-    color: var(--color-accent);
-    text-decoration: underline;
-  }
-  .chat-markdown :global(code) {
-    font-family: var(--font-mono);
-    font-size: 0.85em;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    padding: 0.1rem 0.3rem;
-  }
-  .chat-markdown :global(pre) {
-    position: relative;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    padding: 0.6rem 0.7rem;
-    margin: 0.5rem 0;
-    overflow-x: auto;
-  }
-  .chat-markdown :global(pre code) {
-    background: none;
-    border: none;
-    padding: 0;
-  }
-  .chat-markdown :global(table) {
-    border-collapse: collapse;
-    margin: 0.5rem 0;
-    font-size: 0.85em;
-  }
-  .chat-markdown :global(th),
-  .chat-markdown :global(td) {
-    border: 1px solid var(--color-border);
-    padding: 0.3rem 0.5rem;
-  }
-  .chat-markdown :global(blockquote) {
-    border-left: 2px solid var(--color-border);
-    padding-left: 0.6rem;
-    color: var(--color-muted);
-    margin: 0.5rem 0;
-  }
-
-  .copy-btn {
-    position: absolute;
-    top: 0.3rem;
-    right: 0.4rem;
-    font-size: 0.65rem;
-    color: var(--color-muted);
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    padding: 0.1rem 0.4rem;
-  }
-  .copy-btn:hover {
-    border-color: var(--color-accent);
-    color: var(--color-fg);
   }
 </style>

--- a/apps/sandbox/src/components/Dashboard.astro
+++ b/apps/sandbox/src/components/Dashboard.astro
@@ -38,23 +38,3 @@ const ALLOWED_AGENT_SPECS = ["hello-agent", "python-data"] as const;
     </div>
   </div>
 </section>
-
-<style>
-  .spec-select {
-    appearance: none;
-    -webkit-appearance: none;
-    padding-right: 1.9rem;
-    background-repeat: no-repeat;
-    background-position: right 0.6rem center;
-    background-size: 0.65rem;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23767680' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  }
-  .spec-select:hover {
-    border-color: var(--color-accent);
-  }
-  .spec-select:focus-visible {
-    outline: none;
-    border-color: var(--color-accent);
-    box-shadow: 0 0 0 3px oklch(0.5 0.26 292 / 15%);
-  }
-</style>

--- a/apps/sandbox/src/scripts/agentChat.ts
+++ b/apps/sandbox/src/scripts/agentChat.ts
@@ -1,10 +1,13 @@
 import { marked } from "marked";
 import DOMPurify from "dompurify";
-import type { AgentEvent } from "@drej/agent";
-import { wsUrl } from "./api";
+import type { AgentEvent, PiModel, PiSessionState, SessionStats, ThinkingLevel } from "@drej/agent";
+import { api, wsUrl, type ForkPoint } from "./api";
 
 type BridgeErrorEvent = { type: "bridge_error"; message: string };
-type ChatEvent = AgentEvent | BridgeErrorEvent;
+type CommandResultEvent = { type: "command_result"; command: string; result: unknown };
+type ChatEvent = AgentEvent | BridgeErrorEvent | CommandResultEvent;
+
+const THINKING_LEVELS: ThinkingLevel[] = ["none", "low", "medium", "high"];
 
 marked.setOptions({ breaks: true });
 
@@ -16,6 +19,10 @@ function isNearBottom(el: HTMLElement): boolean {
   return el.scrollHeight - el.scrollTop - el.clientHeight < 40;
 }
 
+function formatCost(cost: number): string {
+  return `$${cost.toFixed(3)}`;
+}
+
 interface ToolCallEntry {
   details: HTMLDetailsElement;
   summary: HTMLElement;
@@ -23,6 +30,9 @@ interface ToolCallEntry {
   resultEl: HTMLElement;
   toolName: string;
 }
+
+/** Menu-item style shared by the model/thinking/fork popover lists — plain rows, not buttons. */
+const MENU_ITEM_CLASS = "w-full rounded px-2 py-1 text-left hover:bg-[var(--color-bg)]";
 
 export function mountAgentChat(agentId: string): { dispose(): void } {
   const messages = document.getElementById("chat-messages") as HTMLDivElement;
@@ -32,11 +42,42 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
   const abortBtn = document.getElementById("chat-abort-btn") as HTMLButtonElement;
   const queueBadge = document.getElementById("chat-queue-badge") as HTMLSpanElement | null;
 
+  const statModel = document.getElementById("stat-model") as HTMLSpanElement;
+  const statThinking = document.getElementById("stat-thinking") as HTMLSpanElement;
+  const statContext = document.getElementById("stat-context") as HTMLSpanElement;
+  const statCost = document.getElementById("stat-cost") as HTMLSpanElement;
+
+  const modelPopover = document.getElementById("model-popover") as HTMLDetailsElement;
+  const modelList = document.getElementById("model-list") as HTMLDivElement;
+  const thinkingPopover = document.getElementById("thinking-popover") as HTMLDetailsElement;
+  const thinkingList = document.getElementById("thinking-list") as HTMLDivElement;
+  const contextPopover = document.getElementById("context-popover") as HTMLDetailsElement;
+  const autoCompactionToggle = document.getElementById(
+    "auto-compaction-toggle",
+  ) as HTMLInputElement;
+  const compactNowBtn = document.getElementById("compact-now-btn") as HTMLButtonElement;
+
+  const sessionMenu = document.getElementById("session-menu") as HTMLDetailsElement;
+  const sessionNewBtn = document.getElementById("session-new-btn") as HTMLButtonElement;
+  const sessionCloneBtn = document.getElementById("session-clone-btn") as HTMLButtonElement;
+  const sessionExportBtn = document.getElementById("session-export-btn") as HTMLButtonElement;
+  const sessionRenameForm = document.getElementById("session-rename-form") as HTMLFormElement;
+  const sessionRenameInput = document.getElementById("session-rename-input") as HTMLInputElement;
+  const sessionSwitchForm = document.getElementById("session-switch-form") as HTMLFormElement;
+  const sessionSwitchInput = document.getElementById("session-switch-input") as HTMLInputElement;
+  const forkSubmenu = document.getElementById("fork-submenu") as HTMLDetailsElement;
+  const forkList = document.getElementById("fork-list") as HTMLDivElement;
+  const autoRetryToggle = document.getElementById("auto-retry-toggle") as HTMLInputElement;
+
   let streaming = false;
   let assistantBubble: HTMLDivElement | null = null;
   let assistantRawText = "";
   let renderScheduled = false;
   const toolCalls = new Map<string, ToolCallEntry>();
+
+  function send(cmd: Record<string, unknown> & { type: string }) {
+    ws.send(JSON.stringify(cmd));
+  }
 
   function setStreaming(value: boolean) {
     streaming = value;
@@ -59,20 +100,42 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
         : role === "error"
           ? "rounded-lg border border-[var(--color-danger)] px-3 py-2 text-[var(--color-danger)]"
           : role === "system"
-            ? "mono system-note px-1 text-xs text-[var(--color-muted)] italic"
-            : "chat-markdown rounded-lg border border-[var(--color-border)] px-3 py-2";
+            ? "mono pl-1 text-xs text-[var(--color-muted)] italic"
+            : "prose prose-sm max-w-none rounded-lg border border-[var(--color-border)] px-3 py-2";
     bubble.textContent = text;
     messages.appendChild(bubble);
     scrollToBottomIfNear(wasNearBottom);
     return bubble;
   }
 
+  /** Same as a "system" bubble, but with an inline action link (used for the retry-cancel affordance). */
+  function addSystemNoteWithAction(text: string, actionLabel: string, onAction: () => void) {
+    const wasNearBottom = isNearBottom(messages);
+    const bubble = document.createElement("div");
+    bubble.className = "mono pl-1 text-xs text-[var(--color-muted)] italic";
+    bubble.textContent = `${text} `;
+    const action = document.createElement("button");
+    action.type = "button";
+    action.className = "not-italic underline hover:text-[var(--color-fg)]";
+    action.textContent = actionLabel;
+    action.addEventListener("click", () => {
+      onAction();
+      action.disabled = true;
+      action.className = "not-italic underline opacity-40";
+    });
+    bubble.appendChild(action);
+    messages.appendChild(bubble);
+    scrollToBottomIfNear(wasNearBottom);
+  }
+
   function addCopyButtons(container: HTMLElement) {
     for (const pre of container.querySelectorAll("pre")) {
-      if (pre.querySelector(".copy-btn")) continue;
+      if (pre.querySelector("[data-copy-btn]")) continue;
       const btn = document.createElement("button");
       btn.type = "button";
-      btn.className = "copy-btn";
+      btn.dataset.copyBtn = "";
+      btn.className =
+        "absolute top-1 right-1 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 py-0.5 text-[0.65rem] text-[var(--color-muted)] hover:border-[var(--color-accent)] hover:text-[var(--color-fg)]";
       btn.textContent = "Copy";
       btn.addEventListener("click", () => {
         const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
@@ -81,6 +144,7 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
           setTimeout(() => (btn.textContent = "Copy"), 1200);
         });
       });
+      pre.classList.add("relative");
       pre.appendChild(btn);
     }
   }
@@ -102,7 +166,7 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
     if (!assistantBubble) {
       assistantBubble = document.createElement("div");
       assistantBubble.className =
-        "chat-markdown rounded-lg border border-[var(--color-border)] px-3 py-2";
+        "prose prose-sm max-w-none rounded-lg border border-[var(--color-border)] px-3 py-2";
       messages.appendChild(assistantBubble);
       assistantRawText = "";
     }
@@ -116,16 +180,17 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
 
     const wasNearBottom = isNearBottom(messages);
     const details = document.createElement("details");
-    details.className =
-      "tool-call rounded-lg border border-[var(--color-border)] px-3 py-2 text-xs";
+    details.className = "rounded-lg border border-[var(--color-border)] px-3 py-2 text-xs";
     const summary = document.createElement("summary");
-    summary.className = "mono cursor-pointer text-[var(--color-muted)]";
+    summary.className = "mono list-none cursor-pointer text-[var(--color-muted)]";
     summary.textContent = `▶ ${toolName}`;
     const argsEl = document.createElement("pre");
-    argsEl.className = "mono mt-2 whitespace-pre-wrap break-all text-[var(--color-muted)]";
+    argsEl.className =
+      "mono mt-2 max-h-[260px] overflow-auto whitespace-pre-wrap break-all text-[var(--color-muted)]";
     argsEl.textContent = JSON.stringify(args, null, 2);
     const resultEl = document.createElement("pre");
-    resultEl.className = "mono mt-2 hidden whitespace-pre-wrap break-all text-[var(--color-muted)]";
+    resultEl.className =
+      "mono mt-2 hidden max-h-[260px] overflow-auto whitespace-pre-wrap break-all text-[var(--color-muted)]";
     details.append(summary, argsEl, resultEl);
     messages.appendChild(details);
     scrollToBottomIfNear(wasNearBottom);
@@ -141,7 +206,142 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
     queueBadge.textContent = total > 0 ? `${total} queued` : "";
   }
 
+  // --- status bar ---
+
+  function renderState(state: PiSessionState) {
+    statModel.textContent = `model ${state.model?.id ?? "—"}`;
+    statThinking.textContent = `thinking ${state.thinkingLevel}`;
+    autoCompactionToggle.checked = state.autoCompactionEnabled;
+  }
+
+  function renderStats(stats: SessionStats) {
+    const pct = stats.contextUsage ? `${Math.round(stats.contextUsage.percent)}%` : "—";
+    statContext.textContent = `ctx ${pct}`;
+    statCost.textContent = formatCost(stats.cost);
+  }
+
+  async function refreshStatus() {
+    try {
+      const [state, stats] = await Promise.all([
+        api.getAgentState(agentId),
+        api.getAgentStats(agentId),
+      ]);
+      renderState(state);
+      renderStats(stats);
+    } catch {
+      // Best-effort — the status bar just stays at its last known values.
+    }
+  }
+
+  function renderModelList(models: PiModel[]) {
+    modelList.replaceChildren();
+    for (const model of models) {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = MENU_ITEM_CLASS;
+      item.textContent = model.id;
+      item.addEventListener("click", () => {
+        send({ type: "setModel", provider: model.api, modelId: model.id });
+        modelPopover.open = false;
+      });
+      modelList.appendChild(item);
+    }
+  }
+
+  function renderThinkingList() {
+    thinkingList.replaceChildren();
+    for (const level of THINKING_LEVELS) {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = MENU_ITEM_CLASS;
+      item.textContent = level;
+      item.addEventListener("click", () => {
+        send({ type: "setThinkingLevel", level });
+        thinkingPopover.open = false;
+      });
+      thinkingList.appendChild(item);
+    }
+  }
+
+  function renderForkList(forkPoints: ForkPoint[]) {
+    forkList.replaceChildren();
+    if (forkPoints.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "px-2 py-1 text-[var(--color-muted)]";
+      empty.textContent = "No fork points yet.";
+      forkList.appendChild(empty);
+      return;
+    }
+    for (const point of forkPoints) {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = `${MENU_ITEM_CLASS} truncate`;
+      item.title = point.text;
+      item.textContent = point.text.slice(0, 60) || point.entryId;
+      item.addEventListener("click", () => {
+        send({ type: "fork", entryId: point.entryId });
+        sessionMenu.open = false;
+      });
+      forkList.appendChild(item);
+    }
+  }
+
+  modelPopover.addEventListener("toggle", () => {
+    if (!modelPopover.open) return;
+    void api.getAgentModels(agentId).then((r) => renderModelList(r.models));
+  });
+  thinkingPopover.addEventListener("toggle", () => {
+    if (thinkingPopover.open) renderThinkingList();
+  });
+  forkSubmenu.addEventListener("toggle", () => {
+    if (!forkSubmenu.open) return;
+    void api.getAgentForkPoints(agentId).then((r) => renderForkList(r.forkPoints));
+  });
+
+  autoCompactionToggle.addEventListener("change", () => {
+    send({ type: "setAutoCompaction", enabled: autoCompactionToggle.checked });
+  });
+  compactNowBtn.addEventListener("click", () => {
+    send({ type: "compact" });
+    contextPopover.open = false;
+  });
+  autoRetryToggle.addEventListener("change", () => {
+    send({ type: "setAutoRetry", enabled: autoRetryToggle.checked });
+  });
+
+  sessionNewBtn.addEventListener("click", () => {
+    send({ type: "newSession" });
+    sessionMenu.open = false;
+  });
+  sessionCloneBtn.addEventListener("click", () => {
+    send({ type: "clone" });
+    sessionMenu.open = false;
+  });
+  sessionExportBtn.addEventListener("click", () => {
+    send({ type: "exportHtml" });
+  });
+  sessionRenameForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const name = sessionRenameInput.value.trim();
+    if (!name) return;
+    send({ type: "setSessionName", name });
+    sessionRenameInput.value = "";
+    sessionMenu.open = false;
+  });
+  sessionSwitchForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const path = sessionSwitchInput.value.trim();
+    if (!path) return;
+    send({ type: "switchSession", path });
+    sessionSwitchInput.value = "";
+    sessionMenu.open = false;
+  });
+
   const ws = new WebSocket(wsUrl(`/ws/agents/${agentId}/chat`));
+
+  ws.addEventListener("open", () => {
+    void refreshStatus();
+  });
 
   ws.addEventListener("message", (ev) => {
     if (typeof ev.data !== "string") return;
@@ -154,6 +354,7 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
       }
       case "agent_end": {
         setStreaming(false);
+        void refreshStatus();
         break;
       }
       case "text": {
@@ -178,9 +379,10 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
         break;
       }
       case "auto_retry_start": {
-        addBubble(
-          "system",
+        addSystemNoteWithAction(
           `Retrying (attempt ${event.attempt}/${event.maxAttempts})… ${event.errorMessage}`,
+          "Cancel",
+          () => send({ type: "abortRetry" }),
         );
         break;
       }
@@ -204,6 +406,7 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
             `Context compacted (${event.result.tokensBefore} → ${event.result.estimatedTokensAfter} tokens)`,
           );
         }
+        void refreshStatus();
         break;
       }
       case "extension_error": {
@@ -218,6 +421,14 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
       }
       case "queue_update": {
         setQueueBadge(event.steering.length, event.followUp.length);
+        break;
+      }
+      case "command_result": {
+        if (event.command === "exportHtml" && event.result) {
+          const { path } = event.result as { path: string };
+          window.open(api.agentExportUrl(agentId, path), "_blank");
+        }
+        void refreshStatus();
         break;
       }
       case "bridge_error": {
@@ -235,7 +446,7 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
     const text = input.value.trim();
     if (!text) return;
     addBubble("you", text);
-    ws.send(JSON.stringify({ type: streaming ? "followUp" : "prompt", text }));
+    send({ type: streaming ? "followUp" : "prompt", text });
     input.value = "";
     if (!streaming) setStreaming(true);
   });
@@ -244,12 +455,12 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
     const text = input.value.trim();
     if (!text) return;
     addBubble("you", `(steer) ${text}`);
-    ws.send(JSON.stringify({ type: "steer", text }));
+    send({ type: "steer", text });
     input.value = "";
   });
 
   abortBtn.addEventListener("click", () => {
-    ws.send(JSON.stringify({ type: "abort" }));
+    send({ type: "abort" });
   });
 
   return {

--- a/apps/sandbox/src/scripts/api.ts
+++ b/apps/sandbox/src/scripts/api.ts
@@ -14,6 +14,14 @@ export interface FileEntry {
   size: number;
 }
 
+import type { PiModel, PiSessionState, SessionStats } from "@drej/agent";
+export type { PiModel, PiSessionState, SessionStats, ThinkingLevel } from "@drej/agent";
+
+export interface ForkPoint {
+  entryId: string;
+  text: string;
+}
+
 /**
  * Base URL for the API/WS backend. Empty string means same-origin (local dev,
  * where the Bun backend serves both the API and the built frontend). Set to
@@ -76,6 +84,14 @@ export const api = {
     }),
   deleteAgent: (id: string) => request<void>(`/api/agents/${id}`, { method: "DELETE" }),
   getMessages: (id: string) => request<{ messages: unknown[] }>(`/api/agents/${id}/messages`),
+
+  getAgentState: (id: string) => request<PiSessionState>(`/api/agents/${id}/state`),
+  getAgentStats: (id: string) => request<SessionStats>(`/api/agents/${id}/stats`),
+  getAgentModels: (id: string) => request<{ models: PiModel[] }>(`/api/agents/${id}/models`),
+  getAgentForkPoints: (id: string) =>
+    request<{ forkPoints: ForkPoint[] }>(`/api/agents/${id}/fork-points`),
+  agentExportUrl: (id: string, path: string) =>
+    `${API_BASE}/api/agents/${id}/export?path=${encodeURIComponent(path)}`,
 };
 
 export function wsUrl(path: string): string {

--- a/apps/sandbox/src/styles/global.css
+++ b/apps/sandbox/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "@xterm/xterm/css/xterm.css";
+@plugin "@tailwindcss/typography";
 
 /*
  * Tailwind emits its own rules inside `@layer theme, base, components, utilities`.
@@ -110,6 +111,52 @@
 
 @utility mono {
   font-family: var(--font-mono);
+}
+
+@utility spec-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 1.9rem;
+  background-repeat: no-repeat;
+  background-position: right 0.6rem center;
+  background-size: 0.65rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23767680' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+@layer components {
+  .spec-select:hover {
+    border-color: var(--color-accent);
+  }
+  .spec-select:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px oklch(0.5 0.26 292 / 15%);
+  }
+
+  /* Align typography plugin's prose vars to the site's own tokens instead of its default gray scale. */
+  .prose {
+    --tw-prose-body: var(--color-fg);
+    --tw-prose-headings: var(--color-fg);
+    --tw-prose-links: var(--color-accent);
+    --tw-prose-bold: var(--color-fg);
+    --tw-prose-bullets: var(--color-muted);
+    --tw-prose-hr: var(--color-border);
+    --tw-prose-quotes: var(--color-muted);
+    --tw-prose-quote-borders: var(--color-border);
+    --tw-prose-code: var(--color-fg);
+    --tw-prose-pre-code: var(--color-fg);
+    --tw-prose-pre-bg: var(--color-bg);
+    --tw-prose-th-borders: var(--color-border);
+    --tw-prose-td-borders: var(--color-border);
+  }
+  .prose :where(code):not(:where([class~="not-prose"] *))::before,
+  .prose :where(code):not(:where([class~="not-prose"] *))::after {
+    content: "";
+  }
+  .prose :where(pre):not(:where([class~="not-prose"] *)) {
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+  }
 }
 
 .xterm {

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
+        "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.2",
         "bun-types": "1.3.14",
         "tailwindcss": "^4.3.2",
@@ -1123,6 +1124,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.1", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "postcss": "8.5.15", "tailwindcss": "4.3.1" } }, "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A=="],
 
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.20", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders" } }, "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw=="],
+
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
@@ -1472,6 +1475,8 @@
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
@@ -2382,6 +2387,8 @@
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -6,6 +6,7 @@ import type {
   CompactResult,
   PiMessage,
   PiModel,
+  PiSessionState,
   PiSlashCommand,
   SessionStats,
   ThinkingLevel,
@@ -362,6 +363,7 @@ http.createServer(function(req, res) {
     if (req.url === "/logs")   { res.writeHead(200, { "Content-Type": "text/plain" }); res.end(logBuf.join("\\n")); return; }
     if (req.url === "/messages") { rpcWithAck({ id: "gm" + Date.now(), type: "get_messages" }, res); return; }
     if (req.url === "/available-models") { rpcWithAck({ id: "gam" + Date.now(), type: "get_available_models" }, res); return; }
+    if (req.url === "/state") { rpcWithAck({ id: "gs" + Date.now(), type: "get_state" }, res); return; }
     res.writeHead(404); res.end();
     return;
   }
@@ -744,6 +746,10 @@ export class PiAdapter {
   async getAvailableModels(): Promise<PiModel[]> {
     const data = await rpcGet<{ models: PiModel[] }>(this.bridgeUrl, "/available-models");
     return data.models;
+  }
+
+  async getState(): Promise<PiSessionState> {
+    return rpcGet<PiSessionState>(this.bridgeUrl, "/state");
   }
 
   // --- misc ---

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -14,6 +14,7 @@ import type {
   CompactResult,
   PiMessage,
   PiModel,
+  PiSessionState,
   PiSlashCommand,
   SessionStats,
   ThinkingLevel,
@@ -441,6 +442,15 @@ export class Agent {
   /** List all models available to Pi under the current provider configuration. */
   async getAvailableModels(): Promise<PiModel[]> {
     return this._adapter.getAvailableModels();
+  }
+
+  /**
+   * Retrieve Pi's current session state: active model, thinking level, streaming/compaction
+   * status, queue modes, and session identity. The only piece of Pi's RPC surface with no
+   * other way to observe the *current* model or thinking level (as opposed to the full list).
+   */
+  async getState(): Promise<PiSessionState> {
+    return this._adapter.getState();
   }
 
   // --- env & lifecycle ---

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,6 +11,7 @@ export type {
   CompactResult,
   SessionStats,
   PiSlashCommand,
+  PiSessionState,
 } from "./types";
 export { textOnly } from "./types";
 export type { AgentSnapshotRecord } from "./snapshots";

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -160,3 +160,19 @@ export interface PiSlashCommand {
   source: "extension" | "prompt" | "skill";
   sourceInfo: unknown;
 }
+
+/** Pi's current session state, as returned by `agent.getState()`. */
+export interface PiSessionState {
+  model?: PiModel;
+  thinkingLevel: ThinkingLevel;
+  isStreaming: boolean;
+  isCompacting: boolean;
+  steeringMode: "all" | "one-at-a-time";
+  followUpMode: "all" | "one-at-a-time";
+  sessionFile?: string;
+  sessionId: string;
+  sessionName?: string;
+  autoCompactionEnabled: boolean;
+  messageCount: number;
+  pendingMessageCount: number;
+}


### PR DESCRIPTION
## Summary

Implements `plans/agent-controls.md`. `@drej/agent`'s `Agent` class already wraps nearly all of Pi's RPC surface, but the sandbox dashboard only exercised `prompt`/`steer`/`followUp`/`abort` — session management, model switching, forking, and live stats were completely invisible.

Explicit design constraint: not a button per method. Three composable pieces:

- **Status bar** above the chat transcript — `model · thinking level · context% · cost`, read-only by default, but each stat is also a click target opening a small popover (switch model, set thinking level, compact-now/auto-compaction toggle).
- **One "Session" menu** (`<details>`-based, same idiom as the tool-call bubbles from #116) consolidating New Session, Rename, Clone, Fork (lazy submenu from `getForkMessages()`), Switch Session, Export HTML, and the auto-retry toggle — one entry point instead of eight buttons.
- **Retry cancel** folded into the existing `auto_retry_start` system note as an inline link, no new persistent control.

### `packages/agent`

Adds `Agent.getState()`, wrapping Pi's `get_state` RPC command — confirmed via Pi's own docs that this was the *only* RPC command with no existing wrapper (needed to show the current model/thinking level, as opposed to the full list `getAvailableModels()` returns). Changeset added (`minor`, additive).

### `apps/sandbox` backend

- `ws/chat.ts`'s `ChatCommand` union grows 14 cases for one-shot mutations, following the existing `steer`/`followUp`/`abort` ack-only pattern. Commands whose `Agent` method returns data are echoed back as `{ type: "command_result", command, result }` so the UI updates without a separate fetch.
- 3 new GET routes (`/state`, `/stats`, `/models`, `/fork-points`) for pure data lookups that populate popovers on open, plus `/export?path=` to download `exportHtml()`'s output.

### `apps/sandbox` frontend

All new UI is Tailwind utility classes — no new scoped `<style>` blocks. As a drive-by consistency fix (same files already being touched), retrofit the two scoped-CSS blocks from #116/#118:
- `Dashboard.astro`'s `.spec-select` → a `@utility` in `global.css` (Tailwind v4's own extension mechanism, same pattern as the existing `.btn`/`.card`).
- `AgentPanel.astro`'s `.chat-markdown` → `@tailwindcss/typography`'s `prose` class, with `--tw-prose-*` variables pointed at the site's own color tokens instead of hand-rolled descendant selectors.

## Test plan

- [x] `bun run build` (all workspace packages + `apps/sandbox` astro build) — clean
- [x] `bun run typecheck` (root, all packages incl. `packages/agent`) + `apps/sandbox`'s own typecheck — clean
- [x] `bun run test` — all 4 test suites pass (94 tests)
- [x] `oxlint`/`oxfmt --check` — clean
- [x] Confirmed compiled CSS bundle includes `prose`/`--tw-prose-*`/`spec-select` output
- [ ] Manual browser verification against a live agent — not run this session (no local `GEMINI_API_KEY`/OpenSandbox instance); user has said they'll test manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)