### PR TITLE
Fix SQLiteAdapter throwing SQLITE_CANTOPEN on a missing parent directory

### DIFF
--- a/.changeset/sqlite-adapter-mkdir.md
+++ b/.changeset/sqlite-adapter-mkdir.md
@@ -1,0 +1,10 @@
+---
+"@alineo-labs/sqlite": patch
+---
+
+`SQLiteAdapter`'s constructor now creates missing parent directories before opening the
+database file. `bun:sqlite`'s `create: true` only creates the db *file*, not its containing
+directory, so the common `new SQLiteAdapter("./.alineo/ledger.db")` pattern threw
+`SQLITE_CANTOPEN` on a fresh checkout unless `.alineo/` already happened to exist -- hit this
+independently on three separate examples (`pi-agent`, `sandbox-extensions`,
+`rlm-repo-fanout`) that all use exactly this pattern.

--- a/packages/adapters/sqlite/src/adapter.ts
+++ b/packages/adapters/sqlite/src/adapter.ts
@@ -1,4 +1,6 @@
 import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import type {
   IStorageAdapter,
   LedgerEntry,
@@ -97,6 +99,12 @@ export class SQLiteAdapter implements IStorageAdapter {
   private readonly db: Database;
 
   constructor(path: string) {
+    // create: true only creates the db *file* -- bun:sqlite doesn't create missing parent
+    // directories, so a fresh checkout using the common `new SQLiteAdapter("./.alineo/ledger.db")`
+    // pattern throws SQLITE_CANTOPEN before ever getting a chance to write anything. Safe to
+    // call unconditionally: dirname(":memory:") is ".", and mkdirSync(".", {recursive:true}) is
+    // a no-op.
+    mkdirSync(dirname(path), { recursive: true });
     this.db = new Database(path, { create: true });
   }
 

--- a/packages/adapters/sqlite/test/adapter.test.ts
+++ b/packages/adapters/sqlite/test/adapter.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LedgerEvent, SandboxStatus, type LedgerEntry } from "@alineo-labs/core";
 import { SQLiteAdapter } from "../src/adapter.ts";
 
@@ -304,6 +307,26 @@ describe("SQLiteAdapter", () => {
       });
       await db.deleteEnvironment("py");
       expect(await db.getEnvironment("node")).not.toBeNull();
+    });
+  });
+
+  describe("constructor", () => {
+    it("creates missing parent directories instead of throwing SQLITE_CANTOPEN", async () => {
+      const root = join(tmpdir(), `alineo-sqlite-test-${Date.now()}`);
+      const dir = join(root, "nested", "path");
+      const dbPath = join(dir, "ledger.db");
+      expect(existsSync(dir)).toBe(false);
+
+      const nested = new SQLiteAdapter(dbPath);
+      try {
+        await nested.connect();
+        await nested.append(entry());
+        expect(await nested.readAll("test-session", "session-1")).toHaveLength(1);
+        expect(existsSync(dbPath)).toBe(true);
+      } finally {
+        await nested.close();
+        rmSync(root, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
`bun:sqlite`'s `create: true` only creates the db *file*, not its containing directory. The common `new SQLiteAdapter("./.alineo/ledger.db")` pattern used throughout `examples/` throws `SQLITE_CANTOPEN` immediately on a fresh checkout unless `.alineo/` already happens to exist.

Found this hitting independently on three separate examples (`pi-agent`, `sandbox-extensions`, `rlm-repo-fanout`) while testing the published CLI end to end — none of them work out of the box on a truly fresh clone without manually pre-creating the directory first.

## Fix
`mkdirSync(dirname(path), { recursive: true })` before opening the database. Safe for `:memory:` too — `dirname(":memory:")` is `"."`, so the mkdir is a no-op.

## Test plan
- [x] New test: constructing with a nested, non-existent directory path creates it and the adapter works normally afterward
- [x] `bun test` (packages/adapters/sqlite) — 30/30 pass (was 29)
- [x] `bunx tsc --noEmit --strict` — passes
- [x] `bun run build` — passes
- [x] `bunx changeset status --since origin/main` — passes
- [x] `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)