### PR TITLE
feat(cli): pi extension bootstraps drejx and injects RLM guidance dynamically

### DIFF
--- a/.changeset/pi-extension-rlm-flow.md
+++ b/.changeset/pi-extension-rlm-flow.md
@@ -1,0 +1,14 @@
+---
+"drejx": minor
+---
+
+Adds `drejx --version`/`-v`/`version`.
+
+`packages/cli/package.json` now declares a `"pi": { "extensions": [...] }` manifest, so `pi install npm:drejx` resolves `pi-extension/drejx.ts` as the extension entry point (Pi's own package manager reads this field — see `resolveExtensionEntries()` in `@earendil-works/pi-coding-agent`'s `package-manager.js`). This is the intended host-level install path: `pi install npm:drejx` puts the extension at Pi's user/global scope, available in every session afterward, rather than the project-local copy `examples/rlm-repo-fanout` still uses today.
+
+The Pi extension itself (`packages/cli/pi-extension/drejx.ts`) gained:
+- A `session_start` handler that bootstraps `drejx` (installs it via npm, runs `drejx init`) so a user never has to do either step manually — this extension is meant to be the whole distribution/setup path, not just a tool-wrapper.
+- A `before_agent_start` handler that injects `drejx` CLI usage guidance into the system prompt every turn — different guidance depending on whether the current session is itself running inside a drej-managed sandbox (`DREJ_SANDBOX_ID` set, so `drejx fork` is meaningful) or is a host-level session (only `drejx spawn` makes sense). Deliberately dynamic per-turn rather than a static prompt blob baked into one spec.
+- An opt-in RLM-orchestrator mindset prompt, gated on a spec setting `DREJX_RLM_MASTER` in its own `env` (so ordinary one-off coding sessions aren't told "you are an orchestrator" unconditionally), with `DREJX_RLM_SYSTEM_PROMPT` as a full override for specs wanting their own wording.
+
+Adds `examples/rlm-master` — a reusable, non-task-specific RLM master spec, in contrast to `examples/rlm-repo-fanout`'s README-backfill-specific one.

--- a/examples/rlm-master/README.md
+++ b/examples/rlm-master/README.md
@@ -1,0 +1,66 @@
+# rlm-master
+
+A reusable RLM orchestrator master — unlike `examples/rlm-repo-fanout`, this
+isn't tied to any one task. It's meant to be started from a real, interactive
+Pi session (hop 1 of the two-hop flow in
+`plans/pi-extension-rlm-flow.md`), not a hand-written script, and given
+whatever goal you actually want done.
+
+## Setup
+
+Install the drejx Pi extension on your host machine once:
+
+```bash
+pi install npm:drejx
+```
+
+This installs at **user** scope (`~/.pi/agent/extensions`), so it's
+available in every Pi session afterward — the extension itself bootstraps
+`drejx` (installs it, runs `drejx init`) the first time a session starts, so
+there's no separate manual setup step.
+
+Needs `NVIDIA_API_KEY` in your environment (or whichever provider your own
+copy of `agents/master.json` is configured for).
+
+## Run
+
+From your own Pi session:
+
+```
+> use drejx to spawn ./examples/rlm-master/agents/master.json and give it this goal: <your actual goal>
+```
+
+Pi already knows the `drejx spawn` syntax (injected by the extension — see
+`SPAWN_ONLY_GUIDANCE` in `packages/cli/pi-extension/drejx.ts`), so this
+doesn't need to be a literal command; describing the goal is enough for a
+model to write the right `drejx spawn ./examples/rlm-master/agents/master.json
+--prompt "<goal>" --json` call itself.
+
+The master's own sandbox also has the extension installed (baked in by a
+setup step), so once it's running, it has `drejx fork` guidance injected the
+same way — see `FORK_GUIDANCE` in the same file. It decides for itself
+whether the goal is worth decomposing; nothing forces it to fork anything.
+
+## Customizing the master's mindset
+
+The master's system prompt gets an RLM-orchestrator mindset appended
+automatically (`DREJX_RLM_MASTER: "1"` in its `env` — see
+`DEFAULT_RLM_MINDSET` in the extension). To use your own wording instead, set
+`DREJX_RLM_SYSTEM_PROMPT` before spawning:
+
+```bash
+export DREJX_RLM_SYSTEM_PROMPT="Your own custom orchestrator instructions..."
+```
+
+## What's still a placeholder
+
+- **Context gathering isn't wired up yet.** Per `plans/pi-extension-rlm-flow.md`'s
+  open questions, dynamically injecting "spawn an explorer first" guidance
+  based on a user-supplied hint (rather than the master figuring it out
+  entirely on its own) hasn't been built.
+- **`--max`'s ceiling is per-lineage only** (this master sets `"maxAgents": 10`
+  as a starting default) — not coordinated across sibling branches spawned
+  in parallel. See the plan's open question 3.
+- **Live-verify before trusting this for anything real.** This has not yet
+  had the same live-run debugging pass `examples/rlm-repo-fanout` went
+  through — treat it as a first cut, not a proven path.

