### PR TITLE
Add alineo CLI usage telemetry

### DIFF
--- a/.changeset/add-alineo-cli-telemetry.md
+++ b/.changeset/add-alineo-cli-telemetry.md
@@ -1,0 +1,14 @@
+---
+"alineo-cli": minor
+---
+
+Add anonymous CLI usage telemetry: which subcommand ran, a small per-command allowlist of
+boolean flag presence (never values or raw argv), success/failure, timing, and — for
+`spawn`/`fork` only — the target spec's own `provider` id. Default-off for this release (no
+production endpoint deployed yet — flips on once one is), opt-out via
+`alineo telemetry disable`/`status`/`enable` or the `ALINEO_TELEMETRY_DISABLED`/`DO_NOT_TRACK`
+env vars either way. Transport is a plain, bounded (500ms timeout) `fetch()` POST to a new,
+completely standalone ingest app, `apps/telemetry` — no OpenTelemetry, no dependency on any
+other app in this repo, in either direction. Server-side re-validates every event against the
+same allowlisted shape (never trusts the client), with a body-size cap and a per-anonymous-ID
+rate limit on its one unauthenticated route.

--- a/apps/telemetry/config.ts
+++ b/apps/telemetry/config.ts
@@ -1,0 +1,14 @@
+/** Standalone by design -- this app has no dependency on apps/dashboard, apps/sandbox, or any
+ * other app in this repo, and vice versa. */
+export const PORT = Number(process.env.PORT ?? 3002);
+
+export const DB_PATH = process.env.TELEMETRY_DB_PATH ?? "./data/telemetry.db";
+
+/** Per-`anonymousId` sliding-window cap -- generous headroom above any real single CLI's actual
+ * invocation rate, while still bounding abuse of this unauthenticated, public endpoint. */
+export const RATE_LIMIT_MAX_REQUESTS = 30;
+export const RATE_LIMIT_WINDOW_MS = 60_000;
+
+/** A CliTelemetryEvent is a handful of short strings/booleans -- anything meaningfully larger
+ * than this is not a real event. */
+export const MAX_BODY_BYTES = 4096;

