### PR TITLE
Bump execd image v1.0.19 -> v1.0.22 in alineo init's generated config

### DIFF
--- a/.changeset/bump-execd-image.md
+++ b/.changeset/bump-execd-image.md
@@ -1,0 +1,19 @@
+---
+"alineo-cli": patch
+---
+
+Bump the `execd` image `alineo init` pins in the generated `server.toml` from `v1.0.19` to
+`v1.0.22`. v1.0.19 predates cached bwrap-archive support, so every sandbox logged "bwrap
+archive not cached for linux/amd64 -- isolation will be unavailable" and the warning's own
+suggested fix ("upgrade execd image to v1.1.0+") pointed at a tag that was never actually
+published. Per OpenSandbox's docs, `execd` >=v1.0.20 has base isolation-session support and
+>=v1.0.21 is recommended for full functionality; v1.0.22 is the latest published patch.
+
+Note: this resolves the stale-image warning and lets execd's own isolation probe run cleanly,
+but does not by itself enable bwrap isolation end-to-end -- that additionally requires the
+sandbox-creation request to opt into `bootstrap.execd.isolation`, which grants the container
+`CAP_SYS_ADMIN` and unconfined apparmor/seccomp. This SDK does not do that by default (and
+deliberately doesn't turn it on unconditionally, since it would weaken every sandbox's default
+container security posture just to support a rarely-used feature) -- pause()/resume() and
+isolation-session-dependent features remain unavailable out of the box pending a real opt-in
+API for this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ port = 8080
 
 [runtime]
 type = "docker"
-execd_image = "opensandbox/execd:v1.0.19"
+execd_image = "opensandbox/execd:v1.0.22"
 
 [docker]
 network_mode = "bridge"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -174,7 +174,7 @@ port = 8080
 
 [runtime]
 type = "docker"
-execd_image = "opensandbox/execd:v1.0.19"
+execd_image = "opensandbox/execd:v1.0.22"
 
 [docker]
 network_mode = "bridge"

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -103,6 +103,14 @@ export function serverDataDir(): string {
   return join(serverConfigDir(), "opensandbox-data");
 }
 
+/**
+ * v1.0.19 (the previous pin) predates cached bwrap-archive support, so every sandbox logged
+ * "bwrap archive not cached for linux/amd64 -- isolation will be unavailable" and isolation
+ * sessions (and anything that depends on them, e.g. pause()/resume()) hung indefinitely
+ * instead of failing cleanly. OpenSandbox's own docs: >=v1.0.20 has base isolation-session
+ * support, >=v1.0.21 is recommended for full functionality -- the "v1.1.0+" the warning
+ * message itself suggests does not exist as a published tag. v1.0.22 is the latest.
+ */
 export function serverConfigContent(): string {
   return `[server]
 host = "0.0.0.0"
@@ -111,7 +119,7 @@ eip = "http://127.0.0.1:8080"
 
 [runtime]
 type = "docker"
-execd_image = "opensandbox/execd:v1.0.19"
+execd_image = "opensandbox/execd:v1.0.22"
 
 [docker]
 network_mode = "bridge"


### PR DESCRIPTION
## Summary
`alineo init` pins `execd_image = "opensandbox/execd:v1.0.19"` in the generated `server.toml`. v1.0.19 predates cached bwrap-archive support, so every sandbox logged `bwrap archive not cached for linux/amd64 -- isolation will be unavailable` — and the warning's own suggested fix ("upgrade execd image to v1.1.0+") points at a tag that doesn't actually exist on Docker Hub (the series only goes up to v1.0.22 before jumping to `latest`).

Per OpenSandbox's own docs (confirmed via DeepWiki): `execd` >=v1.0.20 has base isolation-session support, >=v1.0.21 is recommended for full functionality. Bumped to v1.0.22, the latest published patch. Also fixed the same stale version string in `CLAUDE.md` and `packages/cli/README.md`'s example `~/.sandbox.toml` snippets (the manual `uvx opensandbox-server` path).

## What this does and doesn't fix
Verified locally: regenerated `server.toml` with this pin, restarted the OpenSandbox container, and confirmed the sandbox logs now show `bwrap found (v0.11.2)` with the "not cached" warning gone.

It does **not** fix `pause()`/`resume()` or other isolation-session features end to end. That additionally requires the sandbox-creation request to opt into `bootstrap.execd.isolation`, which grants the container `CAP_SYS_ADMIN` and unconfined apparmor/seccomp — a real weakening of every sandbox's default container security posture. Deliberately not wiring that up unconditionally in this PR; noted in the changeset as a known gap pending a real opt-in API (e.g. a `SandboxOptions` flag) in a future change.

## Test plan
- [x] `bunx tsc --noEmit --strict` on packages/cli — passes
- [x] `bun test` (packages/cli) — passes
- [x] `bunx changeset status --since origin/main` — passes
- [x] Manually verified against a live OpenSandbox server: the "bwrap archive not cached" warning is gone after the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)