--- a/examples/rlm-master/agents/master.json
+++ b/examples/rlm-master/agents/master.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://registry.drej.dev/spec/agent.json",
+  "name": "rlm-master",
+  "title": "RLM Master (generic)",
+  "description": "Reusable RLM orchestrator master. Not tied to any one task — spawn it with `drejx spawn ./agents/master.json --prompt \"<any goal>\"` and it decides for itself whether the goal is worth decomposing, using drejx fork to spin up children from its own live state if so.",
+  "author": "drej",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nvidia-nemotron-nano-9b-v2",
+  "packages": ["git"],
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}",
+    "MASTER_AGENT_OPENSANDBOX_DOMAIN": "${MASTER_AGENT_OPENSANDBOX_DOMAIN}",
+    "DREJX_RLM_MASTER": "1",
+    "DREJX_RLM_SYSTEM_PROMPT": "${DREJX_RLM_SYSTEM_PROMPT}"
+  },
+  "spawnDepth": 2,
+  "maxAgents": 10,
+  "resources": { "cpu": "1000m", "memory": "2Gi" },
+  "setup": [
+    {
+      "name": "Install bun (drejx's own shebang requires it)",
+      "run": "curl -fsSL https://bun.sh/install | bash && ln -sf /root/.bun/bin/bun /usr/local/bin/bun"
+    },
+    { "name": "Install drejx", "run": "npm install -g drejx" },
+    {
+      "name": "Configure drejx",
+      "run": "mkdir -p .drej && printf '{\"serverUrl\":\"http://%s\",\"useServerProxy\":false,\"apiKey\":\"\",\"adapterPath\":\"./.drej/ledger.db\",\"agentsDir\":\"./agents\",\"defaults\":{\"resources\":{\"cpu\":\"500m\",\"memory\":\"1Gi\"}}}' \"$MASTER_AGENT_OPENSANDBOX_DOMAIN\" > drej.config.json"
+    },
+    {
+      "name": "Enable the drejx Pi extension (dynamic drejx fork guidance, no hardcoded task syntax)",
+      "run": "mkdir -p .pi/extensions && cp \"$(npm root -g)/drejx/pi-extension/drejx.ts\" .pi/extensions/drejx.ts"
+    },
+    {
+      "name": "Add the default worker spec",
+      "run": "mkdir -p agents && printf '{\"name\":\"rlm-worker\",\"cli\":\"pi\",\"provider\":\"nvidia\",\"model\":\"nvidia/nemotron-3-nano-30b-a3b\",\"env\":{\"NVIDIA_API_KEY\":\"%s\"},\"resources\":{\"cpu\":\"500m\",\"memory\":\"1Gi\"}}' \"$NVIDIA_API_KEY\" > agents/worker.json"
+    }
+  ]
+}

