### PR TITLE
docs: add Examples, Cookbook, FAQ, and llms.txt/llms-full.txt

### DIFF
--- a/.changeset/docs-supportive-sections.md
+++ b/.changeset/docs-supportive-sections.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Add Cookbook, Examples, and FAQ sections plus llms.txt/llms-full.txt to the docs site. Examples is a new fumadocs collection sourced from the real `examples/*/README.md` files via `<include>` (single source of truth, no content duplication); Cookbook surfaces the existing Core SDK patterns pages under a new top-level nav item; llms.txt/llms-full.txt give LLM crawlers a plain-text index and full-text dump of all docs.

--- a/apps/docs/content/docs/examples/cancellation.mdx
+++ b/apps/docs/content/docs/examples/cancellation.mdx
@@ -1,0 +1,6 @@
+---
+title: Cancellation & Cleanup
+description: Resource cleanup and error handling when commands fail or time out.
+---
+
+<include cwd>../../examples/cancellation/README.md</include>

--- a/apps/docs/content/docs/examples/capture.mdx
+++ b/apps/docs/content/docs/examples/capture.mdx
@@ -1,0 +1,6 @@
+---
+title: Capturing Output
+description: Capture exec stdout and use it as input for subsequent steps.
+---
+
+<include cwd>../../examples/capture/README.md</include>

--- a/apps/docs/content/docs/examples/control-flow.mdx
+++ b/apps/docs/content/docs/examples/control-flow.mdx
@@ -1,0 +1,6 @@
+---
+title: Control Flow
+description: retry, when, and forEach — alineo's built-in workflow control-flow primitives.
+---
+
+<include cwd>../../examples/control-flow/README.md</include>

--- a/apps/docs/content/docs/examples/environments.mdx
+++ b/apps/docs/content/docs/examples/environments.mdx
@@ -1,0 +1,6 @@
+---
+title: Reusable Environments
+description: Build a sandbox image once, then restore from snapshot on every run.
+---
+
+<include cwd>../../examples/environments/README.md</include>

--- a/apps/docs/content/docs/examples/error-handling.mdx
+++ b/apps/docs/content/docs/examples/error-handling.mdx
@@ -1,0 +1,6 @@
+---
+title: Error Handling
+description: Strict vs. non-strict exec, and the CommandError/SandboxError/ExecConnectionError types.
+---
+
+<include cwd>../../examples/error-handling/README.md</include>

--- a/apps/docs/content/docs/examples/exec-code.mdx
+++ b/apps/docs/content/docs/examples/exec-code.mdx
@@ -1,0 +1,6 @@
+---
+title: Code Interpreter
+description: Run code through the sandbox's built-in interpreter — stateless and stateful modes.
+---
+
+<include cwd>../../examples/exec-code/README.md</include>

--- a/apps/docs/content/docs/examples/file-ops.mdx
+++ b/apps/docs/content/docs/examples/file-ops.mdx
@@ -1,0 +1,6 @@
+---
+title: File Operations
+description: The full sandbox file operations API — read, write, move, search, and transfer.
+---
+
+<include cwd>../../examples/file-ops/README.md</include>

--- a/apps/docs/content/docs/examples/hello-world.mdx
+++ b/apps/docs/content/docs/examples/hello-world.mdx
@@ -1,0 +1,6 @@
+---
+title: Hello World
+description: Spin up an Ubuntu sandbox, run a command, and stream the output.
+---
+
+<include cwd>../../examples/hello-world/README.md</include>

