### PR TITLE
Update github.com/DrejT/drej refs to DrejT/alineo

### DIFF
--- a/.changeset/update-github-repo-url.md
+++ b/.changeset/update-github-repo-url.md
@@ -1,0 +1,14 @@
+---
+"alineo-cli": patch
+"alineo": patch
+"@alineo-labs/core": patch
+"@alineo-labs/opensandbox": patch
+"@alineo-labs/agent": patch
+"@alineo-labs/sqlite": patch
+"@alineo-labs/postgres": patch
+"@alineo-labs/otel": patch
+"@alineo-labs/workflow": patch
+"@alineo-labs/flue": patch
+---
+
+Update package.json repository fields to the renamed GitHub repo (DrejT/drej -> DrejT/alineo). No behavior change.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature request or idea
-    url: https://github.com/DrejT/drej/discussions/categories/ideas
+    url: https://github.com/DrejT/alineo/discussions/categories/ideas
     about: Brainstorm and propose new features in GitHub Discussions.
   - name: Question or discussion
-    url: https://github.com/DrejT/drej/discussions
+    url: https://github.com/DrejT/alineo/discussions
     about: Ask questions and discuss ideas in GitHub Discussions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@
 ## Local setup
 
 ```bash
-git clone https://github.com/DrejT/drej.git
-cd drej
+git clone https://github.com/DrejT/alineo.git
+cd alineo
 bun run setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alineo
 
-[![CI](https://github.com/DrejT/drej/actions/workflows/ci.yml/badge.svg)](https://github.com/DrejT/drej/actions/workflows/ci.yml)
+[![CI](https://github.com/DrejT/alineo/actions/workflows/ci.yml/badge.svg)](https://github.com/DrejT/alineo/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/alineo)](https://www.npmjs.com/package/alineo)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 

--- a/apps/docs/content/docs/alineo/registry/schema.mdx
+++ b/apps/docs/content/docs/alineo/registry/schema.mdx
@@ -3,7 +3,7 @@ title: AgentSpec schema
 description: Complete field reference for the AgentSpec JSON fetched by alineo add and run by @alineo-labs/agent's Agent.load().
 ---
 
-An agent spec is a JSON object — the same `AgentSpec` type `@alineo-labs/agent` exports. Only `name` and `cli` are required; `alineo add` and `Agent.load()` both use the same [`validateAgentSpec()`](https://github.com/DrejT/drej/blob/main/packages/agent/src/schema.ts) function.
+An agent spec is a JSON object — the same `AgentSpec` type `@alineo-labs/agent` exports. Only `name` and `cli` are required; `alineo add` and `Agent.load()` both use the same [`validateAgentSpec()`](https://github.com/DrejT/alineo/blob/main/packages/agent/src/schema.ts) function.
 
 ## Full example
 

--- a/packages/adapters/flue/package.json
+++ b/packages/adapters/flue/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/adapters/flue"
   },
   "files": [

--- a/packages/adapters/otel/package.json
+++ b/packages/adapters/otel/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/adapters/otel"
   },
   "files": [

--- a/packages/adapters/postgres/README.md
+++ b/packages/adapters/postgres/README.md
@@ -6,7 +6,7 @@ Postgres storage adapter for [alineo](https://alineo.tech). Stores the sandbox l
 bun add @alineo-labs/postgres
 ```
 
-For local development, [`@alineo-labs/sqlite`](https://github.com/DrejT/drej/tree/main/packages/adapters/sqlite) is simpler and requires no infrastructure.
+For local development, [`@alineo-labs/sqlite`](https://github.com/DrejT/alineo/tree/main/packages/adapters/sqlite) is simpler and requires no infrastructure.
 
 ---
 

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/adapters/postgres"
   },
   "files": [

--- a/packages/adapters/sqlite/README.md
+++ b/packages/adapters/sqlite/README.md
@@ -6,7 +6,7 @@ SQLite storage adapter for [alineo](https://alineo.tech). Stores the sandbox led
 bun add @alineo-labs/sqlite
 ```
 
-For production workloads that need durability across multiple processes or machines, use [`@alineo-labs/postgres`](https://github.com/DrejT/drej/tree/main/packages/adapters/postgres) instead.
+For production workloads that need durability across multiple processes or machines, use [`@alineo-labs/postgres`](https://github.com/DrejT/alineo/tree/main/packages/adapters/postgres) instead.
 
 ---
 

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/adapters/sqlite"
   },
   "files": [

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/agent"
   },
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/cli"
   },
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/core"
   },
   "files": [

--- a/packages/opensandbox/package.json
+++ b/packages/opensandbox/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/opensandbox"
   },
   "files": [

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/sdks/typescript"
   },
   "files": [

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DrejT/drej.git",
+    "url": "git+https://github.com/DrejT/alineo.git",
     "directory": "packages/workflow"
   },
   "files": [


### PR DESCRIPTION
## Summary
The GitHub repo has been renamed from `DrejT/drej` to `DrejT/alineo`. GitHub's redirect keeps old links working, but this sweeps every literal reference to the new location so nothing depends on that redirect:

- `package.json` `repository` field on all 10 publishable packages
- README CI badge + npm badge context
- `CONTRIBUTING.md`'s clone instructions — also fixes a bug this surfaced: the post-clone `cd drej` was already stale (`git clone` creates a dir named after the repo, so it should be `cd alineo`)
- `.github/ISSUE_TEMPLATE/config.yml`'s Discussions links
- `packages/adapters/{postgres,sqlite}/README.md` cross-links
- One `apps/docs` content cross-reference to `validateAgentSpec()`'s source

## Test plan
- [x] `bun run typecheck` — all packages pass
- [x] `bun run format:check` — clean
- [x] Swept for any remaining `DrejT/drej` reference — none left

🤖 Generated with [Claude Code](https://claude.com/claude-code)