--- a/examples/rlm-master/agents/worker.json
+++ b/examples/rlm-master/agents/worker.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://registry.drej.dev/spec/agent.json",
+  "name": "rlm-worker",
+  "title": "RLM Worker (generic)",
+  "description": "Generic child spec for `drejx fork`. No drejx install, no drej.config.json, no spawnDepth: it can never itself call back into drejx, and Agent.spawn() force-sets its DREJX_SPAWN_DEPTH to 0 regardless of what's here — a structural guarantee, not a convention.",
+  "author": "drej",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}"
+  },
+  "resources": { "cpu": "500m", "memory": "1Gi" }
+}

--- a/examples/rlm-repo-fanout/agents/worker.json
+++ b/examples/rlm-repo-fanout/agents/worker.json
@@ -2,7 +2,7 @@
   "$schema": "https://registry.drej.dev/spec/agent.json",
   "name": "rlm-fanout-worker",
   "title": "RLM Fan-out Worker",
-  "description": "A child spec run via `drejx spawn` — never installed directly. No drejx install, no drej.config.json, no spawnDepth: it never calls back into drejx and Agent.spawn() force-sets its DREJX_SPAWN_DEPTH to 0 regardless of what's here.",
+  "description": "A child spec run via `drejx fork` — never installed directly. No drejx install, no drej.config.json, no spawnDepth: it never calls back into drejx and Agent.spawn() force-sets its DREJX_SPAWN_DEPTH to 0 regardless of what's here.",
   "author": "drej",
   "cli": "pi",
   "provider": "nvidia",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,10 @@
     "tsdown": "0.22.3",
     "typebox": "^1.3.5",
     "typescript": "6.0.3"
+  },
+  "pi": {
+    "extensions": [
+      "./pi-extension/drejx.ts"
+    ]
   }
 }

--- a/packages/cli/pi-extension/drejx.ts
+++ b/packages/cli/pi-extension/drejx.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ExecResult } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
 /**
@@ -13,11 +13,53 @@ import { Type } from "typebox";
  * a task, expressed as an actual shell command it writes and runs via its
  * bash tool — not a verbal decision to call a fixed-shape registered tool.
  *
- * Install into a sandbox via a spec's setup steps:
+ * Install on a host machine (recommended — makes this available in every Pi
+ * session afterward, not just one project):
+ *   pi install npm:drejx
+ *
+ * `packages/cli/package.json`'s `"pi": { "extensions": [...] }` field is what
+ * makes that resolve to this file (see `resolveExtensionEntries()` in Pi's
+ * own `package-manager.js`).
+ *
+ * Install into a single sandbox via a spec's setup steps instead (what
+ * `examples/rlm-repo-fanout` does today, project-scoped):
  *   npm install -g drejx
  *   mkdir -p .pi/extensions && cp "$(npm root -g)/drejx/pi-extension/drejx.ts" .pi/extensions/drejx.ts
  */
 export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    await ensureDrejxReady(pi, ctx);
+  });
+
+  // `DREJ_SANDBOX_ID` is only set inside a sandbox created by an agent-creation
+  // path (Agent.load()/resume()/spawn(), see packages/agent/src/agent.ts) — its
+  // presence here means THIS Pi process is itself running inside one, so it has
+  // live state (installed packages, a checked-out repo, files on disk) worth
+  // forking into children via `drejx fork`. A host-level session (a user's own
+  // local Pi, no sandbox of its own) has nothing to fork — only `drejx spawn`
+  // (start a fresh, independent agent) makes sense there.
+  const canFork = Boolean(process.env.DREJ_SANDBOX_ID);
+
+  // Mechanical CLI guidance (above) is safe to inject unconditionally — it's
+  // just "here's the syntax," true for any session. The RLM *mindset* prompt
+  // below is opt-in: a one-off coding session shouldn't be told "you are an
+  // orchestrator" unconditionally, only a spec deliberately built to act as
+  // one. Gated on DREJX_RLM_MASTER (set in that spec's own `env`), with
+  // DREJX_RLM_SYSTEM_PROMPT as a full override for specs that want their own
+  // wording instead of the default — same ${VAR}-interpolation pattern every
+  // other agent-spec env value already uses (see
+  // examples/rlm-repo-fanout/agents/master.json's RLM_FANOUT_SECRET/
+  // MASTER_AGENT_OPENSANDBOX_DOMAIN for the existing precedent).
+  const rlmMindset = process.env.DREJX_RLM_SYSTEM_PROMPT
+    ? `\n\n${process.env.DREJX_RLM_SYSTEM_PROMPT}`
+    : process.env.DREJX_RLM_MASTER
+      ? DEFAULT_RLM_MINDSET
+      : "";
+
+  pi.on("before_agent_start", (event) => ({
+    systemPrompt: event.systemPrompt + (canFork ? FORK_GUIDANCE : SPAWN_ONLY_GUIDANCE) + rlmMindset,
+  }));
+
   pi.registerTool({
     name: "drejx_spawn",
     label: "Start a drejx agent session",
@@ -90,4 +132,118 @@ export default function (pi: ExtensionAPI) {
       return { content: [{ type: "text", text: res.stdout }], details: {} };
     },
   });
