### PR TITLE
Point telemetry at the live endpoint and enable it by default

### DIFF
--- a/.changeset/enable-telemetry-default.md
+++ b/.changeset/enable-telemetry-default.md
@@ -1,0 +1,8 @@
+---
+"alineo-cli": minor
+---
+
+Point CLI telemetry at the deployed ingest endpoint (`https://telemetry.alineo.tech`) and flip
+the default from off to on, now that the endpoint is actually live. Opt out any time with
+`alineo telemetry disable`, `ALINEO_TELEMETRY_DISABLED=1`, or `DO_NOT_TRACK=1`. See
+`alineo telemetry` in the docs for exactly what's collected.

--- a/apps/docs/content/docs/alineo/commands/telemetry.mdx
+++ b/apps/docs/content/docs/alineo/commands/telemetry.mdx
@@ -19,7 +19,7 @@ bunx alineo-cli telemetry status|enable|disable
 
 `alineo` can send small, anonymous usage events — which subcommand ran, a per-command allowlist of boolean flag presence, success/failure, and timing — to help prioritize development. `alineo telemetry` reads and writes the local config file that controls this (`~/.config/alineo/telemetry.json`), created on first use with a random `anonymousId`.
 
-Currently **default-off** — no production ingest endpoint is deployed yet, so `enable` has no visible effect until one is.
+**Default-on**, sent to `https://telemetry.alineo.tech`. See [Opting out](#opting-out) below.
 
 ## What's collected
 
@@ -45,18 +45,18 @@ bunx alineo-cli telemetry status
 ```
 
 ```
-[alineo] telemetry: disabled
+[alineo] telemetry: enabled
   anonymous id: 3f2e9c1a-8b7d-4e6f-a1c2-9d8e7f6a5b4c
 ```
 
 ```bash
-bunx alineo-cli telemetry enable
-# [alineo] telemetry enabled
+bunx alineo-cli telemetry disable
+# [alineo] telemetry disabled
 ```
 
 ## Opting out
 
-Telemetry is off by default. Once it's on for real (see above), turn it off any time with:
+Telemetry is on by default. Turn it off any time with:
 
 ```bash
 bunx alineo-cli telemetry disable

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,11 +50,11 @@ alineo remove python-data
 
 ### `alineo telemetry status|enable|disable`
 
-Shows or changes whether `alineo` sends anonymous usage telemetry — which subcommand ran, a per-command allowlist of boolean flag presence (never values or raw argv), success/failure, and timing. Currently default-off; no production ingest endpoint is deployed yet.
+Shows or changes whether `alineo` sends anonymous usage telemetry — which subcommand ran, a per-command allowlist of boolean flag presence (never values or raw argv), success/failure, and timing. Default-on, sent to `https://telemetry.alineo.tech`.
 
 ```bash
 alineo telemetry status
-# [alineo] telemetry: disabled
+# [alineo] telemetry: enabled
 #   anonymous id: 3f2e9c1a-8b7d-4e6f-a1c2-9d8e7f6a5b4c
 ```
 

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -34,10 +34,10 @@ export interface CliTelemetryEvent {
   anonymousId: string;
 }
 
-/** No production endpoint is deployed yet -- this default is a local-dev placeholder only.
- * Overridable via env var for whenever `apps/telemetry` is actually deployed, same override
- * convention `@alineo-labs/otel`'s own collector URL uses. */
-const DEFAULT_TELEMETRY_ENDPOINT = "http://localhost:3002/v1/events";
+/** The deployed ingest endpoint (see apps/telemetry). Overridable via env var, same override
+ * convention `@alineo-labs/otel`'s own collector URL uses -- useful for pointing at a local
+ * `apps/telemetry` instance during development instead. */
+const DEFAULT_TELEMETRY_ENDPOINT = "https://telemetry.alineo.tech/v1/events";
 const SEND_TIMEOUT_MS = 500;
 
 /** `ALINEO_TELEMETRY_CONFIG_PATH` is an internal test seam, not a documented user-facing setting
@@ -57,13 +57,12 @@ export async function readTelemetryConfig(): Promise<TelemetryConfig> {
   if (await file.exists()) {
     const data = (await file.json()) as Partial<TelemetryConfig>;
     return {
-      enabled: data.enabled ?? false,
+      enabled: data.enabled ?? true,
       anonymousId: data.anonymousId ?? newAnonymousId(),
       notifiedAt: data.notifiedAt ?? null,
     };
   }
-  // Default-off until apps/telemetry is actually deployed -- flip to `true` once it is.
-  return { enabled: false, anonymousId: newAnonymousId(), notifiedAt: null };
+  return { enabled: true, anonymousId: newAnonymousId(), notifiedAt: null };
 }
 
 export async function writeTelemetryConfig(config: TelemetryConfig): Promise<void> {

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -44,8 +44,8 @@ afterEach(async () => {
 });
 
 describe("envDisabled / isTelemetryDisabled", () => {
-  it("is disabled by default (no config file yet)", async () => {
-    expect(await isTelemetryDisabled()).toBe(true);
+  it("is enabled by default (no config file yet)", async () => {
+    expect(await isTelemetryDisabled()).toBe(false);
   });
 
   it("ALINEO_TELEMETRY_DISABLED disables regardless of persisted config", async () => {
@@ -66,6 +66,11 @@ describe("envDisabled / isTelemetryDisabled", () => {
     await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: null });
     expect(await isTelemetryDisabled()).toBe(false);
   });
+
+  it("is disabled once the persisted config explicitly opts out, with no env var set", async () => {
+    await writeTelemetryConfig({ enabled: false, anonymousId: "x", notifiedAt: null });
+    expect(await isTelemetryDisabled()).toBe(true);
+  });
 });
 
 describe("readTelemetryConfig / writeTelemetryConfig", () => {
@@ -77,7 +82,7 @@ describe("readTelemetryConfig / writeTelemetryConfig", () => {
 
   it("generates a fresh anonymousId when no config file exists yet", async () => {
     const config = await readTelemetryConfig();
-    expect(config.enabled).toBe(false);
+    expect(config.enabled).toBe(true);
     expect(config.anonymousId.length).toBeGreaterThan(0);
     expect(config.notifiedAt).toBeNull();
   });
@@ -138,6 +143,7 @@ describe("sendTelemetryEvent", () => {
 
 describe("withTelemetry", () => {
   it("calls run() directly when telemetry is disabled, without ever touching fetch", async () => {
+    await writeTelemetryConfig({ enabled: false, anonymousId: "x", notifiedAt: Date.now() });
     const fetchSpy = mock(() => {
       throw new Error("should not be called");
     });


### PR DESCRIPTION
## Summary
`apps/telemetry` is now deployed and reachable at `https://telemetry.alineo.tech` (systemd service on the VPS, Caddy-terminated TLS). This flips the CLI over from local-dev placeholder to the real thing:

- `DEFAULT_TELEMETRY_ENDPOINT`: `http://localhost:3002/v1/events` → `https://telemetry.alineo.tech/v1/events` (still overridable via `ALINEO_TELEMETRY_ENDPOINT`)
- `TelemetryConfig`'s default `enabled`: `false` → `true` — matches the Next.js/Astro/Turborepo default-on-with-opt-out precedent this feature was designed around; opt-out paths (`alineo telemetry disable`, `ALINEO_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`) are unchanged and unaffected
- Updated `packages/cli/test/telemetry.test.ts` for the new default (added a test for the explicit-opt-out path, which wasn't previously exercised since disabled was already the default)
- Updated `packages/cli/README.md` and the `alineo telemetry` docs page to describe the real, live behavior instead of "not deployed yet"

## Test plan
- [x] `bun test test/telemetry.test.ts` — 14/14 pass (13 existing + 1 new opt-out case)
- [x] `bun run typecheck` / `bun run test` / `bun run build` — all packages pass
- [x] `bun run format:check` — clean
- [x] `cd apps/docs && bun run build` — docs site builds with updated content
- [x] Manually verified `https://telemetry.alineo.tech/health` returns 200 with a valid cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)