### PR TITLE
perf(opensandbox): stop waiting on exec/checkpoint hold-open delays

### DIFF
--- a/.changeset/quick-execs-nap.md
+++ b/.changeset/quick-execs-nap.md
@@ -1,0 +1,9 @@
+---
+"@drej/opensandbox": patch
+"@drej/core": patch
+"drej": patch
+---
+
+Cancel the exec/code SSE stream as soon as the terminal event (`execution_complete` or `error`) arrives instead of reading until the server closes the connection. execd holds the HTTP stream open for a fixed interval after sending its last event, so every `exec()`/`execCode()`/session command was paying that delay on top of the real round trip — this cuts steady-state exec latency from roughly 1 second to tens of milliseconds.
+
+Also switch the fixed-interval polling in `waitForRunning`, `waitForSnapshot`, and `resolveExecClient` to start fast and back off toward the original interval, instead of sleeping the full interval on every tick regardless of how quickly the real state change lands. Measured against a local OpenSandbox server, this cut checkpoint latency from ~2s to ~300-500ms.

--- a/bun.lock
+++ b/bun.lock
@@ -85,9 +85,17 @@
         "tailwindcss": "^4.3.2",
       },
     },
+    "examples/benchmark": {
+      "name": "drej-example-benchmark",
+      "version": "0.0.1",
+      "dependencies": {
+        "@drej/sqlite": "workspace:*",
+        "drej": "workspace:*",
+      },
+    },
     "examples/cancellation": {
       "name": "drej-example-cancellation",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -95,7 +103,7 @@
     },
     "examples/capture": {
       "name": "drej-example-capture",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -103,7 +111,7 @@
     },
     "examples/control-flow": {
       "name": "drej-example-control-flow",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "@drej/workflow": "workspace:*",
@@ -112,7 +120,7 @@
     },
     "examples/environments": {
       "name": "drej-example-environments",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -120,7 +128,7 @@
     },
     "examples/error-handling": {
       "name": "drej-example-error-handling",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -128,7 +136,7 @@
     },
     "examples/exec-code": {
       "name": "drej-example-exec-code",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -136,7 +144,7 @@
     },
     "examples/file-ops": {
       "name": "drej-example-file-ops",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -144,7 +152,7 @@
     },
     "examples/hello-world": {
       "name": "drej-example-hello-world",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -152,7 +160,7 @@
     },
     "examples/interactive-exec": {
       "name": "drej-example-interactive-exec",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -160,7 +168,7 @@
     },
     "examples/pi-agent": {
       "name": "drej-example-pi-agent",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/opensandbox": "workspace:*",
@@ -170,7 +178,7 @@
     },
     "examples/ports": {
       "name": "drej-example-ports",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -178,7 +186,7 @@
     },
     "examples/read-file": {
       "name": "drej-example-read-file",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -186,7 +194,7 @@
     },
     "examples/rlm-repo-fanout": {
       "name": "drej-example-rlm-repo-fanout",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -195,7 +203,7 @@
     },
     "examples/run-bash-script": {
       "name": "drej-example-run-bash-script",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -203,7 +211,7 @@
     },
     "examples/sandbox-extensions": {
       "name": "drej-example-sandbox-extensions",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -212,7 +220,7 @@
     },
     "examples/sandbox-fork": {
       "name": "drej-example-sandbox-fork",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -220,7 +228,7 @@
     },
     "examples/snapshot-replay": {
       "name": "drej-example-snapshot-replay",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/sqlite": "workspace:*",
         "drej": "workspace:*",
@@ -238,12 +246,12 @@
       },
       "peerDependencies": {
         "@flue/runtime": ">=1.0.0-beta",
-        "drej": ">=0.10.1",
+        "drej": ">=0.10.3",
       },
     },
     "packages/adapters/otel": {
       "name": "@drej/otel",
-      "version": "0.2.5",
+      "version": "0.2.7",
       "dependencies": {
         "@drej/core": "workspace:*",
       },
@@ -259,7 +267,7 @@
     },
     "packages/adapters/postgres": {
       "name": "@drej/postgres",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "dependencies": {
         "@drej/core": "workspace:*",
         "postgres": "3.4.9",
@@ -272,7 +280,7 @@
     },
     "packages/adapters/sqlite": {
       "name": "@drej/sqlite",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "dependencies": {
         "@drej/core": "workspace:*",
       },
@@ -284,7 +292,7 @@
     },
     "packages/agent": {
       "name": "@drej/agent",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "dependencies": {
         "@drej/core": "workspace:*",
         "drej": "workspace:*",
@@ -297,7 +305,7 @@
     },
     "packages/cli": {
       "name": "drejx",
-      "version": "0.6.0",
+      "version": "0.7.1",
       "bin": {
         "drejx": "./dist/index.mjs",
       },
@@ -318,7 +326,7 @@
     },
     "packages/core": {
       "name": "@drej/core",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "dependencies": {
         "@drej/opensandbox": "workspace:*",
       },
@@ -341,7 +349,7 @@
     },
     "packages/sdks/typescript": {
       "name": "drej",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "dependencies": {
         "@drej/core": "workspace:*",
         "@drej/opensandbox": "workspace:*",
@@ -355,7 +363,7 @@
     },
     "packages/workflow": {
       "name": "@drej/workflow",
-      "version": "1.1.6",
+      "version": "1.1.8",
       "dependencies": {
         "drej": "workspace:*",
       },
@@ -368,7 +376,7 @@
     },
     "tests/integration": {
       "name": "@drej/integration-tests",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "dependencies": {
         "@drej/agent": "workspace:*",
         "@drej/sqlite": "workspace:*",
@@ -1606,6 +1614,8 @@
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "drej": ["drej@workspace:packages/sdks/typescript"],
+
+    "drej-example-benchmark": ["drej-example-benchmark@workspace:examples/benchmark"],
 
     "drej-example-cancellation": ["drej-example-cancellation@workspace:examples/cancellation"],
 

--- a/examples/benchmark/index.ts
+++ b/examples/benchmark/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Times the sandbox substrate's cold-start and steady-state phases:
+ * provisioning (create → Running), first exec (execd readiness poll +
+ * round trip), warm exec (round trip only), and checkpoint.
+ *
+ * Usage: bun index.ts [iterations]
+ * Env: OPEN_SANDBOX_URL, OPEN_SANDBOX_API_KEY, USE_SERVER_PROXY, BENCH_IMAGE
+ */
+import { Drej } from "drej";
+import { SQLiteAdapter } from "@drej/sqlite";
+
+const client = new Drej({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter(":memory:"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
+});
+
+const iterations = Number(process.argv[2] ?? 5);
+const image = process.env.BENCH_IMAGE ?? "ubuntu:22.04";
+const cpu = process.env.BENCH_CPU ?? "500m";
+const memory = process.env.BENCH_MEMORY ?? "512Mi";
+
+interface Row {
+  provisionMs: number;
+  firstExecMs: number;
+  warmExecMs: number;
+  checkpointMs: number;
+}
+
+const rows: Row[] = [];
+
+for (let i = 0; i < iterations; i++) {
+  const t0 = performance.now();
+  const sb = await client.sandbox({
+    image,
+    resources: { cpu, memory },
+    name: `bench-${i}`,
+  });
+  const t1 = performance.now();
+
+  await sb.exec("true");
+  const t2 = performance.now();
+
+  await sb.exec("true");
+  const t3 = performance.now();
+
+  await sb.checkpoint();
+  const t4 = performance.now();
+
+  await sb.close();
+
+  const row: Row = {
+    provisionMs: t1 - t0,
+    firstExecMs: t2 - t1,
+    warmExecMs: t3 - t2,
+    checkpointMs: t4 - t3,
+  };
+  rows.push(row);
+
+  console.log(
+    `[${i + 1}/${iterations}] provision=${row.provisionMs.toFixed(0)}ms ` +
+      `first-exec=${row.firstExecMs.toFixed(0)}ms warm-exec=${row.warmExecMs.toFixed(0)}ms ` +
+      `checkpoint=${row.checkpointMs.toFixed(0)}ms`,
+  );
+}
+
+function stats(values: number[]): { min: number; max: number; avg: number } {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  return { min, max, avg };
+}
+
+console.log("\n--- summary ---");
+for (const key of ["provisionMs", "firstExecMs", "warmExecMs", "checkpointMs"] as const) {
+  const { min, max, avg } = stats(rows.map((r) => r[key]));
+  console.log(
+    `${key.replace("Ms", "")}: avg=${avg.toFixed(0)}ms min=${min.toFixed(0)}ms max=${max.toFixed(0)}ms`,
+  );
+}

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "drej-example-benchmark",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@drej/sqlite": "workspace:*",
+    "drej": "workspace:*"
+  }
+}

--- a/packages/core/src/sandbox/core.ts
+++ b/packages/core/src/sandbox/core.ts
@@ -108,6 +108,9 @@ export class SandboxCore implements SandboxInternal {
 
   async waitForRunning(timeoutMs = 120_000): Promise<void> {
     const deadline = Date.now() + timeoutMs;
+    // Starts fast and backs off to 1s — most containers are Running well under
+    // one fixed-interval tick, so a flat 1s poll was pure waste in the common case.
+    let delay = 100;
     while (Date.now() < deadline) {
       const s = await this.deps.control.getSandbox(this.sandboxId);
       if (s.status.state === SandboxState.Running) return;
@@ -117,20 +120,24 @@ export class SandboxCore implements SandboxInternal {
           this.sandboxId,
         );
       }
-      await new Promise<void>((r) => setTimeout(r, 1_000));
+      await new Promise<void>((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 1.5, 1_000);
     }
     throw new SandboxError(`Sandbox did not reach Running within ${timeoutMs}ms`, this.sandboxId);
   }
 
   async waitForSnapshot(snapshotId: string, timeoutMs = 120_000): Promise<void> {
     const deadline = Date.now() + timeoutMs;
+    // See waitForRunning — same rationale, capped at the original 2s interval.
+    let delay = 100;
     while (Date.now() < deadline) {
       const snap = await this.deps.control.getSnapshot(snapshotId);
       if (snap.state === SnapshotState.Ready) return;
       if (snap.state === SnapshotState.Failed) {
         throw new SandboxError(`Snapshot ${snapshotId} failed`, this.sandboxId);
       }
-      await new Promise<void>((r) => setTimeout(r, 2_000));
+      await new Promise<void>((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 1.5, 2_000);
     }
     throw new SandboxError(
       `Snapshot ${snapshotId} did not become ready within ${timeoutMs}ms`,

--- a/packages/core/src/sandbox/resolve.ts
+++ b/packages/core/src/sandbox/resolve.ts
@@ -18,13 +18,17 @@ export async function resolveExecClient(
   const baseUrl = ep.endpoint.startsWith("http") ? ep.endpoint : `http://${ep.endpoint}`;
   const token = ep.headers?.["X-EXECD-ACCESS-TOKEN"] ?? "";
   const client = new ExecClient({ baseUrl, accessToken: token });
+  // Starts fast and backs off to delayMs — execd is usually ready well under one
+  // fixed-interval tick, so a flat wait here was pure waste in the common case.
+  let delay = Math.min(100, delayMs);
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       await client.listContexts();
       return client;
     } catch {
       if (attempt === retries) throw new ExecConnectionError(sandboxId);
-      await new Promise<void>((r) => setTimeout(r, delayMs));
+      await new Promise<void>((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 1.5, delayMs);
     }
   }
   throw new Error("unreachable");

--- a/packages/opensandbox/src/exec.ts
+++ b/packages/opensandbox/src/exec.ts
@@ -13,7 +13,18 @@ import type {
   CreateSessionResponse,
 } from "./types";
 
-async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSEEvent> {
+/**
+ * `isTerminal` lets one-shot command/code streams cancel the underlying
+ * connection as soon as their terminal event arrives, instead of reading to
+ * EOF: execd holds the HTTP stream open for a fixed interval after the last
+ * event is sent (a server-side post-completion sleep), so waiting for `done`
+ * tacks that delay onto every exec. Long-lived streams (metrics watch) pass
+ * no predicate and read until the server actually closes the connection.
+ */
+async function* parseSSE(
+  stream: ReadableStream<Uint8Array>,
+  isTerminal?: (event: SSEEvent) => boolean,
+): AsyncGenerator<SSEEvent> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -28,12 +39,13 @@ async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSE
       for (const block of blocks) {
         const trimmed = block.trim();
         if (!trimmed) continue;
+        let event: SSEEvent | undefined;
         if (trimmed.startsWith("{")) {
           // execd sends raw JSON lines, not data:-prefixed SSE
           try {
-            yield JSON.parse(trimmed) as SSEEvent;
+            event = JSON.parse(trimmed) as SSEEvent;
           } catch {
-            /* skip malformed */
+            continue; // skip malformed
           }
         } else {
           let type: string | undefined;
@@ -43,14 +55,29 @@ async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<SSE
             else if (line.startsWith("data:")) data = line.slice(5).trim();
           }
           if (data !== undefined) {
-            yield { type: (type ?? SSEEventType.Message) as SSEEventType, ...JSON.parse(data) };
+            event = { type: (type ?? SSEEventType.Message) as SSEEventType, ...JSON.parse(data) };
           }
+        }
+        if (!event) continue;
+        yield event;
+        if (isTerminal?.(event)) {
+          // Deliberately don't reader.cancel() here — that aborts the connection
+          // immediately, and some server-side proxies (e.g. OpenSandbox's Python
+          // control server relaying execd's response via httpx) treat a mid-stream
+          // client abort as a broken upstream read and throw. Just stop reading:
+          // we resolve now either way, and the server closes the connection on
+          // its own terms shortly after (see the comment on parseSSE above).
+          return;
         }
       }
     }
   } finally {
     reader.releaseLock();
   }
+}
+
+function isExecTerminal(event: SSEEvent): boolean {
+  return event.type === SSEEventType.ExecutionComplete || event.type === SSEEventType.Error;
 }
 
 export class ExecClient {
@@ -95,6 +122,7 @@ export class ExecClient {
     method: string,
     path: string,
     body?: unknown,
+    isTerminal?: (event: SSEEvent) => boolean,
   ): AsyncGenerator<SSEEvent> {
     const res = await fetch(`${this.baseUrl}${path}`, {
       method,
@@ -110,7 +138,7 @@ export class ExecClient {
       throw new Error(text || `execd error ${res.status}`);
     }
     if (!res.body) return;
-    yield* parseSSE(res.body);
+    yield* parseSSE(res.body, isTerminal);
   }
 
   ping(): Promise<{ status: string }> {
@@ -136,7 +164,7 @@ export class ExecClient {
   }
 
   async *executeCode(options: ExecuteCodeOptions): AsyncGenerator<SSEEvent> {
-    yield* this.streamRequest("POST", "/code", options);
+    yield* this.streamRequest("POST", "/code", options, isExecTerminal);
   }
 
   interruptCode(): Promise<void> {
@@ -144,7 +172,7 @@ export class ExecClient {
   }
 
   async *executeCommand(options: ExecuteCommandOptions): AsyncGenerator<SSEEvent> {
-    yield* this.streamRequest("POST", "/command", options);
+    yield* this.streamRequest("POST", "/command", options, isExecTerminal);
   }
 
   interruptCommand(): Promise<void> {
@@ -253,7 +281,7 @@ export class ExecClient {
   }
 
   async *runInSession(sessionId: string, opts: RunInSessionRequest): AsyncGenerator<SSEEvent> {
-    yield* this.streamRequest("POST", `/session/${sessionId}/run`, opts);
+    yield* this.streamRequest("POST", `/session/${sessionId}/run`, opts, isExecTerminal);
   }
 
   deleteSession(sessionId: string): Promise<void> {

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -677,6 +677,9 @@ export class Drej {
 
   private async _waitForRunning(sandboxId: string, timeoutMs = 120_000): Promise<void> {
     const deadline = Date.now() + timeoutMs;
+    // Starts fast and backs off to 1s — most containers are Running well under
+    // one fixed-interval tick, so a flat 1s poll was pure waste in the common case.
+    let delay = 100;
     while (Date.now() < deadline) {
       const s = await this._control.getSandbox(sandboxId);
       if (s.status.state === SandboxState.Running) return;
@@ -686,7 +689,8 @@ export class Drej {
           500,
         );
       }
-      await new Promise<void>((r) => setTimeout(r, 1_000));
+      await new Promise<void>((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 1.5, 1_000);
     }
     throw new DrejError(`Sandbox ${sandboxId} did not reach Running within ${timeoutMs}ms`, 408);
   }


### PR DESCRIPTION
## Summary
- `execd` holds the `/command`/`/code` SSE stream open for a fixed interval after sending its terminal event (`execution_complete`/`error`); the client was reading to EOF instead of stopping there, costing every `exec()` call ~1s regardless of actual command duration. Now stops reading as soon as the terminal event arrives.
- `waitForRunning`/`waitForSnapshot`/`resolveExecClient` polled on a flat 1s/2s interval regardless of how fast the real state change landed; now start fast and back off toward the original interval.
- Adds `examples/benchmark` to measure the sandbox substrate's cold-start, exec, and checkpoint phases going forward.

## Numbers
Measured against a local OpenSandbox server (`uvx opensandbox-server`, Docker runtime), 5-iteration runs, before/after:

| Phase | Before | After |
|---|---|---|
| warm exec (round trip only) | ~1025ms avg | ~20ms avg |
| first exec (readiness + round trip) | ~1067ms avg | ~50ms avg |
| checkpoint | ~2049ms avg | ~400ms avg |
| provision (create→Running) | unchanged | unchanged (dominated by `createSandbox()` control-plane call, not polling) |

## Upstream note
The underlying execd behavior (`RunCommand` not terminating its chunked response the way `RunCode`/`RunInSession` do) is filed upstream: opensandbox-group/OpenSandbox#1277. We deliberately don't call `reader.cancel()` on early exit — an earlier version of this fix did, which triggered `httpx.RemoteProtocolError` on OpenSandbox's Python control-server proxy when relaying execd's response mid-stream. Just returning from the generator (no forced abort) avoids that while keeping the full latency win.

## Test plan
- [x] `bunx tsc --noEmit --strict` clean for `packages/core`, `packages/opensandbox`, `packages/sdks/typescript`
- [x] `vitest run` passing for `packages/core` (44 tests), `packages/opensandbox` (14 tests), `packages/sdks/typescript` (22 tests)
- [x] `oxlint`/`oxfmt` clean on changed files
- [x] Verified against a real local OpenSandbox server with both `useServerProxy: true` and `false`
- [x] Changeset added (`@drej/opensandbox`, `@drej/core`, `drej`, all patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)