### PR TITLE
Document the alineo telemetry command

### DIFF
--- a/.changeset/document-alineo-telemetry.md
+++ b/.changeset/document-alineo-telemetry.md
@@ -1,0 +1,5 @@
+---
+"alineo-cli": patch
+---
+
+Document the alineo telemetry command in packages/cli/README.md and the docs site. No behavior change.

--- a/apps/docs/content/docs/alineo/commands/index.mdx
+++ b/apps/docs/content/docs/alineo/commands/index.mdx
@@ -26,6 +26,11 @@ description: All alineo commands and their options.
     title="remove"
     description="Delete a saved agent spec file."
   />
+  <Card
+    href="/docs/alineo/commands/telemetry"
+    title="telemetry"
+    description="Show, enable, or disable anonymous CLI usage telemetry."
+  />
 </Cards>
 
 ## Agent — session lifecycle

--- a/apps/docs/content/docs/alineo/commands/telemetry.mdx
+++ b/apps/docs/content/docs/alineo/commands/telemetry.mdx
@@ -1,0 +1,77 @@
+---
+title: alineo telemetry
+description: Show, enable, or disable anonymous CLI usage telemetry.
+---
+
+```bash
+bunx alineo-cli telemetry status|enable|disable
+```
+
+## Arguments
+
+| Argument                      | Description                                                         |
+| ----------------------------- | ------------------------------------------------------------------- |
+| `status` (default if omitted) | Print whether telemetry is enabled and this machine's anonymous ID. |
+| `enable`                      | Turn telemetry on.                                                  |
+| `disable`                     | Turn telemetry off.                                                 |
+
+## What it does
+
+`alineo` can send small, anonymous usage events — which subcommand ran, a per-command allowlist of boolean flag presence, success/failure, and timing — to help prioritize development. `alineo telemetry` reads and writes the local config file that controls this (`~/.config/alineo/telemetry.json`), created on first use with a random `anonymousId`.
+
+Currently **default-off** — no production ingest endpoint is deployed yet, so `enable` has no visible effect until one is.
+
+## What's collected
+
+Never anything beyond this:
+
+| Field                                                      | Example                                                                            |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `command`                                                  | `"spawn"`                                                                          |
+| `flags`                                                    | `{ "json": true, "prompt": false }` — presence only, never values                  |
+| `specProvider`                                             | `"nvidia"` — `spawn`/`fork` only, read from the target spec's own `provider` field |
+| `outcome`                                                  | `"success"` or `"error"`                                                           |
+| `errorClass`                                               | `"CommandError"` — the error's constructor name only, never its message            |
+| `durationMs`                                               | `842`                                                                              |
+| `cliVersion`, `osPlatform`, `osArch`, `bunVersion`, `isCI` | environment metadata                                                               |
+| `anonymousId`                                              | a random UUID generated once per machine                                           |
+
+**Never collected**: raw `argv`, flag values, file paths, spec contents, prompts, sandbox output, or anything else that could identify you or your code.
+
+## Example
+
+```bash
+bunx alineo-cli telemetry status
+```
+
+```
+[alineo] telemetry: disabled
+  anonymous id: 3f2e9c1a-8b7d-4e6f-a1c2-9d8e7f6a5b4c
+```
+
+```bash
+bunx alineo-cli telemetry enable
+# [alineo] telemetry enabled
+```
+
+## Opting out
+
+Telemetry is off by default. Once it's on for real (see above), turn it off any time with:
+
+```bash
+bunx alineo-cli telemetry disable
+```
+
+or by setting either env var, which take priority over the persisted config and require no config file read at all:
+
+```bash
+ALINEO_TELEMETRY_DISABLED=1 alineo spawn ./agents/my-agent.json
+# or the cross-tool convention:
+DO_NOT_TRACK=1 alineo spawn ./agents/my-agent.json
+```
+
+## Notes
+
+- A one-time notice is printed to stderr the first time an event would actually send, naming both opt-out mechanisms — never mixed into `--json` output.
+- Sending is bounded: a 500ms timeout races the request, and a failed or slow send never delays or fails the real command it's attached to.
+- Scoped to the `alineo` CLI only — `alineo`/`@alineo-labs/agent`/`@alineo-labs/workflow` used as libraries in your own code are never instrumented.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,6 +48,18 @@ Removes a saved agent spec.
 alineo remove python-data
 ```
 
+### `alineo telemetry status|enable|disable`
+
+Shows or changes whether `alineo` sends anonymous usage telemetry — which subcommand ran, a per-command allowlist of boolean flag presence (never values or raw argv), success/failure, and timing. Currently default-off; no production ingest endpoint is deployed yet.
+
+```bash
+alineo telemetry status
+# [alineo] telemetry: disabled
+#   anonymous id: 3f2e9c1a-8b7d-4e6f-a1c2-9d8e7f6a5b4c
+```
+
+Also respects `ALINEO_TELEMETRY_DISABLED=1` and the cross-tool `DO_NOT_TRACK=1` convention, either of which disables telemetry regardless of the persisted config.
+
 ---
 
 ## Agent — session lifecycle


### PR DESCRIPTION
## Summary
`alineo telemetry` (added in #151) had zero documentation anywhere — closes that gap:

- New `apps/docs/content/docs/alineo/commands/telemetry.mdx`, matching the style/sections of the other command pages (usage, arguments, what it does, what's collected / never collected, example, opt-out mechanisms, notes).
- Added its `Card` entry to `commands/index.mdx`'s SDK group (was silently missing from the command list).
- Added a matching `### alineo telemetry` section to `packages/cli/README.md`, which documented every other command but this one.

## Test plan
- [x] `cd apps/docs && bun run build` — `/docs/alineo/commands/telemetry` builds and prerenders correctly
- [x] `bun run format:check` — clean
- Note: `apps/docs`'s `bun run lint` fails independently of this change (pre-existing `eslint-plugin-react` crash against an auto-generated `.source/source.config.mjs` file, unrelated to any doc content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)