--- a/apps/docs/content/docs/examples/index.mdx
+++ b/apps/docs/content/docs/examples/index.mdx
@@ -1,0 +1,79 @@
+---
+title: Examples
+description: Runnable examples covering every corner of the alineo SDK — clone, install, and run.
+---
+
+Every example below is a real, runnable package in the [alineo repo](https://github.com/DrejT/alineo/tree/main/examples) — `bunx alineo-cli init`, `bun install`, `bun start`.
+
+<Cards>
+  <Card
+    href="/docs/examples/hello-world"
+    title="Hello World"
+    description="Spin up an Ubuntu sandbox, run a command, and stream the output."
+  />
+  <Card
+    href="/docs/examples/exec-code"
+    title="Code Interpreter"
+    description="Run code through the sandbox's built-in interpreter — stateless and stateful modes."
+  />
+  <Card
+    href="/docs/examples/file-ops"
+    title="File Operations"
+    description="The full sandbox file operations API — read, write, move, search, and transfer."
+  />
+  <Card
+    href="/docs/examples/read-file"
+    title="Reading Files"
+    description="Read a file written inside the sandbox back to the host process."
+  />
+  <Card
+    href="/docs/examples/capture"
+    title="Capturing Output"
+    description="Capture exec stdout and use it as input for subsequent steps."
+  />
+  <Card
+    href="/docs/examples/run-bash-script"
+    title="Running Bash Scripts"
+    description="Run a multi-line bash script inside an isolated sandbox and stream its output."
+  />
+  <Card
+    href="/docs/examples/interactive-exec"
+    title="Interactive Exec"
+    description="A live, bidirectional PTY session that can be checkpointed and resumed mid-session."
+  />
+  <Card
+    href="/docs/examples/ports"
+    title="Exposing Ports"
+    description="Start an HTTP server inside a sandbox and reach it from the host via sb.proxy()."
+  />
+  <Card
+    href="/docs/examples/control-flow"
+    title="Control Flow"
+    description="retry, when, and forEach — alineo's built-in workflow control-flow primitives."
+  />
+  <Card
+    href="/docs/examples/cancellation"
+    title="Cancellation & Cleanup"
+    description="Resource cleanup and error handling when commands fail or time out."
+  />
+  <Card
+    href="/docs/examples/error-handling"
+    title="Error Handling"
+    description="Strict vs. non-strict exec, and the CommandError/SandboxError/ExecConnectionError types."
+  />
+  <Card
+    href="/docs/examples/environments"
+    title="Reusable Environments"
+    description="Build a sandbox image once, then restore from snapshot on every run."
+  />
+  <Card
+    href="/docs/examples/snapshot-replay"
+    title="Checkpoint & Resume"
+    description="Capture a snapshot after install, then resume from it to skip setup on the next run."
+  />
+  <Card
+    href="/docs/examples/sandbox-fork"
+    title="Forking Sandboxes"
+    description="Install dependencies once, then fork into independent sandboxes that run in parallel."
+  />
+</Cards>

--- a/apps/docs/content/docs/examples/interactive-exec.mdx
+++ b/apps/docs/content/docs/examples/interactive-exec.mdx
@@ -1,0 +1,6 @@
+---
+title: Interactive Exec
+description: A live, bidirectional PTY session that can be checkpointed and resumed mid-session.
+---
+
+<include cwd>../../examples/interactive-exec/README.md</include>

--- a/apps/docs/content/docs/examples/meta.json
+++ b/apps/docs/content/docs/examples/meta.json
@@ -1,0 +1,19 @@
+{
+  "title": "Examples",
+  "pages": [
+    "hello-world",
+    "exec-code",
+    "file-ops",
+    "read-file",
+    "capture",
+    "run-bash-script",
+    "interactive-exec",
+    "ports",
+    "control-flow",
+    "cancellation",
+    "error-handling",
+    "environments",
+    "snapshot-replay",
+    "sandbox-fork"
+  ]
+}

--- a/apps/docs/content/docs/examples/ports.mdx
+++ b/apps/docs/content/docs/examples/ports.mdx
@@ -1,0 +1,6 @@
+---
+title: Exposing Ports
+description: Start an HTTP server inside a sandbox and reach it from the host via sb.proxy().
+---
+
+<include cwd>../../examples/ports/README.md</include>

--- a/apps/docs/content/docs/examples/read-file.mdx
+++ b/apps/docs/content/docs/examples/read-file.mdx
@@ -1,0 +1,6 @@
+---
+title: Reading Files
+description: Read a file written inside the sandbox back to the host process.
+---
+
+<include cwd>../../examples/read-file/README.md</include>

--- a/apps/docs/content/docs/examples/run-bash-script.mdx
+++ b/apps/docs/content/docs/examples/run-bash-script.mdx
@@ -1,0 +1,6 @@
+---
+title: Running Bash Scripts
+description: Run a multi-line bash script inside an isolated sandbox and stream its output.
+---
+
+<include cwd>../../examples/run-bash-script/README.md</include>

--- a/apps/docs/content/docs/examples/sandbox-fork.mdx
+++ b/apps/docs/content/docs/examples/sandbox-fork.mdx
@@ -1,0 +1,6 @@
+---
+title: Forking Sandboxes
+description: Install dependencies once, then fork into independent sandboxes that run in parallel.
+---
+
+<include cwd>../../examples/sandbox-fork/README.md</include>

--- a/apps/docs/content/docs/examples/snapshot-replay.mdx
+++ b/apps/docs/content/docs/examples/snapshot-replay.mdx
@@ -1,0 +1,6 @@
+---
+title: Checkpoint & Resume
+description: Capture a snapshot after install, then resume from it to skip setup on the next run.
+---
+
+<include cwd>../../examples/snapshot-replay/README.md</include>

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,8 +1,11 @@
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 
-export const coreDocs = defineDocs({ dir: "content/docs/core" });
-export const workflowDocs = defineDocs({ dir: "content/docs/workflow" });
-export const alineoDocs = defineDocs({ dir: "content/docs/alineo" });
-export const agentDocs = defineDocs({ dir: "content/docs/agent" });
+const docs = { postprocess: { includeProcessedMarkdown: true } };
+
+export const coreDocs = defineDocs({ dir: "content/docs/core", docs });
+export const workflowDocs = defineDocs({ dir: "content/docs/workflow", docs });
+export const alineoDocs = defineDocs({ dir: "content/docs/alineo", docs });
+export const agentDocs = defineDocs({ dir: "content/docs/agent", docs });
+export const examplesDocs = defineDocs({ dir: "content/docs/examples", docs });
 
 export default defineConfig();

--- a/apps/docs/src/app/api/search/route.ts
+++ b/apps/docs/src/app/api/search/route.ts
@@ -1,5 +1,11 @@
 import { createSearchAPI } from "fumadocs-core/search/server";
-import { coreSource, workflowSource, alineoSource, agentSource } from "@/lib/source";
+import {
+  coreSource,
+  workflowSource,
+  alineoSource,
+  agentSource,
+  examplesSource,
+} from "@/lib/source";
 
 export const dynamic = "force-static";
 
@@ -8,6 +14,7 @@ const allPages = [
   ...workflowSource.getPages(),
   ...alineoSource.getPages(),
   ...agentSource.getPages(),
+  ...examplesSource.getPages(),
 ];
 
 export const { staticGET: GET } = createSearchAPI("advanced", {

--- a/apps/docs/src/app/cookbook/page.tsx
+++ b/apps/docs/src/app/cookbook/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import { Card, Cards } from "fumadocs-ui/components/card";
+
+export const metadata: Metadata = {
+  title: "Cookbook",
+  description: "Task-oriented recipes for building with alineo.",
+};
+
+export default function CookbookPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col items-start gap-6 px-6 py-24">
+      <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">Cookbook</h1>
+      <p className="text-fd-muted-foreground">
+        Recipes for handling failure, time, and observability in the Core SDK. Workflow, Agent, and
+        CLI recipes are on the way.
+      </p>
+      <Cards>
+        <Card
+          href="/docs/core/patterns/timeouts-and-cancellation"
+          title="Timeouts & cancellation"
+          description="Sandbox lifetime, bash timeout command, and try/finally cleanup."
+        />
+        <Card
+          href="/docs/core/patterns/error-handling"
+          title="Error handling"
+          description="Strict vs non-strict exec, CommandError, SandboxError, and ExecConnectionError."
+        />
+        <Card
+          href="/docs/core/patterns/run-management"
+          title="Run management"
+          description="List, resume, and delete runs from the ledger."
+        />
+        <Card
+          href="/docs/core/patterns/named-checkpoints"
+          title="Named checkpoints"
+          description="Save and restore sandbox state under a name you choose."
+        />
+        <Card
+          href="/docs/core/patterns/fork"
+          title="Forking sandboxes"
+          description="Branch a sandbox into independent copies without repeating setup."
+        />
+        <Card
+          href="/docs/core/patterns/observability"
+          title="Observability"
+          description="WorkflowHooks and OpenTelemetry tracing with @alineo-labs/otel."
+        />
+        <Card
+          href="/docs/core/patterns/flue"
+          title="Flue integration"
+          description="Use alineo sandboxes as Flue session environments with @alineo-labs/flue."
+        />
+      </Cards>
+    </div>
+  );
+}

--- a/apps/docs/src/app/cookbook/page.tsx
+++ b/apps/docs/src/app/cookbook/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Card, Cards } from "fumadocs-ui/components/card";
 
 export const metadata: Metadata = {
   title: "Cookbook",
@@ -8,49 +7,11 @@ export const metadata: Metadata = {
 
 export default function CookbookPage() {
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-6 py-24">
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 px-6 py-24">
       <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">Cookbook</h1>
       <p className="text-fd-muted-foreground">
-        Recipes for handling failure, time, and observability in the Core SDK. Workflow, Agent, and
-        CLI recipes are on the way.
+        Coming soon — task-oriented recipes for building with alineo.
       </p>
-      <Cards>
-        <Card
-          href="/docs/core/patterns/timeouts-and-cancellation"
-          title="Timeouts & cancellation"
-          description="Sandbox lifetime, bash timeout command, and try/finally cleanup."
-        />
-        <Card
-          href="/docs/core/patterns/error-handling"
-          title="Error handling"
-          description="Strict vs non-strict exec, CommandError, SandboxError, and ExecConnectionError."
-        />
-        <Card
-          href="/docs/core/patterns/run-management"
-          title="Run management"
-          description="List, resume, and delete runs from the ledger."
-        />
-        <Card
-          href="/docs/core/patterns/named-checkpoints"
-          title="Named checkpoints"
-          description="Save and restore sandbox state under a name you choose."
-        />
-        <Card
-          href="/docs/core/patterns/fork"
-          title="Forking sandboxes"
-          description="Branch a sandbox into independent copies without repeating setup."
-        />
-        <Card
-          href="/docs/core/patterns/observability"
-          title="Observability"
-          description="WorkflowHooks and OpenTelemetry tracing with @alineo-labs/otel."
-        />
-        <Card
-          href="/docs/core/patterns/flue"
-          title="Flue integration"
-          description="Use alineo sandboxes as Flue session environments with @alineo-labs/flue."
-        />
-      </Cards>
     </div>
   );
 }

--- a/apps/docs/src/app/cookbook/page.tsx
+++ b/apps/docs/src/app/cookbook/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function CookbookPage() {
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col items-start gap-6 px-6 py-24">
+    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-6 py-24">
       <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">Cookbook</h1>
       <p className="text-fd-muted-foreground">
         Recipes for handling failure, time, and observability in the Core SDK. Workflow, Agent, and

--- a/apps/docs/src/app/docs-og/[collection]/[...slug]/route.tsx
+++ b/apps/docs/src/app/docs-og/[collection]/[...slug]/route.tsx
@@ -1,5 +1,11 @@
 import { ImageResponse } from "next/og";
-import { coreSource, workflowSource, alineoSource, agentSource } from "@/lib/source";
+import {
+  coreSource,
+  workflowSource,
+  alineoSource,
+  agentSource,
+  examplesSource,
+} from "@/lib/source";
 import { loadOgFonts, ogImageSize, renderOgImage } from "@/lib/og-image";
 
 const SOURCES = {
@@ -7,6 +13,7 @@ const SOURCES = {
   workflow: workflowSource,
   alineo: alineoSource,
   agent: agentSource,
+  examples: examplesSource,
 } as const;
 
 type Collection = keyof typeof SOURCES;

--- a/apps/docs/src/app/docs/examples/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/examples/[[...slug]]/page.tsx
@@ -1,0 +1,55 @@
+import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/layouts/docs/page";
+import { examplesSource } from "@/lib/source";
+import { notFound } from "next/navigation";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+import type { Metadata } from "next";
+import { createMetadata } from "@/lib/metadata";
+
+const OVERVIEW_SLUGS = new Set([""]);
+
+export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
+  const { slug } = await params;
+  const page = examplesSource.getPage(slug);
+  if (!page) notFound();
+
+  const MDX = page.data.body;
+  const slugStr = (slug ?? []).join("/");
+  const isOverview = OVERVIEW_SLUGS.has(slugStr);
+
+  return (
+    <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocsTitle>{page.data.title}</DocsTitle>
+      {page.data.description && <DocsDescription>{page.data.description}</DocsDescription>}
+      <DocsBody>
+        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const page = examplesSource.getPage(slug);
+  if (!page) return createMetadata({ title: "Not Found" });
+
+  const ogImage = [`/docs-og/examples`, ...(slug ?? []), "image"].join("/");
+
+  return createMetadata({
+    title: page.data.title,
+    description: page.data.description,
+    alternates: { canonical: page.url },
+    openGraph: { images: [ogImage] },
+    twitter: { images: [ogImage] },
+  });
+}
+
+export async function generateStaticParams() {
+  return examplesSource.getPages().map((page) => ({
+    slug: page.slugs,
+  }));
+}

--- a/apps/docs/src/app/docs/examples/layout.tsx
+++ b/apps/docs/src/app/docs/examples/layout.tsx
@@ -1,0 +1,17 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { examplesSource } from "@/lib/source";
+import { docsTabs } from "@/lib/nav-tabs";
+
+export default function ExamplesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DocsLayout
+      tree={examplesSource.pageTree}
+      nav={{ enabled: true, title: null }}
+      themeSwitch={{ enabled: false }}
+      searchToggle={{ enabled: false }}
+      tabs={docsTabs}
+    >
+      {children}
+    </DocsLayout>
+  );
+}

--- a/apps/docs/src/app/faq/page.tsx
+++ b/apps/docs/src/app/faq/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+
+export const metadata: Metadata = {
+  title: "FAQ",
+  description: "Common questions about alineo, OpenSandbox, and getting set up.",
+};
+
+export default function FaqPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col items-start gap-6 px-6 py-24">
+      <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">FAQ</h1>
+      <Accordions type="single">
+        <Accordion title="What is OpenSandbox, and do I need Docker?">
+          alineo runs sandboxes against an <a href="https://open-sandbox.ai">OpenSandbox</a>{" "}
+          instance — it's the container runtime underneath. The fastest way to get one locally is{" "}
+          <code>bunx alineo-cli init</code>, which starts OpenSandbox in Docker and configures
+          alineo to talk to it automatically. If you'd rather not use Docker, you can run{" "}
+          <code>uvx opensandbox-server</code> directly on your host instead — see the{" "}
+          <a href="/docs/alineo/getting-started">alineo CLI docs</a> for both paths.
+        </Accordion>
+        <Accordion title="SQLite or Postgres — which storage adapter should I use?">
+          SQLite (<code>@alineo-labs/sqlite</code>) is the right default for local development and
+          single-process deployments — zero config, WAL mode, nothing to run. Postgres (
+          <code>@alineo-labs/postgres</code>) is for production, multi-process deployments that need
+          a shared ledger across instances. Both implement the same <code>IStorageAdapter</code>{" "}
+          interface, so switching later is a one-line change — see{" "}
+          <a href="/docs/core/adapters">Storage Adapters</a>.
+        </Accordion>
+        <Accordion title="What's the difference between alineo, @alineo-labs/workflow, and @alineo-labs/agent?">
+          <code>alineo</code> is the core SDK — the <code>Alineo</code> client and the{" "}
+          <code>Sandbox</code> object itself (spawn, exec, checkpoint, resume).{" "}
+          <code>@alineo-labs/workflow</code> adds a lazy pipeline builder on top — retry, branching,
+          and fan-out across multiple sandboxes. <code>@alineo-labs/agent</code> runs Pi coding
+          agents inside a sandbox container. You only need <code>workflow</code> or{" "}
+          <code>agent</code> if you're using their specific features — plain sandbox usage only
+          needs the core <code>alineo</code> package.
+        </Accordion>
+        <Accordion title="Does alineo work on Windows?">
+          Yes — the repo has native cross-platform support and can be developed directly on Windows
+          without WSL or Git Bash. Repository scripts use Bun's native shell APIs, and{" "}
+          <code>alineo init</code> detects Windows and uses named pipes (
+          <code>//./pipe/docker_engine</code>) for Docker socket injection automatically.
+        </Accordion>
+        <Accordion title="Is alineo open source?">
+          Yes — Apache 2.0, and published to npm as <code>alineo</code>. The source is at{" "}
+          <a href="https://github.com/DrejT/alineo">github.com/DrejT/alineo</a>.
+        </Accordion>
+      </Accordions>
+    </div>
+  );
+}