+}
+
+const FORK_GUIDANCE = `
+
+## Orchestrating sub-agents with drejx
+
+You have the \`drejx\` CLI available. Your own session is running inside a
+drej-managed sandbox, so you can fork YOUR OWN live filesystem state
+(installed packages, a checked-out repo, any files already on disk) into
+independent child agents:
+
+    drejx fork <your-session-name> <child-spec.json> --prompt "<plain-English instruction>" --json
+
+Each forked child starts from your exact current state, not a fresh clone —
+use this when children need to see something you've already set up. Run this
+as an actual shell command via your bash tool, not by describing it — you
+decide how many children to fork and how to split the work; nothing scripts
+that decision for you. Add \`--depth N\` / \`--max N\` to override a spec's own
+nesting-depth or total-descendant budget if it has one.
+
+To start a completely independent agent instead (no shared state needed):
+\`drejx spawn <spec.json> --prompt "<msg>" --json\`. Other commands:
+\`drejx agents [--json]\` (list running sessions), \`drejx prompt <sandbox-id>
+<msg>\` (continue talking to one), \`drejx kill <sandbox-id>\` (stop one).
+
+Only reach for forking when a task genuinely splits into independent pieces
+of real size — for something you can finish yourself in a few tool calls,
+just do it directly.`;
+
+const SPAWN_ONLY_GUIDANCE = `
+
+## Starting sub-agents with drejx
+
+You have the \`drejx\` CLI available to start independent agent sessions in
+their own sandboxes:
+
+    drejx spawn <spec.json> --prompt "<msg>" --json
+
+Other commands: \`drejx agents [--json]\` (list running sessions), \`drejx
+prompt <sandbox-id> <msg>\` (continue talking to one), \`drejx kill
+<sandbox-id>\` (stop one). A spawned agent running inside its own sandbox may
+itself be able to fork further sub-agents from its own live state via
+\`drejx fork\` — that's its own decision to make, not yours to script for it.`;
+
+const DEFAULT_RLM_MINDSET = `
+
+## Your role: RLM orchestrator
+
+Think in terms of decompose, delegate, and collect. When a task is large
+enough to genuinely split into independent pieces, prefer forking dedicated
+sub-agents over doing everything yourself in one long session — each
+sub-agent should get a clear, bounded slice of the work and report back a
+concise result, not its full transcript. Keep your own context focused on
+decomposition and integration, not on redoing what a child already did. For
+small or genuinely atomic tasks, just do the work yourself — decomposition
+should reflect the task's real shape, not be forced on something that
+doesn't need it.`;
+
+// Runs once per extension load, not once per `session_start` — that event
+// also fires on reload/new/resume/fork, and `drejx init` (while itself
+// idempotent) has a few seconds of Docker-state-check overhead not worth
+// repeating every time. Reset on failure so a later session_start can retry
+// instead of a transient failure (no network, Docker not running yet)
+// permanently wedging bootstrap for the rest of the process.
+let bootstrapped = false;
+
+async function execOk(
+  pi: ExtensionAPI,
+  command: string,
+  args: string[],
+): Promise<ExecResult | null> {
+  try {
+    return await pi.exec(command, args);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensures `drejx` is installed and OpenSandbox is reachable, so the user
+ * never has to run either setup step themselves — this extension is meant
+ * to be the entire distribution/setup path. `drejx init` already no-ops
+ * cleanly when OpenSandbox is already running (see `packages/cli/src/commands/init.ts`),
+ * so it's safe to call unconditionally rather than trying to detect
+ * reachability here first.
+ */
+async function ensureDrejxReady(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  if (bootstrapped) return;
+  bootstrapped = true;
+
+  const check = await execOk(pi, "drejx", ["--version"]);
+  if (!check || check.code !== 0) {
+    ctx.ui.notify("Installing drejx...", "info");
+    const install = await execOk(pi, "npm", ["install", "-g", "drejx"]);
+    if (!install || install.code !== 0) {
+      ctx.ui.notify(
+        `Failed to install drejx: ${install?.stderr || "npm not available"}. ` +
+          `RLM flows won't work until this is resolved — install manually with "npm install -g drejx".`,
+        "error",
+      );
+      bootstrapped = false;
+      return;
+    }
+  }
+
+  const init = await execOk(pi, "drejx", ["init"]);
+  if (!init || init.code !== 0) {
+    ctx.ui.notify(
+      `"drejx init" failed: ${init?.stderr || "unknown error"}. ` +
+        `RLM flows won't work until OpenSandbox is reachable — see "drejx init" for manual setup.`,
+      "warning",
+    );
+    bootstrapped = false;
+  }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,13 @@ async function main(): Promise<void> {
   }
 
   switch (cmd) {
+    case "--version":
+    case "-v":
+    case "version": {
+      const { version } = await import("../package.json");
+      console.log(version);
+      break;
+    }
     case "init": {
       const { init } = await import("./commands/init.js");
       await init();
@@ -91,6 +98,7 @@ async function main(): Promise<void> {
       console.log(`drejx — drej agent registry CLI
 
   drejx                              Launch the interactive TUI (in a terminal)
+  drejx --version                   Print the installed version
 
 SDK — OpenSandbox config and the local spec cache:
   drejx init                        Start OpenSandbox locally via Docker


### PR DESCRIPTION
## Summary
- `packages/cli/package.json` declares a `"pi": { "extensions": [...] }` manifest, so `pi install npm:drejx` resolves the extension entry point — the intended host-level install path (Pi's user/global scope, available in every session) implementing hop 1 of `plans/pi-extension-rlm-flow.md`'s two-hop design.
- The extension bootstraps `drejx` itself on `session_start` (`npm install -g drejx`, `drejx init`) — no manual setup step for the user.
- New `before_agent_start` handler injects `drejx` CLI guidance into the system prompt every turn, dynamically choosing between "you can `drejx spawn`" (host-level) and "you can `drejx fork`" (already inside a drej sandbox, detected via `DREJ_SANDBOX_ID`) — not a static prompt blob.
- Opt-in RLM-orchestrator mindset prompt, gated on `DREJX_RLM_MASTER` in a spec's own `env`, with `DREJX_RLM_SYSTEM_PROMPT` as a full override.
- Adds `drejx --version`.
- Adds `examples/rlm-master` — a reusable, non-task-specific master spec (vs. `rlm-repo-fanout`'s README-backfill-specific one).
- Fixes a stale `drejx spawn` reference in `rlm-repo-fanout/agents/worker.json` missed during the earlier CLI rename.

## Test plan
- [x] `bunx tsc --noEmit --strict` clean on `packages/cli`
- [x] `bun test` clean (59 pass)
- [x] `bun run lint` clean
- [x] `bun run --cwd packages/cli build` succeeds
- [x] Live-verified via a real local Pi session with the extension loaded (`pi -e pi-extension/drejx.ts`): typed tool registration, both branches of the `before_agent_start` guidance injection (with/without `DREJ_SANDBOX_ID`), and the `DREJX_RLM_MASTER` mindset prompt all confirmed working correctly
- [ ] Full two-hop live run (host spawns master via `drejx spawn`, master forks real workers via `drejx fork`) — needs a published `drejx` release to test without local binary patching; deferred per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)