### PR TITLE
Mark publishable packages public — npm publish infra ready

### DIFF
--- a/.changeset/flip-packages-public.md
+++ b/.changeset/flip-packages-public.md
@@ -1,0 +1,16 @@
+---
+"@alineo-labs/flue": patch
+"@alineo-labs/otel": patch
+"@alineo-labs/postgres": patch
+"@alineo-labs/sqlite": patch
+"@alineo-labs/agent": patch
+"alineo-cli": patch
+"@alineo-labs/core": patch
+"@alineo-labs/opensandbox": patch
+"alineo": patch
+"@alineo-labs/workflow": patch
+---
+
+Remove `private: true` from the 10 publishable packages so they can actually be published to
+npm. No functional or API changes — this is the last step of npm-publish readiness (repository
+URLs, `publishConfig`, and `bin`/`repository` fields were already correct).

--- a/packages/adapters/flue/package.json
+++ b/packages/adapters/flue/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/flue",
   "version": "3.0.0",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/adapters/otel/package.json
+++ b/packages/adapters/otel/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/otel",
   "version": "0.2.8",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/postgres",
   "version": "0.3.8",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/sqlite",
   "version": "0.3.8",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/agent",
   "version": "0.6.2",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "alineo-cli",
   "version": "0.7.2",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/core",
   "version": "0.6.3",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/opensandbox/package.json
+++ b/packages/opensandbox/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/opensandbox",
   "version": "0.3.1",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,7 +1,6 @@
 {
   "name": "alineo",
   "version": "0.10.4",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@alineo-labs/workflow",
   "version": "1.1.9",
-  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Reverts the earlier `private: true` safety flip on all 10 publishable packages (`alineo`, `alineo-cli`, and the 8 `@alineo-labs/*` packages) now that:
- `NPM_TOKEN` has been rotated to an account with `alineo-labs` npm org publish rights
- Org membership/access is confirmed

## What happens after this merges
`release.yml` triggers on every push to `main`. With no `private:true` blocking anything and a valid `NPM_TOKEN`, the next push will make `changesets/action` open a **"chore: version packages"** PR (there are 10 pending major-bump changesets from the rename, plus the telemetry minor bump). **Merging *that* PR is the step that actually publishes to npm** — this PR alone does not publish anything.

## Test plan
- [x] `bun run typecheck` — all packages pass
- [x] `bun run format:check` — clean
- [x] `bunx changeset status` — confirms the pending major bump list (10 packages)
- [ ] Actual npm publish — happens on merge of the follow-up "chore: version packages" PR, not this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)