--- a/apps/docs/src/app/faq/page.tsx
+++ b/apps/docs/src/app/faq/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function FaqPage() {
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col items-start gap-6 px-6 py-24">
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-6 py-24">
       <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">FAQ</h1>
       <Accordions type="single">
         <Accordion title="What is OpenSandbox, and do I need Docker?">

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -67,6 +67,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             themeSwitch={{ enabled: false }}
             links={[
               { text: "Docs", url: "/docs/core", active: "nested-url" },
+              { text: "Cookbook", url: "/cookbook", active: "nested-url" },
+              { text: "FAQ", url: "/faq", active: "nested-url" },
               { text: "Use Cases", url: "/use-cases", active: "nested-url" },
               { text: "Changelog", url: "/changelog", active: "nested-url" },
             ]}

--- a/apps/docs/src/app/llms-full.txt/route.ts
+++ b/apps/docs/src/app/llms-full.txt/route.ts
@@ -1,0 +1,22 @@
+import {
+  coreSource,
+  workflowSource,
+  agentSource,
+  alineoSource,
+  examplesSource,
+} from "@/lib/source";
+import { getLLMText } from "@/lib/get-llm-text";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  const allPages = [
+    ...coreSource.getPages(),
+    ...workflowSource.getPages(),
+    ...agentSource.getPages(),
+    ...alineoSource.getPages(),
+    ...examplesSource.getPages(),
+  ];
+  const scanned = await Promise.all(allPages.map(getLLMText));
+  return new Response(scanned.join("\n\n---\n\n"));
+}

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -1,0 +1,24 @@
+import { llms } from "fumadocs-core/source";
+import {
+  coreSource,
+  workflowSource,
+  agentSource,
+  alineoSource,
+  examplesSource,
+} from "@/lib/source";
+import { DEFAULT_DESCRIPTION } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+
+const SECTIONS = [
+  ["Core SDK", coreSource],
+  ["Workflow Builder", workflowSource],
+  ["Agent SDK", agentSource],
+  ["alineo CLI", alineoSource],
+  ["Examples", examplesSource],
+] as const;
+
+export function GET() {
+  const body = SECTIONS.map(([, source]) => llms(source).index()).join("\n\n");
+  return new Response(`# alineo docs\n\n> ${DEFAULT_DESCRIPTION}\n\n${body}\n`);
+}

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -1,12 +1,18 @@
 import type { MetadataRoute } from "next";