--- a/apps/telemetry/db.ts
+++ b/apps/telemetry/db.ts
@@ -1,0 +1,81 @@
+/**
+ * Storage for `alineo` CLI telemetry events -- deliberately plain `bun:sqlite`, not
+ * `@alineo-labs/sqlite`'s `IStorageAdapter`: that adapter's schema is shaped around the sandbox
+ * ledger (sandboxes/exec events/checkpoints), the wrong model for a flat analytics-events table.
+ * Mirrors how `apps/dashboard/server`'s own `workflows-db.ts`/`vault.ts` each spin up their own
+ * separate SQLite file/schema rather than forcing an unrelated concept into `IStorageAdapter`'s
+ * shape.
+ */
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { DB_PATH } from "./config";
+
+/** Intentionally duplicated from `packages/cli/src/telemetry.ts`'s identical interface rather
+ * than shared via a workspace package -- this app and `alineo` communicate purely over the
+ * `POST /v1/events` HTTP contract, with no runtime/deploy dependency in either direction. Type
+ * duplication across an HTTP boundary is the normal cost of that, not a code smell. */
+export interface CliTelemetryEvent {
+  command: string;
+  flags: Record<string, boolean>;
+  specProvider?: string;
+  outcome: "success" | "error";
+  errorClass?: string;
+  durationMs: number;
+  cliVersion: string;
+  osPlatform: string;
+  osArch: string;
+  bunVersion: string;
+  isCI: boolean;
+  anonymousId: string;
+}
+
+mkdirSync(dirname(DB_PATH), { recursive: true });
+const db = new Database(DB_PATH, { create: true });
+db.exec("PRAGMA journal_mode = WAL;");
+db.exec(`
+CREATE TABLE IF NOT EXISTS events (
+  id            TEXT    PRIMARY KEY,
+  command       TEXT    NOT NULL,
+  flags         TEXT    NOT NULL,
+  spec_provider TEXT,
+  outcome       TEXT    NOT NULL,
+  error_class   TEXT,
+  duration_ms   INTEGER NOT NULL,
+  cli_version   TEXT    NOT NULL,
+  os_platform   TEXT    NOT NULL,
+  os_arch       TEXT    NOT NULL,
+  bun_version   TEXT    NOT NULL,
+  is_ci         INTEGER NOT NULL,
+  anonymous_id  TEXT    NOT NULL,
+  received_at   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_received_at ON events (received_at);
+CREATE INDEX IF NOT EXISTS idx_events_anonymous_id ON events (anonymous_id);
+`);
+
+export function insertEvent(event: CliTelemetryEvent): void {
+  db.run(
+    `INSERT INTO events (
+      id, command, flags, spec_provider, outcome, error_class, duration_ms, cli_version,
+      os_platform, os_arch, bun_version, is_ci, anonymous_id, received_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      crypto.randomUUID(),
+      event.command,
+      JSON.stringify(event.flags),
+      event.specProvider ?? null,
+      event.outcome,
+      event.errorClass ?? null,
+      event.durationMs,
+      event.cliVersion,
+      event.osPlatform,
+      event.osArch,
+      event.bunVersion,
+      event.isCI ? 1 : 0,
+      event.anonymousId,
+      Date.now(),
+    ],
+  );
+}

--- a/apps/telemetry/package.json
+++ b/apps/telemetry/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@alineo-labs/telemetry",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "server": "bun server.ts",
+    "server:dev": "bun --watch server.ts",
+    "typecheck": "tsc --noEmit --project tsconfig.json",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "bun-types": "1.3.14",
+    "typescript": "6.0.3"
+  }
+}

--- a/apps/telemetry/routes/events.ts
+++ b/apps/telemetry/routes/events.ts
@@ -1,0 +1,157 @@
+/**
+ * `POST /v1/events` -- the only route this app has. Re-validates the event against the exact
+ * same allowlisted shape `alineo` claims to send (defense in depth -- never trust that a client
+ * only ever sends what its own code says it will): any unexpected top-level field, or a known
+ * field of the wrong type, is rejected outright rather than silently dropped.
+ */
+import { insertEvent, type CliTelemetryEvent } from "../db";
+import { MAX_BODY_BYTES, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "../config";
+
+const KNOWN_FIELDS = new Set([
+  "command",
+  "flags",
+  "specProvider",
+  "outcome",
+  "errorClass",
+  "durationMs",
+  "cliVersion",
+  "osPlatform",
+  "osArch",
+  "bunVersion",
+  "isCI",
+  "anonymousId",
+]);
+
+/** Bounded flags object -- a real command's own allowlist (owned by `packages/cli`, not
+ * duplicated here) never has more than a handful of entries; this is a structural cap, not
+ * per-command knowledge, so this app doesn't need to know every command's own flag schema to
+ * stay decoupled from `packages/cli`. */
+const MAX_FLAGS = 20;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateEvent(value: unknown): CliTelemetryEvent {
+  if (!isPlainObject(value)) throw new Error("body must be a JSON object");
+
+  for (const key of Object.keys(value)) {
+    if (!KNOWN_FIELDS.has(key)) throw new Error(`unexpected field: "${key}"`);
+  }
+
+  const {
+    command,
+    flags,
+    specProvider,
+    outcome,
+    errorClass,
+    durationMs,
+    cliVersion,
+    osPlatform,
+    osArch,
+    bunVersion,
+    isCI,
+    anonymousId,
+  } = value;
+
+  if (typeof command !== "string" || !command.trim())
+    throw new Error(`"command" must be a non-empty string`);
+  if (!isPlainObject(flags)) throw new Error(`"flags" must be an object`);
+  const flagEntries = Object.entries(flags);
+  if (flagEntries.length > MAX_FLAGS) throw new Error(`"flags" has too many entries`);
+  for (const [k, v] of flagEntries) {
+    if (typeof v !== "boolean") throw new Error(`"flags.${k}" must be a boolean`);
+  }
+  if (specProvider !== undefined && typeof specProvider !== "string") {
+    throw new Error(`"specProvider" must be a string if present`);
+  }
+  if (outcome !== "success" && outcome !== "error") {
+    throw new Error(`"outcome" must be "success" or "error"`);
+  }
+  if (errorClass !== undefined && typeof errorClass !== "string") {
+    throw new Error(`"errorClass" must be a string if present`);
+  }
+  if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0) {
+    throw new Error(`"durationMs" must be a non-negative number`);
+  }
+  for (const [name, v] of [
+    ["cliVersion", cliVersion],
+    ["osPlatform", osPlatform],
+    ["osArch", osArch],
+    ["bunVersion", bunVersion],
+    ["anonymousId", anonymousId],
+  ] as const) {
+    if (typeof v !== "string" || !v.trim()) throw new Error(`"${name}" must be a non-empty string`);
+  }
+  if (typeof isCI !== "boolean") throw new Error(`"isCI" must be a boolean`);
+
+  return {
+    command,
+    flags: flags as Record<string, boolean>,
+    specProvider: specProvider as string | undefined,
+    outcome,
+    errorClass: errorClass as string | undefined,
+    durationMs,
+    cliVersion: cliVersion as string,
+    osPlatform: osPlatform as string,
+    osArch: osArch as string,
+    bunVersion: bunVersion as string,
+    isCI,
+    anonymousId: anonymousId as string,
+  };
+}
+
+/** In-memory sliding window, per `anonymousId` -- this endpoint has no auth (there's no user
+ * identity to authenticate, the data is anonymous by design), so this is the only abuse guard
+ * for a single reporter sending too often. Module-level, reset on process restart -- acceptable
+ * for a crude rate limit whose only job is bounding a runaway/misbehaving client, not billing. */
+const requestTimestamps = new Map<string, number[]>();
+
+function isRateLimited(anonymousId: string): boolean {
+  const now = Date.now();
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  const existing = (requestTimestamps.get(anonymousId) ?? []).filter((t) => t > cutoff);
+  if (existing.length >= RATE_LIMIT_MAX_REQUESTS) {
+    requestTimestamps.set(anonymousId, existing);
+    return true;
+  }
+  existing.push(now);
+  requestTimestamps.set(anonymousId, existing);
+  return false;
+}
+
+export async function postEvent(req: Request): Promise<Response> {
+  const contentLength = Number(req.headers.get("content-length") ?? "0");
+  if (contentLength > MAX_BODY_BYTES) {
+    return Response.json({ error: "payload too large" }, { status: 413 });
+  }
+
+  const text = await req.text();
+  if (text.length > MAX_BODY_BYTES) {
+    return Response.json({ error: "payload too large" }, { status: 413 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  let event: CliTelemetryEvent;
+  try {
+    event = validateEvent(parsed);
+  } catch (err) {
+    return Response.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 400 },
+    );
+  }
+
+  if (isRateLimited(event.anonymousId)) {
+    return Response.json({ error: "rate limited" }, { status: 429 });
+  }
+
+  insertEvent(event);
+  return new Response(null, { status: 204 });
+}

--- a/apps/telemetry/server.ts
+++ b/apps/telemetry/server.ts
@@ -1,0 +1,15 @@
+import { PORT } from "./config";
+import { postEvent } from "./routes/events";
+
+const server = Bun.serve({
+  port: PORT,
+  routes: {
+    "/health": new Response("ok"),
+    "/v1/events": {
+      POST: (req: Request) => postEvent(req),
+    },
+  },
+  fetch: () => Response.json({ error: "not found" }, { status: 404 }),
+});
+
+console.log(`[telemetry] listening on http://localhost:${server.port}`);

--- a/apps/telemetry/test/events.test.ts
+++ b/apps/telemetry/test/events.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Point at a throwaway db file before anything under test (config.ts/db.ts) is ever imported --
+// module-level `new Database(...)` in db.ts reads this at import time.
+const dir = await mkdtemp(join(tmpdir(), "alineo-telemetry-test-"));
+process.env.TELEMETRY_DB_PATH = join(dir, "telemetry.db");
+
+const { postEvent } = await import("../routes/events");
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function validEventBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    command: "spawn",
+    flags: { json: true },
+    outcome: "success",
+    durationMs: 120,
+    cliVersion: "0.7.2",
+    osPlatform: "linux",
+    osArch: "x64",
+    bunVersion: "1.3.9",
+    isCI: false,
+    anonymousId: crypto.randomUUID(),
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  const text = JSON.stringify(body);
+  return new Request("http://localhost/v1/events", {
+    method: "POST",
+    headers: { "content-type": "application/json", "content-length": String(text.length) },
+    body: text,
+  });
+}
+
+describe("POST /v1/events", () => {
+  it("accepts a valid event and returns 204", async () => {
+    const res = await postEvent(makeRequest(validEventBody()));
+    expect(res.status).toBe(204);
+  });
+
+  it("accepts an error-outcome event with errorClass", async () => {
+    const res = await postEvent(
+      makeRequest(validEventBody({ outcome: "error", errorClass: "CommandError" })),
+    );
+    expect(res.status).toBe(204);
+  });
+
+  it("rejects an unexpected top-level field", async () => {
+    const res = await postEvent(makeRequest(validEventBody({ extra: "nope" })));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-boolean flag value", async () => {
+    const res = await postEvent(makeRequest(validEventBody({ flags: { json: "yes" } })));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects too many flag entries", async () => {
+    const flags: Record<string, boolean> = {};
+    for (let i = 0; i < 25; i++) flags[`f${i}`] = true;
+    const res = await postEvent(makeRequest(validEventBody({ flags })));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing required field", async () => {
+    const body = validEventBody();
+    delete body.command;
+    const res = await postEvent(makeRequest(body));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid outcome value", async () => {
+    const res = await postEvent(makeRequest(validEventBody({ outcome: "maybe" })));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const res = await postEvent(
+      new Request("http://localhost/v1/events", {
+        method: "POST",
+        headers: { "content-length": "9" },
+        body: "not json!",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a too-large body via Content-Length", async () => {
+    const res = await postEvent(makeRequest(validEventBody({ command: "x".repeat(10000) })));
+    expect(res.status).toBe(413);
+  });
+
+  it("rate limits after too many requests from the same anonymousId", async () => {
+    const anonymousId = crypto.randomUUID();
+    let lastStatus = 0;
+    for (let i = 0; i < 35; i++) {
+      lastStatus = (await postEvent(makeRequest(validEventBody({ anonymousId })))).status;
+    }
+    expect(lastStatus).toBe(429);
+  });
+
+  it("does not rate limit a different anonymousId after another one gets limited", async () => {
+    const limited = crypto.randomUUID();
+    for (let i = 0; i < 35; i++) {
+      await postEvent(makeRequest(validEventBody({ anonymousId: limited })));
+    }
+    const res = await postEvent(makeRequest(validEventBody({ anonymousId: crypto.randomUUID() })));
+    expect(res.status).toBe(204);
+  });
+});

--- a/apps/telemetry/tsconfig.json
+++ b/apps/telemetry/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun-types"]
+  },
+  "include": [".", "test"],
+  "exclude": ["data"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,14 @@
         "typescript": "^5.7.0",
       },
     },
+    "apps/telemetry": {
+      "name": "@alineo-labs/telemetry",
+      "version": "0.1.0",
+      "devDependencies": {
+        "bun-types": "1.3.14",
+        "typescript": "6.0.3",
+      },
+    },
     "examples/benchmark": {
       "name": "alineo-example-benchmark",
       "version": "0.0.2",
@@ -455,6 +463,8 @@
     "@alineo-labs/sandbox": ["@alineo-labs/sandbox@workspace:apps/sandbox"],
 
     "@alineo-labs/sqlite": ["@alineo-labs/sqlite@workspace:packages/adapters/sqlite"],
+
+    "@alineo-labs/telemetry": ["@alineo-labs/telemetry@workspace:apps/telemetry"],
 
     "@alineo-labs/workflow": ["@alineo-labs/workflow@workspace:packages/workflow"],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "tests/integration",
     "apps/docs",
     "apps/registry",
-    "apps/sandbox"
+    "apps/sandbox",
+    "apps/telemetry"
   ],
   "scripts": {
     "setup": "bun scripts/setup.ts",

--- a/packages/cli/src/commands/registry.ts
+++ b/packages/cli/src/commands/registry.ts
@@ -99,4 +99,14 @@ export const commands: CliCommand[] = [
     ],
     run: async (argv) => (await import("./logs.js")).logsCommand.run(argv),
   },
+  {
+    name: "telemetry",
+    group: "sdk",
+    variants: [
+      { usage: "alineo telemetry status", summary: "Show whether telemetry is enabled" },
+      { usage: "alineo telemetry enable", summary: "Enable anonymous usage telemetry" },
+      { usage: "alineo telemetry disable", summary: "Disable anonymous usage telemetry" },
+    ],
+    run: async (argv) => (await import("./telemetry.js")).telemetryCommand.run(argv),
+  },
 ];

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,43 @@
+import { envDisabled, readTelemetryConfig, writeTelemetryConfig } from "../telemetry.js";
+import type { CliCommand } from "./types.js";
+
+export async function telemetry(argv: string[]): Promise<void> {
+  const sub = argv[0];
+  const config = await readTelemetryConfig();
+
+  if (sub === "enable") {
+    await writeTelemetryConfig({ ...config, enabled: true });
+    console.log("[alineo] telemetry enabled");
+    return;
+  }
+  if (sub === "disable") {
+    await writeTelemetryConfig({ ...config, enabled: false });
+    console.log("[alineo] telemetry disabled");
+    return;
+  }
+  if (sub === "status" || !sub) {
+    if (envDisabled()) {
+      console.log(
+        "[alineo] telemetry: disabled (ALINEO_TELEMETRY_DISABLED or DO_NOT_TRACK is set)",
+      );
+    } else {
+      console.log(`[alineo] telemetry: ${config.enabled ? "enabled" : "disabled"}`);
+    }
+    console.log(`  anonymous id: ${config.anonymousId}`);
+    return;
+  }
+  throw new Error("Usage: alineo telemetry status|enable|disable");
+}
+
+export const telemetryCommand: CliCommand = {
+  name: "telemetry",
+  group: "sdk",
+  variants: [
+    { usage: "alineo telemetry status", summary: "Show whether telemetry is enabled" },
+    { usage: "alineo telemetry enable", summary: "Enable anonymous usage telemetry" },
+    { usage: "alineo telemetry disable", summary: "Disable anonymous usage telemetry" },
+  ],
+  run: async (argv) => {
+    await telemetry(argv);
+  },
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { commands } from "./commands/registry.js";
 import type { CliCommand } from "./commands/types.js";
+import { recordTuiLaunch, withTelemetry } from "./telemetry.js";
 
 const [, , cmd, ...argv] = process.argv;
 
@@ -43,6 +44,7 @@ async function main(): Promise<void> {
   // Bare `alineo` in an interactive terminal launches the TUI; piped/scripted
   // invocations with no subcommand (no TTY) fall through to the help text below.
   if (!cmd && process.stdout.isTTY) {
+    await recordTuiLaunch();
     const { launchTui } = await import("./tui/index.js");
     await launchTui();
     return;
@@ -56,7 +58,7 @@ async function main(): Promise<void> {
 
   const found = commands.find((c) => c.name === cmd);
   if (found) {
-    await found.run(argv);
+    await withTelemetry(found.name, argv, () => found.run(argv));
     return;
   }
 

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,0 +1,246 @@
+/**
+ * `alineo` CLI usage telemetry. Anonymous, allowlisted (command name + a small per-command set
+ * of boolean flag presence, never argv/paths/spec contents), default-on with an explicit
+ * opt-out. Wired in at the single dispatch choke point in index.ts, not per-command -- every
+ * command file in commands/ stays untouched.
+ */
+import { join } from "node:path";
+import { serverConfigDir } from "./config.js";
+
+export interface TelemetryConfig {
+  enabled: boolean;
+  anonymousId: string;
+  /** Epoch ms of the first-run notice; null until it's been shown once. */
+  notifiedAt: number | null;
+}
+
+/** Intentionally duplicated from `apps/telemetry/db.ts`'s identical interface rather than shared
+ * via a workspace package -- this CLI and that app communicate purely over the `POST /v1/events`
+ * HTTP contract, with no runtime/deploy dependency in either direction. */
+export interface CliTelemetryEvent {
+  command: string;
+  flags: Record<string, boolean>;
+  /** `spawn`/`fork` only -- the target spec's own `AgentSpec.provider` string (e.g. `"nvidia"`),
+   * when readable. See `extractSpecProvider()`'s doc comment for why this field, not `model`. */
+  specProvider?: string;
+  outcome: "success" | "error";
+  errorClass?: string;
+  durationMs: number;
+  cliVersion: string;
+  osPlatform: string;
+  osArch: string;
+  bunVersion: string;
+  isCI: boolean;
+  anonymousId: string;
+}
+
+/** No production endpoint is deployed yet -- this default is a local-dev placeholder only.
+ * Overridable via env var for whenever `apps/telemetry` is actually deployed, same override
+ * convention `@alineo-labs/otel`'s own collector URL uses. */
+const DEFAULT_TELEMETRY_ENDPOINT = "http://localhost:3002/v1/events";
+const SEND_TIMEOUT_MS = 500;
+
+/** `ALINEO_TELEMETRY_CONFIG_PATH` is an internal test seam, not a documented user-facing setting
+ * (`node:os`'s `homedir()` doesn't re-read `process.env.HOME` after its first call in a process,
+ * so tests can't isolate the real `serverConfigDir()` path via env mutation the way they can for
+ * plain env-var-driven config elsewhere) -- defaults to the real path for every real invocation. */
+function telemetryConfigPath(): string {
+  return process.env.ALINEO_TELEMETRY_CONFIG_PATH ?? join(serverConfigDir(), "telemetry.json");
+}
+
+function newAnonymousId(): string {
+  return crypto.randomUUID();
+}
+
+export async function readTelemetryConfig(): Promise<TelemetryConfig> {
+  const file = Bun.file(telemetryConfigPath());
+  if (await file.exists()) {
+    const data = (await file.json()) as Partial<TelemetryConfig>;
+    return {
+      enabled: data.enabled ?? false,
+      anonymousId: data.anonymousId ?? newAnonymousId(),
+      notifiedAt: data.notifiedAt ?? null,
+    };
+  }
+  // Default-off until apps/telemetry is actually deployed -- flip to `true` once it is.
+  return { enabled: false, anonymousId: newAnonymousId(), notifiedAt: null };
+}
+
+export async function writeTelemetryConfig(config: TelemetryConfig): Promise<void> {
+  await Bun.write(telemetryConfigPath(), JSON.stringify(config, null, 2) + "\n");
+}
+
+/** Checked before anything else -- either env var disables telemetry with no config file read at
+ * all, matching Next.js's "check the env var before any other init logic runs" ordering.
+ * `DO_NOT_TRACK` is the cross-tool convention Turborepo also honors alongside its own var.
+ * Exported so `commands/telemetry.ts`'s `status` output can explain *why* telemetry is off when
+ * an env var is the reason, not just the persisted config's own `enabled` flag. */
+export function envDisabled(): boolean {
+  return !!process.env.ALINEO_TELEMETRY_DISABLED || !!process.env.DO_NOT_TRACK;
+}
+
+export async function isTelemetryDisabled(): Promise<boolean> {
+  if (envDisabled()) return true;
+  const config = await readTelemetryConfig();
+  return !config.enabled;
+}
+
+const FIRST_RUN_NOTICE = `[alineo] Anonymous usage telemetry: which command ran, a few known flags,
+success/failure, timing -- never spec contents, prompts, or file paths. Disable any time with
+'alineo telemetry disable' or ALINEO_TELEMETRY_DISABLED=1.`;
+
+async function maybePrintFirstRunNotice(config: TelemetryConfig): Promise<void> {
+  if (config.notifiedAt !== null) return;
+  console.error(FIRST_RUN_NOTICE);
+  await writeTelemetryConfig({ ...config, notifiedAt: Date.now() });
+}
+
+/** Bounded send, not fire-and-forget, not a blocking wait -- races the POST against a short
+ * timeout so an unreachable/slow endpoint never meaningfully delays a real command's exit.
+ * Never throws: a failed/slow send must not surface as a CLI error. */
+export async function sendTelemetryEvent(
+  event: CliTelemetryEvent,
+  endpointUrl: string = process.env.ALINEO_TELEMETRY_ENDPOINT ?? DEFAULT_TELEMETRY_ENDPOINT,
+): Promise<void> {
+  try {
+    await fetch(endpointUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+    });
+  } catch {
+    // Unreachable endpoint, timeout, network error -- telemetry is best-effort, never a reason
+    // to fail (or even warn during) a real command.
+  }
+}
+
+/** Per-command allowlist of flags safe to record *presence of* -- never their values, never raw
+ * argv. A flag not listed here is invisible to telemetry until someone deliberately adds it;
+ * under-collecting is the only failure mode. Keys match each command's own `flag(argv, "--x")`/
+ * `argv.includes("--x")` calls (see commands/spawn.ts, fork.ts, prompt.ts, agents.ts, logs.ts). */
+const FLAG_ALLOWLIST: Record<string, string[]> = {
+  spawn: ["--prompt", "--rebuild", "--json", "--depth", "--max", "--timeout", "--run-id"],
+  fork: ["--prompt", "--json", "--depth", "--max", "--timeout"],
+  prompt: ["--json", "--spec", "--timeout"],
+  agents: ["--json"],
+  logs: ["--json"],
+  init: [],
+  add: [],
+  list: [],
+  remove: [],
+  kill: [],
+};
+
+/** Presence-only booleans for whichever flags `commandName`'s own allowlist names -- never the
+ * flag's value, never anything not on the list. */
+function extractAllowedFlags(commandName: string, argv: string[]): Record<string, boolean> {
+  const allowed = FLAG_ALLOWLIST[commandName] ?? [];
+  const flags: Record<string, boolean> = {};
+  for (const flagName of allowed) {
+    flags[flagName.replace(/^--/, "")] = argv.includes(flagName);
+  }
+  return flags;
+}
+
+/** `spawn`/`fork` take a spec file as their first non-flag argv token -- reads just its own
+ * `provider` field (a small, closed, non-identifying set like `"nvidia"`/`"google"`) to answer
+ * "which providers actually get used." Deliberately not `model` (closer to free text, not needed
+ * for that question) and nothing else from the spec. Never throws -- a missing/unreadable spec
+ * file must never surface through telemetry into the real command. */
+async function extractSpecProvider(
+  commandName: string,
+  argv: string[],
+): Promise<string | undefined> {
+  if (commandName !== "spawn" && commandName !== "fork") return undefined;
+  const specPath = (commandName === "fork" ? argv.slice(1) : argv).find((a) => !a.startsWith("--"));
+  if (!specPath) return undefined;
+  try {
+    const spec = (await Bun.file(specPath).json()) as { provider?: unknown };
+    return typeof spec.provider === "string" ? spec.provider : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function errorClassOf(err: unknown): string {
+  return err instanceof Error ? err.constructor.name : "UnknownError";
+}
+
+/**
+ * Wraps a single command's `run()` call: on disabled, just calls `run()` directly (zero
+ * overhead, no config read even). Otherwise times the call, records outcome/errorClass, builds
+ * and sends the event, prints the first-run notice if this is the first time, and always
+ * re-throws whatever `run()` threw, unchanged -- telemetry must never swallow or alter a real
+ * command failure.
+ */
+export async function withTelemetry(
+  commandName: string,
+  argv: string[],
+  run: () => Promise<void>,
+): Promise<void> {
+  if (envDisabled()) {
+    await run();
+    return;
+  }
+
+  const config = await readTelemetryConfig();
+  if (!config.enabled) {
+    await run();
+    return;
+  }
+
+  await maybePrintFirstRunNotice(config);
+
+  const flags = extractAllowedFlags(commandName, argv);
+  const specProvider = await extractSpecProvider(commandName, argv);
+  const start = performance.now();
+  let outcome: "success" | "error" = "success";
+  let errorClass: string | undefined;
+  try {
+    await run();
+  } catch (err) {
+    outcome = "error";
+    errorClass = errorClassOf(err);
+    throw err;
+  } finally {
+    const { version } = await import("../package.json");
+    await sendTelemetryEvent({
+      command: commandName,
+      flags,
+      specProvider,
+      outcome,
+      errorClass,
+      durationMs: Math.round(performance.now() - start),
+      cliVersion: version,
+      osPlatform: process.platform,
+      osArch: process.arch,
+      bunVersion: Bun.version,
+      isCI: !!process.env.CI,
+      anonymousId: config.anonymousId,
+    });
+  }
+}
+
+/** The bare-`alineo`-launches-TUI path (index.ts) isn't a single bounded command run the way
+ * `withTelemetry()` assumes -- a TUI session's own lifetime makes "wait for this before
+ * proceeding" meaningless, so this only ever fires a launch count, never duration/outcome. */
+export async function recordTuiLaunch(): Promise<void> {
+  if (envDisabled()) return;
+  const config = await readTelemetryConfig();
+  if (!config.enabled) return;
+  await maybePrintFirstRunNotice(config);
+  const { version } = await import("../package.json");
+  await sendTelemetryEvent({
+    command: "tui",
+    flags: {},
+    outcome: "success",
+    durationMs: 0,
+    cliVersion: version,
+    osPlatform: process.platform,
+    osArch: process.arch,
+    bunVersion: Bun.version,
+    isCI: !!process.env.CI,
+    anonymousId: config.anonymousId,
+  });
+}

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  envDisabled,
+  isTelemetryDisabled,
+  readTelemetryConfig,
+  sendTelemetryEvent,
+  withTelemetry,
+  writeTelemetryConfig,
+} from "../src/telemetry.js";
+
+let originalConfigPath: string | undefined;
+let originalDisabled: string | undefined;
+let originalDoNotTrack: string | undefined;
+let originalFetch: typeof fetch;
+let tempDir: string;
+
+beforeEach(async () => {
+  originalConfigPath = process.env.ALINEO_TELEMETRY_CONFIG_PATH;
+  originalDisabled = process.env.ALINEO_TELEMETRY_DISABLED;
+  originalDoNotTrack = process.env.DO_NOT_TRACK;
+  originalFetch = globalThis.fetch;
+  delete process.env.ALINEO_TELEMETRY_DISABLED;
+  delete process.env.DO_NOT_TRACK;
+  // `node:os`'s `homedir()` doesn't re-read `process.env.HOME` after its first call in a
+  // process, so isolation goes through `telemetry.ts`'s own internal test seam instead -- see
+  // that file's `telemetryConfigPath()` doc comment.
+  tempDir = await mkdtemp(join(tmpdir(), "alineo-telemetry-test-"));
+  process.env.ALINEO_TELEMETRY_CONFIG_PATH = join(tempDir, "telemetry.json");
+});
+
+afterEach(async () => {
+  if (originalConfigPath === undefined) delete process.env.ALINEO_TELEMETRY_CONFIG_PATH;
+  else process.env.ALINEO_TELEMETRY_CONFIG_PATH = originalConfigPath;
+  if (originalDisabled === undefined) delete process.env.ALINEO_TELEMETRY_DISABLED;
+  else process.env.ALINEO_TELEMETRY_DISABLED = originalDisabled;
+  if (originalDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;
+  else process.env.DO_NOT_TRACK = originalDoNotTrack;
+  globalThis.fetch = originalFetch;
+  mock.restore();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("envDisabled / isTelemetryDisabled", () => {
+  it("is disabled by default (no config file yet)", async () => {
+    expect(await isTelemetryDisabled()).toBe(true);
+  });
+
+  it("ALINEO_TELEMETRY_DISABLED disables regardless of persisted config", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: null });
+    process.env.ALINEO_TELEMETRY_DISABLED = "1";
+    expect(envDisabled()).toBe(true);
+    expect(await isTelemetryDisabled()).toBe(true);
+  });
+
+  it("DO_NOT_TRACK disables regardless of persisted config", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: null });
+    process.env.DO_NOT_TRACK = "1";
+    expect(envDisabled()).toBe(true);
+    expect(await isTelemetryDisabled()).toBe(true);
+  });
+
+  it("is enabled once the persisted config says so, with no env var set", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: null });
+    expect(await isTelemetryDisabled()).toBe(false);
+  });
+});
+
+describe("readTelemetryConfig / writeTelemetryConfig", () => {
+  it("round-trips a written config", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "abc-123", notifiedAt: 42 });
+    const config = await readTelemetryConfig();
+    expect(config).toEqual({ enabled: true, anonymousId: "abc-123", notifiedAt: 42 });
+  });
+
+  it("generates a fresh anonymousId when no config file exists yet", async () => {
+    const config = await readTelemetryConfig();
+    expect(config.enabled).toBe(false);
+    expect(config.anonymousId.length).toBeGreaterThan(0);
+    expect(config.notifiedAt).toBeNull();
+  });
+});
+
+describe("sendTelemetryEvent", () => {
+  const event = {
+    command: "spawn",
+    flags: { json: true },
+    outcome: "success" as const,
+    durationMs: 10,
+    cliVersion: "0.0.0",
+    osPlatform: "linux",
+    osArch: "x64",
+    bunVersion: "1.0.0",
+    isCI: false,
+    anonymousId: "abc",
+  };
+
+  it("never throws when fetch rejects", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("network down")),
+    ) as unknown as typeof fetch;
+    await expect(
+      sendTelemetryEvent(event, "http://example.invalid/v1/events"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("never throws and does not hang when fetch never resolves", async () => {
+    // A hanging real request still rejects once its AbortSignal fires -- this mock has to
+    // honor that same contract to actually exercise sendTelemetryEvent's own timeout bound
+    // (a mock that ignores `init.signal` entirely would hang regardless of what the
+    // implementation does, proving nothing about its timeout logic).
+    globalThis.fetch = mock(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    ) as unknown as typeof fetch;
+    const start = performance.now();
+    await sendTelemetryEvent(event, "http://example.invalid/v1/events");
+    expect(performance.now() - start).toBeLessThan(2000);
+  });
+
+  it("POSTs the event as JSON to the given endpoint", async () => {
+    let capturedBody: string | undefined;
+    let capturedUrl: string | undefined;
+    globalThis.fetch = mock((url: string, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedBody = init?.body as string;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as unknown as typeof fetch;
+    await sendTelemetryEvent(event, "http://example.invalid/v1/events");
+    expect(capturedUrl).toBe("http://example.invalid/v1/events");
+    expect(JSON.parse(capturedBody ?? "{}")).toEqual(event);
+  });
+});
+
+describe("withTelemetry", () => {
+  it("calls run() directly when telemetry is disabled, without ever touching fetch", async () => {
+    const fetchSpy = mock(() => {
+      throw new Error("should not be called");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    let ran = false;
+    await withTelemetry("spawn", [], async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-throws the original error after recording outcome: error", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: Date.now() });
+    let capturedBody: string | undefined;
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as unknown as typeof fetch;
+
+    const boom = new Error("boom");
+    await expect(
+      withTelemetry("spawn", [], async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    const sent = JSON.parse(capturedBody ?? "{}");
+    expect(sent.outcome).toBe("error");
+    expect(sent.errorClass).toBe("Error");
+  });
+
+  it("only reports allowlisted flags for the given command, dropping everything else", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: Date.now() });
+    let capturedBody: string | undefined;
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as unknown as typeof fetch;
+
+    // "agents" only allowlists --json; --not-a-real-flag must never appear in the sent event.
+    await withTelemetry("agents", ["--json", "--not-a-real-flag"], async () => {});
+
+    const sent = JSON.parse(capturedBody ?? "{}");
+    expect(sent.flags).toEqual({ json: true });
+  });
+
+  it("prints the first-run notice exactly once, on the first send", async () => {
+    await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: null });
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 204 })),
+    ) as unknown as typeof fetch;
+
+    const originalError = console.error;
+    const messages: unknown[] = [];
+    console.error = (...args: unknown[]) => messages.push(args);
+    try {
+      await withTelemetry("agents", [], async () => {});
+      await withTelemetry("agents", [], async () => {});
+    } finally {
+      console.error = originalError;
+    }
+
+    const noticeCount = messages.filter((m) =>
+      String(m).includes("Anonymous usage telemetry"),
+    ).length;
+    expect(noticeCount).toBe(1);
+
+    const config = await readTelemetryConfig();
+    expect(config.notifiedAt).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Ports the CLI usage telemetry feature from `drej-private` into this OSS repo, renamed to `alineo`/`alineo-cli`.

- **Collection**: anonymous, allowlisted usage events — which subcommand ran, a small per-command allowlist of boolean flag presence (never values or raw argv), success/failure + `errorClass` (never `.message`), timing, CLI/OS/Bun versions, `isCI`, and for `spawn`/`fork` only, the target spec's `provider` field. Not OpenTelemetry — a plain, bounded (500ms timeout) `fetch()` POST, matching Next.js/Astro/Turborepo/Prisma's own approach rather than .NET's OTel route.
- **Wired at the single dispatch choke point** in `packages/cli/src/index.ts` (`withTelemetry()` wraps every subcommand's `run()`; `recordTuiLaunch()` covers the bare-TUI-launch path) — no existing command file touched.
- **New standalone app, `apps/telemetry`** (`@alineo-labs/telemetry`) — its own `Bun.serve` process + SQLite file, one route (`POST /v1/events`), zero dependency on any other app in this repo in either direction. Re-validates every event server-side against the same allowlisted shape, with a body-size cap and a per-`anonymousId` rate limit.
- **CLI surface**: `alineo telemetry status|enable|disable`, plus `ALINEO_TELEMETRY_DISABLED`/`DO_NOT_TRACK` env vars.
- **Default-off** — no production ingest endpoint is deployed for this repo yet; flips on once one is.
- Root `package.json` workspaces gets `apps/telemetry`; a `minor` changeset for `alineo-cli` is included.

## Test plan
- [x] `bun run typecheck` — all packages pass
- [x] `bun run test` — all packages pass (includes new `packages/cli/test/telemetry.test.ts` and `apps/telemetry/test/events.test.ts`)
- [x] `bun run build` — all packages pass, `telemetry` chunk bundled into the CLI dist
- [x] `bun run format:check` — clean
- [x] `bunx changeset status` — clean
- [ ] Deploying `apps/telemetry` and flipping the default to enabled — left for a follow-up, same as it was in `drej-private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)