### PR TITLE
Raise packages/agent's default inactivity timeout from 60s to 3 minutes

### DIFF
--- a/.changeset/agent-inactivity-timeout.md
+++ b/.changeset/agent-inactivity-timeout.md
@@ -1,0 +1,13 @@
+---
+"@alineo-labs/agent": patch
+---
+
+Raise `sseStream`'s default inactivity timeout from 60s to 3 minutes. Pi's own `bash` tool is
+not incrementally streamed, so a single tool call that spins up a whole child sandbox (e.g. a
+master session running `alineo fork` on itself, as in `examples/rlm-repo-fanout`) produces zero
+`AgentEvent`s for as long as that call takes — child sandbox provisioning plus Pi CLI install
+alone routinely took 30-150s+ in testing, regularly exceeding the old 60s default and killing
+otherwise-healthy sessions mid-run. Confirmed via a real `examples/rlm-repo-fanout` run: the
+exact `alineo fork` tool call that previously crashed the host script with `PromptTimeoutError`
+at 60s now completes normally under the new default. Callers needing something tighter or
+looser can still pass `inactivityTimeoutMs` explicitly to `prompt()`.

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -333,8 +333,18 @@ async function rpcGet<T>(bridgeUrl: string, path: string): Promise<T> {
  * of whether Pi itself is making progress, so this can't just be "no read() in N seconds". The
  * timer below is instead reset only when a real event is parsed and yielded (or `[DONE]`
  * arrives), so a connection that's alive-but-silent for this long still times out.
+ *
+ * 60s (the original default) was too tight for a common, legitimate pattern: Pi's own `bash`
+ * tool is not incrementally streamed (see the `bash()` doc comment in session-control.ts), so
+ * a single tool call that spins up a whole child sandbox -- e.g. a master session running
+ * `alineo fork` on itself, as in examples/rlm-repo-fanout -- produces zero AgentEvents for as
+ * long as that tool call takes, which regularly exceeded 60s (child sandbox provisioning +
+ * Pi CLI install alone routinely took 30-150s+ in practice) and tripped this timeout mid-run
+ * even though the session was making real progress. Raised to 3 minutes as a still-bounded
+ * but realistic ceiling for that pattern; pass `inactivityTimeoutMs` explicitly to `prompt()`
+ * for sessions that need something tighter or looser.
  */
-const DEFAULT_INACTIVITY_TIMEOUT_MS = 60_000;
+const DEFAULT_INACTIVITY_TIMEOUT_MS = 180_000;
 
 async function* sseStream(
   bridgeUrl: string,


### PR DESCRIPTION
## Summary
`sseStream`'s inactivity-timeout mechanism (packages/agent/src/adapters/pi.ts) is a good design — it exists specifically to surface genuinely-stuck sessions instead of hanging forever — but the 60s default was too tight for a common, legitimate pattern: Pi's own `bash` tool is not incrementally streamed, so a single tool call that spins up a whole child sandbox produces zero `AgentEvent`s for as long as that call takes.

Found this by actually running `examples/rlm-repo-fanout` (the project's flagship "master forks children" demo) end to end: the master's own `alineo fork rlm-fanout-master ...` bash tool call routinely took well over 60s (child sandbox provisioning + Pi CLI install alone: 30-150s+ observed), tripping `PromptTimeoutError` and crashing the whole host script even though the session was making real, healthy progress.

## Fix
Raised `DEFAULT_INACTIVITY_TIMEOUT_MS` from `60_000` to `180_000` (3 minutes) — still bounded/finite so genuinely-stuck sessions get caught, just a realistic ceiling for this pattern. Callers needing something tighter or looser can still pass `inactivityTimeoutMs` explicitly to `prompt()`.

## Verification
- Re-ran `examples/rlm-repo-fanout` end to end with the fix. The exact `alineo fork` tool call that previously crashed the host script at 60s now completes normally, and the master correctly reasons about the (separate, pre-existing, unrelated to this fix) "execd not ready" infra error it hits downstream — a much better failure mode than a silent host-level crash.
- `bun run typecheck` / `bun run test` / `bun run format:check` — all pass.
- Existing `packages/agent/test/pi-prompt-timeout.test.ts` tests are unaffected — both explicitly override `inactivityTimeoutMs` rather than relying on the default.

Note: this run also surfaced two further pre-existing, unrelated issues that were previously masked by the crash this PR fixes — an "execd not ready" infra error (same root cause as the `sandbox-extensions` example's `pause()`/`resume()` hang, tied to a stale execd image) and a gap where `Agent.attach()` doesn't start the Pi bridge, so calling `.bash()` on an attached agent throws. Neither is addressed here — out of scope for this fix, flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)