-import { coreSource, workflowSource, alineoSource, agentSource } from "@/lib/source";
+import {
+  coreSource,
+  workflowSource,
+  alineoSource,
+  agentSource,
+  examplesSource,
+} from "@/lib/source";
 
 export const dynamic = "force-static";
 
 const BASE_URL = "https://docs.alineo.tech";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const sources = [coreSource, workflowSource, alineoSource, agentSource];
+  const sources = [coreSource, workflowSource, alineoSource, agentSource, examplesSource];
 
   const docPages = sources.flatMap((source) =>
     source.getPages().map((page) => ({
@@ -32,6 +38,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${BASE_URL}/use-cases`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/cookbook`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/faq`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.5,

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,0 +1,13 @@
+interface LLMPage {
+  url: string;
+  data: {
+    title: string;
+    description?: string;
+    getText: (type: "processed") => Promise<string>;
+  };
+}
+
+export async function getLLMText(page: LLMPage) {
+  const content = await page.data.getText("processed");
+  return `# ${page.data.title}\nURL: ${page.url}\n\n${page.data.description ?? ""}\n\n${content}`;
+}

--- a/apps/docs/src/lib/nav-tabs.tsx
+++ b/apps/docs/src/lib/nav-tabs.tsx
@@ -1,4 +1,4 @@
-import { Package, Workflow, Bot, Terminal } from "lucide-react";
+import { Package, Workflow, Bot, Terminal, FlaskConical } from "lucide-react";
 import type { LayoutTab } from "fumadocs-ui/layouts/shared";
 
 export const docsTabs: LayoutTab[] = [
@@ -25,5 +25,11 @@ export const docsTabs: LayoutTab[] = [
     title: "alineo CLI",
     description: "alineo-cli",
     icon: <Terminal className="size-4" />,
+  },
+  {
+    url: "/docs/examples",
+    title: "Examples",
+    description: "Runnable examples",
+    icon: <FlaskConical className="size-4" />,
   },
 ];

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,4 +1,4 @@
-import { coreDocs, workflowDocs, alineoDocs, agentDocs } from "collections/server";
+import { coreDocs, workflowDocs, alineoDocs, agentDocs, examplesDocs } from "collections/server";
 import { loader } from "fumadocs-core/source";
 
 export const coreSource = loader({
@@ -19,4 +19,9 @@ export const alineoSource = loader({
 export const agentSource = loader({
   baseUrl: "/docs/agent",
   source: agentDocs.toFumadocsSource(),
+});
+
+export const examplesSource = loader({
+  baseUrl: "/docs/examples",
+  source: examplesDocs.toFumadocsSource(),
 });


### PR DESCRIPTION
## Summary
- **Examples** (`/docs/examples`) — new fumadocs collection, 14 pages sourced live from the real `examples/*/README.md` via `<include>` so setup/run instructions stay a single source of truth. Wired into search, sitemap, per-page OG images, and the in-docs tab switcher.
- **Cookbook** (`/cookbook`) — new top-level nav page. Content is blanked to a "Coming soon" placeholder for now, at the user's request — infrastructure (route, nav entry, sitemap) is in place for when recipes land.
- **FAQ** (`/faq`) — answers 5 common questions (OpenSandbox/Docker setup, SQLite vs Postgres, package boundaries, Windows support, license), grounded in already-documented repo content.
- **`llms.txt` / `llms-full.txt`** — plain-text index and full-text dump of all 5 doc collections for LLM crawlers, following the pattern fumadocs' own docs site uses.

Plan: `plans/docs-supportive-sections.md` (local, gitignored).

Fixes a layout bug found while reviewing on the dev server: `<Cards>` grids collapsed to a single narrow min-content column on the Cookbook/FAQ pages because their wrapper used `flex-col items-start`, which makes CSS Grid's `fr` tracks compute a tiny intrinsic width under shrink-to-fit sizing. Existing MDX doc pages never hit this since `DocsBody` renders in a plain block container, not a flex column.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` — all 195 routes generate successfully, including the 14 new Examples pages, `/cookbook`, `/faq`, `/llms.txt`, `/llms-full.txt`
- [x] Inspected built output directly: `out/llms.txt` / `out/llms-full.txt` content, rendered example HTML (confirmed `<include>` resolves real README content), per-example OG images present in `out/docs-og/examples/`
- [x] `oxfmt --check` clean
- [x] Verified on running dev server via curl + structural HTML inspection, then via screenshot (caught and fixed the Cards grid bug)
- [x] Changeset added (`docs`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)