### PR TITLE
Add cookbooks: task-oriented recipes inspired by Composio's examples

### DIFF
--- a/.changeset/cookbooks-section.md
+++ b/.changeset/cookbooks-section.md
@@ -1,0 +1,8 @@
+---
+"docs": patch
+---
+
+Add a Cookbooks section: a new fumadocs collection (`/docs/cookbooks`) sourced from the real
+`cookbooks/*/README.md` files via `<include>`, wired into the sidebar tab switcher, sitemap,
+llms.txt/llms-full.txt, and OG image generation the same way Examples already is. The standalone
+`/cookbook` marketing page now lists these recipes instead of showing "Coming soon".

--- a/apps/docs/content/docs/cookbooks/ai-agent-bugfix.mdx
+++ b/apps/docs/content/docs/cookbooks/ai-agent-bugfix.mdx
@@ -1,0 +1,6 @@
+---
+title: AI Agent Bugfix
+description: An agent that debugs and fixes a failing test on its own, then gets independently verified.
+---
+
+<include cwd>../../cookbooks/ai-agent-bugfix/README.md</include>

--- a/apps/docs/content/docs/cookbooks/ci-test-runner.mdx
+++ b/apps/docs/content/docs/cookbooks/ci-test-runner.mdx
@@ -1,0 +1,6 @@
+---
+title: CI Test Runner
+description: Run a repo's test suite in a disposable sandbox and turn the output into a structured pass/fail report.
+---
+
+<include cwd>../../cookbooks/ci-test-runner/README.md</include>

--- a/apps/docs/content/docs/cookbooks/index.mdx
+++ b/apps/docs/content/docs/cookbooks/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Cookbooks
+description: Task-oriented recipes for building with alineo — composed from the SDK's primitives to solve real end-to-end problems.
+---
+
+Every recipe below is a real, runnable package in the
+[alineo repo](https://github.com/DrejT/alineo/tree/main/cookbooks) — `cd cookbooks/<recipe>`,
+`bun install`, `bun start`. Where [Examples](/docs/examples) demonstrates one SDK primitive at a
+time, a cookbook recipe composes several of them to solve one real task.
+
+<Cards>
+  <Card
+    href="/docs/cookbooks/untrusted-code-execution"
+    title="Untrusted Code Execution"
+    description="Safely run LLM-generated or user-submitted code — per-snippet isolation, resource caps, and timeouts."
+  />
+  <Card
+    href="/docs/cookbooks/ci-test-runner"
+    title="CI Test Runner"
+    description="Run a repo's test suite in a disposable sandbox and turn the output into a structured pass/fail report."
+  />
+  <Card
+    href="/docs/cookbooks/parallel-test-shards"
+    title="Parallel Test Shards"
+    description="Install dependencies once, then fork into parallel sandboxes to shard work across them."
+  />
+  <Card
+    href="/docs/cookbooks/resumable-etl-pipeline"
+    title="Resumable ETL Pipeline"
+    description="A multi-stage pipeline that checkpoints after every stage and resumes without redoing completed work."
+  />
+  <Card
+    href="/docs/cookbooks/ai-agent-bugfix"
+    title="AI Agent Bugfix"
+    description="An agent that debugs and fixes a failing test on its own, then gets independently verified."
+  />
+</Cards>

--- a/apps/docs/content/docs/cookbooks/meta.json
+++ b/apps/docs/content/docs/cookbooks/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Cookbooks",
+  "pages": [
+    "untrusted-code-execution",
+    "ci-test-runner",
+    "parallel-test-shards",
+    "resumable-etl-pipeline",
+    "ai-agent-bugfix"
+  ]
+}

--- a/apps/docs/content/docs/cookbooks/parallel-test-shards.mdx
+++ b/apps/docs/content/docs/cookbooks/parallel-test-shards.mdx
@@ -1,0 +1,6 @@
+---
+title: Parallel Test Shards
+description: Install dependencies once, then fork into parallel sandboxes to shard work across them.
+---
+
+<include cwd>../../cookbooks/parallel-test-shards/README.md</include>

--- a/apps/docs/content/docs/cookbooks/resumable-etl-pipeline.mdx
+++ b/apps/docs/content/docs/cookbooks/resumable-etl-pipeline.mdx
@@ -1,0 +1,6 @@
+---
+title: Resumable ETL Pipeline
+description: A multi-stage pipeline that checkpoints after every stage and resumes without redoing completed work.
+---
+
+<include cwd>../../cookbooks/resumable-etl-pipeline/README.md</include>

--- a/apps/docs/content/docs/cookbooks/untrusted-code-execution.mdx
+++ b/apps/docs/content/docs/cookbooks/untrusted-code-execution.mdx
@@ -1,0 +1,6 @@
+---
+title: Untrusted Code Execution
+description: Safely run LLM-generated or user-submitted code — per-snippet isolation, resource caps, and timeouts.
+---
+
+<include cwd>../../cookbooks/untrusted-code-execution/README.md</include>

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -7,5 +7,6 @@ export const workflowDocs = defineDocs({ dir: "content/docs/workflow", docs });
 export const alineoDocs = defineDocs({ dir: "content/docs/alineo", docs });
 export const agentDocs = defineDocs({ dir: "content/docs/agent", docs });
 export const examplesDocs = defineDocs({ dir: "content/docs/examples", docs });
+export const cookbooksDocs = defineDocs({ dir: "content/docs/cookbooks", docs });
 
 export default defineConfig();

--- a/apps/docs/src/app/cookbook/page.tsx
+++ b/apps/docs/src/app/cookbook/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { cookbooksSource } from "@/lib/source";
 
 export const metadata: Metadata = {
   title: "Cookbook",
@@ -6,12 +8,38 @@ export const metadata: Metadata = {
 };
 
 export default function CookbookPage() {
+  const recipes = cookbooksSource.getPages().filter((page) => page.slugs.length > 0);
+
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 px-6 py-24">
       <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">Cookbook</h1>
       <p className="text-fd-muted-foreground">
-        Coming soon — task-oriented recipes for building with alineo.
+        Task-oriented recipes for building with alineo — each one composes several SDK primitives
+        (sandboxes, exec, checkpoints, forks, agents) to solve one real end-to-end problem. Every
+        recipe is a small, standalone package you can copy out of the{" "}
+        <a
+          href="https://github.com/DrejT/alineo/tree/main/cookbooks"
+          className="text-fd-primary underline decoration-fd-border hover:decoration-fd-primary"
+        >
+          alineo repo
+        </a>{" "}
+        and run yourself.
       </p>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        {recipes.map((recipe) => (
+          <Link
+            key={recipe.url}
+            href={recipe.url}
+            className="flex flex-col gap-1 rounded-lg border border-fd-border bg-fd-card p-4 transition-colors hover:border-fd-primary"
+          >
+            <span className="font-medium text-fd-card-foreground">{recipe.data.title}</span>
+            {recipe.data.description && (
+              <span className="text-sm text-fd-muted-foreground">{recipe.data.description}</span>
+            )}
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/docs/src/app/docs-og/[collection]/[...slug]/route.tsx
+++ b/apps/docs/src/app/docs-og/[collection]/[...slug]/route.tsx
@@ -5,6 +5,7 @@ import {
   alineoSource,
   agentSource,
   examplesSource,
+  cookbooksSource,
 } from "@/lib/source";
 import { loadOgFonts, ogImageSize, renderOgImage } from "@/lib/og-image";
 
@@ -14,6 +15,7 @@ const SOURCES = {
   alineo: alineoSource,
   agent: agentSource,
   examples: examplesSource,
+  cookbooks: cookbooksSource,
 } as const;
 
 type Collection = keyof typeof SOURCES;

--- a/apps/docs/src/app/docs/cookbooks/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/cookbooks/[[...slug]]/page.tsx
@@ -1,0 +1,55 @@
+import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/layouts/docs/page";
+import { cookbooksSource } from "@/lib/source";
+import { notFound } from "next/navigation";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+import type { Metadata } from "next";
+import { createMetadata } from "@/lib/metadata";
+
+const OVERVIEW_SLUGS = new Set([""]);
+
+export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
+  const { slug } = await params;
+  const page = cookbooksSource.getPage(slug);
+  if (!page) notFound();
+
+  const MDX = page.data.body;
+  const slugStr = (slug ?? []).join("/");
+  const isOverview = OVERVIEW_SLUGS.has(slugStr);
+
+  return (
+    <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocsTitle>{page.data.title}</DocsTitle>
+      {page.data.description && <DocsDescription>{page.data.description}</DocsDescription>}
+      <DocsBody>
+        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const page = cookbooksSource.getPage(slug);
+  if (!page) return createMetadata({ title: "Not Found" });
+
+  const ogImage = [`/docs-og/cookbooks`, ...(slug ?? []), "image"].join("/");
+
+  return createMetadata({
+    title: page.data.title,
+    description: page.data.description,
+    alternates: { canonical: page.url },
+    openGraph: { images: [ogImage] },
+    twitter: { images: [ogImage] },
+  });
+}
+
+export async function generateStaticParams() {
+  return cookbooksSource.getPages().map((page) => ({
+    slug: page.slugs,
+  }));
+}

--- a/apps/docs/src/app/docs/cookbooks/layout.tsx
+++ b/apps/docs/src/app/docs/cookbooks/layout.tsx
@@ -1,0 +1,17 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { cookbooksSource } from "@/lib/source";
+import { docsTabs } from "@/lib/nav-tabs";
+
+export default function CookbooksLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DocsLayout
+      tree={cookbooksSource.pageTree}
+      nav={{ enabled: true, title: null }}
+      themeSwitch={{ enabled: false }}
+      searchToggle={{ enabled: false }}
+      tabs={docsTabs}
+    >
+      {children}
+    </DocsLayout>
+  );
+}

--- a/apps/docs/src/app/llms-full.txt/route.ts
+++ b/apps/docs/src/app/llms-full.txt/route.ts
@@ -4,6 +4,7 @@ import {
   agentSource,
   alineoSource,
   examplesSource,
+  cookbooksSource,
 } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
 
@@ -16,6 +17,7 @@ export async function GET() {
     ...agentSource.getPages(),
     ...alineoSource.getPages(),
     ...examplesSource.getPages(),
+    ...cookbooksSource.getPages(),
   ];
   const scanned = await Promise.all(allPages.map(getLLMText));
   return new Response(scanned.join("\n\n---\n\n"));

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -5,6 +5,7 @@ import {
   agentSource,
   alineoSource,
   examplesSource,
+  cookbooksSource,
 } from "@/lib/source";
 import { DEFAULT_DESCRIPTION } from "@/lib/metadata";
 
@@ -16,6 +17,7 @@ const SECTIONS = [
   ["Agent SDK", agentSource],
   ["alineo CLI", alineoSource],
   ["Examples", examplesSource],
+  ["Cookbooks", cookbooksSource],
 ] as const;
 
 export function GET() {

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -5,6 +5,7 @@ import {
   alineoSource,
   agentSource,
   examplesSource,
+  cookbooksSource,
 } from "@/lib/source";
 
 export const dynamic = "force-static";
@@ -12,7 +13,14 @@ export const dynamic = "force-static";
 const BASE_URL = "https://docs.alineo.tech";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const sources = [coreSource, workflowSource, alineoSource, agentSource, examplesSource];
+  const sources = [
+    coreSource,
+    workflowSource,
+    alineoSource,
+    agentSource,
+    examplesSource,
+    cookbooksSource,
+  ];
 
   const docPages = sources.flatMap((source) =>
     source.getPages().map((page) => ({

--- a/apps/docs/src/lib/nav-tabs.tsx
+++ b/apps/docs/src/lib/nav-tabs.tsx
@@ -1,4 +1,4 @@
-import { Package, Workflow, Bot, Terminal, FlaskConical } from "lucide-react";
+import { Package, Workflow, Bot, Terminal, FlaskConical, ChefHat } from "lucide-react";
 import type { LayoutTab } from "fumadocs-ui/layouts/shared";
 
 export const docsTabs: LayoutTab[] = [
@@ -31,5 +31,11 @@ export const docsTabs: LayoutTab[] = [
     title: "Examples",
     description: "Runnable examples",
     icon: <FlaskConical className="size-4" />,
+  },
+  {
+    url: "/docs/cookbooks",
+    title: "Cookbooks",
+    description: "Task-oriented recipes",
+    icon: <ChefHat className="size-4" />,
   },
 ];

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,4 +1,11 @@
-import { coreDocs, workflowDocs, alineoDocs, agentDocs, examplesDocs } from "collections/server";
+import {
+  coreDocs,
+  workflowDocs,
+  alineoDocs,
+  agentDocs,
+  examplesDocs,
+  cookbooksDocs,
+} from "collections/server";
 import { loader } from "fumadocs-core/source";
 
 export const coreSource = loader({
@@ -24,4 +31,9 @@ export const agentSource = loader({
 export const examplesSource = loader({
   baseUrl: "/docs/examples",
   source: examplesDocs.toFumadocsSource(),
+});
+
+export const cookbooksSource = loader({
+  baseUrl: "/docs/cookbooks",
+  source: cookbooksDocs.toFumadocsSource(),
 });

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,48 @@
         "typescript": "6.0.3",
       },
     },
+    "cookbooks/ai-agent-bugfix": {
+      "name": "alineo-cookbook-ai-agent-bugfix",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/agent": "workspace:*",
+        "@alineo-labs/opensandbox": "workspace:*",
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
+    "cookbooks/ci-test-runner": {
+      "name": "alineo-cookbook-ci-test-runner",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
+    "cookbooks/parallel-test-shards": {
+      "name": "alineo-cookbook-parallel-test-shards",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
+    "cookbooks/resumable-etl-pipeline": {
+      "name": "alineo-cookbook-resumable-etl-pipeline",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
+    "cookbooks/untrusted-code-execution": {
+      "name": "alineo-cookbook-untrusted-code-execution",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
     "examples/benchmark": {
       "name": "alineo-example-benchmark",
       "version": "0.0.4",
@@ -1411,6 +1453,16 @@
     "alineo": ["alineo@workspace:packages/sdks/typescript"],
 
     "alineo-cli": ["alineo-cli@workspace:packages/cli"],
+
+    "alineo-cookbook-ai-agent-bugfix": ["alineo-cookbook-ai-agent-bugfix@workspace:cookbooks/ai-agent-bugfix"],
+
+    "alineo-cookbook-ci-test-runner": ["alineo-cookbook-ci-test-runner@workspace:cookbooks/ci-test-runner"],
+
+    "alineo-cookbook-parallel-test-shards": ["alineo-cookbook-parallel-test-shards@workspace:cookbooks/parallel-test-shards"],
+
+    "alineo-cookbook-resumable-etl-pipeline": ["alineo-cookbook-resumable-etl-pipeline@workspace:cookbooks/resumable-etl-pipeline"],
+
+    "alineo-cookbook-untrusted-code-execution": ["alineo-cookbook-untrusted-code-execution@workspace:cookbooks/untrusted-code-execution"],
 
     "alineo-example-benchmark": ["alineo-example-benchmark@workspace:examples/benchmark"],
 

--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -1,0 +1,37 @@
+# alineo cookbook
+
+Task-oriented recipes for building with alineo — real end-to-end scenarios built by composing the
+SDK's primitives (sandboxes, exec, checkpoints, forks, workflows, agents), as opposed to
+[`examples/`](../examples), which demonstrates one primitive at a time.
+
+Structure and spirit borrowed from
+[Composio's `python/examples`](https://github.com/ComposioHQ/composio/tree/next/python/examples):
+each recipe is a small, standalone, runnable package you can copy out of this repo and adapt —
+no shared runtime package to unwind first.
+
+Every recipe below is also published on the [docs site](https://docs.alineo.tech/docs/cookbooks).
+
+| Recipe                                                 | What it shows                                                                                                   |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| [`untrusted-code-execution`](untrusted-code-execution) | Running LLM-generated / untrusted code safely — per-snippet isolation, resource caps, timeouts                  |
+| [`ci-test-runner`](ci-test-runner)                     | Running a repo's test suite in a disposable sandbox and turning the output into a structured pass/fail report   |
+| [`parallel-test-shards`](parallel-test-shards)         | Installing dependencies once, then `fork()`-ing into parallel sandboxes to shard work                           |
+| [`resumable-etl-pipeline`](resumable-etl-pipeline)     | A multi-stage pipeline that checkpoints after each stage and resumes without redoing completed work             |
+| [`ai-agent-bugfix`](ai-agent-bugfix)                   | An `@alineo-labs/agent` agent that debugs and fixes a failing test on its own, then gets independently verified |
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run any recipe
+
+```bash
+cd cookbooks/<recipe>
+bun install
+bun start
+```
+
+Each recipe's own README has the specifics — including any extra setup, like the API key
+`ai-agent-bugfix` needs.

--- a/cookbooks/ai-agent-bugfix/README.md
+++ b/cookbooks/ai-agent-bugfix/README.md
@@ -1,0 +1,40 @@
+# ai-agent-bugfix
+
+An AI agent that debugs a failing test and fixes the bug itself — inside its own sandbox, using
+nothing but bash and a model.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+export NVIDIA_API_KEY=...   # https://build.nvidia.com — free tier available
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Plants a deliberate off-by-one bug in `calc.py` and a test that catches it
+2. Runs `pytest` via `agent.bash()` to show the failure
+3. Prompts the agent — via `@alineo-labs/agent`'s `Agent.load()` + `agent.prompt()` — to find and
+   fix the bug itself, streaming its reasoning and tool calls as they happen
+4. Re-runs `pytest` independently of the agent (via `agent.sandbox.exec()`) to verify the fix,
+   rather than trusting the agent's own claim that it passed
+
+`agents/bugfix-agent.json` configures a Pi agent on `python:3.11-slim` using the NVIDIA NIM API.
+Swap `provider`/`model` for anything in `@alineo-labs/model-providers` to use a different key.
+
+## Notes
+
+Step 3's independent verification is the important part of this recipe: never trust an agent's
+self-report that a fix worked — re-run the check yourself against the sandbox it was working in.
+
+See the [Agent SDK docs](/docs/agent) for the full `@alineo-labs/agent` API (`prompt`, `bash`,
+`steer`, `fork`, model switching, and more), and
+[examples/pi-agent](https://github.com/DrejT/alineo/tree/main/examples/pi-agent) for a tour of
+every command it exposes.

--- a/cookbooks/ai-agent-bugfix/agents/bugfix-agent.json
+++ b/cookbooks/ai-agent-bugfix/agents/bugfix-agent.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://registry.alineo.tech/spec/agent.json",
+  "name": "bugfix-agent",
+  "title": "Bugfix Agent",
+  "description": "A Pi agent on python:3.11-slim that debugs a failing test and fixes the bug itself.",
+  "author": "alineo",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "packages": ["python3", "python3-pip"],
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}"
+  },
+  "resources": { "cpu": "1000m", "memory": "2Gi" }
+}

--- a/cookbooks/ai-agent-bugfix/index.ts
+++ b/cookbooks/ai-agent-bugfix/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Recipe: an AI agent that debugs a failing test and fixes the bug itself —
+ * inside its own sandbox, using nothing but bash and a model.
+ *
+ * Needs a running OpenSandbox server (`alineo init`) and NVIDIA_API_KEY in the
+ * environment — the agent config below uses the NVIDIA NIM API (free tier
+ * available). Swap "provider"/"model" in agents/bugfix-agent.json for any
+ * provider in @alineo-labs/model-providers to use a different key instead.
+ */
+import { Agent, textOnly } from "@alineo-labs/agent";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const adapter = new SQLiteAdapter("./.alineo/ledger.db");
+const agent = await Agent.load("./agents/bugfix-agent.json", { adapter });
+
+console.log(`Sandbox: ${agent.sandboxId}\n`);
+
+try {
+  // ── 1. Plant a bug ─────────────────────────────────────────────────────────
+  await agent.sandbox.exec("mkdir -p /workspace");
+  await agent.sandbox.writeFile(
+    "/workspace/calc.py",
+    ["def average(nums):", "    return sum(nums) / len(nums) - 1  # bug: off by one", ""].join(
+      "\n",
+    ),
+  );
+  await agent.sandbox.writeFile(
+    "/workspace/test_calc.py",
+    [
+      "from calc import average",
+      "",
+      "def test_average():",
+      "    assert average([1, 2, 3]) == 2",
+      "",
+    ].join("\n"),
+  );
+  await agent.sandbox.exec("cd /workspace && pip install --quiet pytest");
+
+  console.log("=== Before: failing test ===\n");
+  for await (const chunk of textOnly(agent.bash("cd /workspace && pytest -q || true"))) {
+    process.stdout.write(chunk);
+  }
+
+  // ── 2. Ask the agent to find and fix the bug ────────────────────────────────
+  console.log("\n=== Agent fixing the bug ===\n");
+  for await (const chunk of textOnly(
+    agent.prompt(
+      "There's a failing test in /workspace. Run pytest to see the failure, find the bug in " +
+        "calc.py, fix it, and re-run pytest to confirm it passes. Keep your reply short.",
+    ),
+  )) {
+    process.stdout.write(chunk);
+  }
+
+  // ── 3. Verify independently ──────────────────────────────────────────────────
+  console.log("\n\n=== After: verifying independently ===\n");
+  const { stdout, exitCode } = await agent.sandbox.exec("cd /workspace && pytest -q", {
+    strict: false,
+  });
+  console.log(stdout.trim());
+  console.log(exitCode === 0 ? "\nAgent fixed the bug." : "\nStill failing.");
+} finally {
+  await agent.close();
+  console.log("\nAgent closed.");
+}

--- a/cookbooks/ai-agent-bugfix/package.json
+++ b/cookbooks/ai-agent-bugfix/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "alineo-cookbook-ai-agent-bugfix",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/agent": "workspace:*",
+    "@alineo-labs/opensandbox": "workspace:*",
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/cookbooks/ci-test-runner/README.md
+++ b/cookbooks/ci-test-runner/README.md
@@ -1,0 +1,39 @@
+# ci-test-runner
+
+Run a repo's test suite in a disposable, CI-style sandbox and turn the raw output into a
+structured pass/fail report — the building block for a PR check, a bot, or an agent that needs to
+know "did the tests pass" without scraping a log.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Scaffolds a tiny Python project (`calc.py` + `test_calc.py`) directly in the sandbox — one test
+   deliberately fails, so you see a real failure report
+2. Installs `pytest`
+3. Runs the suite with `strict: false` so a non-zero exit is data, not a thrown error
+4. Prints a structured report (`status`, `summary`, and the full output on failure) and sets
+   `process.exitCode` accordingly — the same shape a CI step or bot would check
+
+## Notes
+
+Swap the "scaffold a project" step for a real clone to point this at any repository:
+
+```ts
+await sb.exec(`git clone --depth 1 ${repoUrl} /workspace`);
+```
+
+All examples default to `useServerProxy: true` — traffic routes through the OpenSandbox server so
+Docker bridge IPs don't need to be reachable directly. Set `USE_SERVER_PROXY=false` to disable
+(e.g. when using `uvx opensandbox-server` on the host).

--- a/cookbooks/ci-test-runner/index.ts
+++ b/cookbooks/ci-test-runner/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Recipe: run a repo's test suite in a disposable, CI-style sandbox and turn
+ * the result into a structured pass/fail report instead of a raw log dump.
+ *
+ * This scaffolds a tiny Python project on the fly so the recipe runs
+ * end-to-end with no external network dependency beyond `pip install pytest`.
+ * Swap the "get the repo into the sandbox" step for a real clone:
+ *
+ *   await sb.exec(`git clone --depth 1 ${repoUrl} /workspace`);
+ */
+import { Alineo } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const client = new Alineo({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
+});
+
+const sb = await client.sandbox({
+  image: "python:3.11-slim",
+  resources: { cpu: "500m", memory: "512Mi" },
+  name: "ci-test-runner",
+});
+
+console.log(`Sandbox ID: ${sb.sandboxId}\n`);
+
+try {
+  // ── 1. Get the repo into the sandbox ──────────────────────────────────────
+  await sb.createDirectory("/workspace");
+  await sb.writeFile(
+    "/workspace/calc.py",
+    ["def add(a, b):", "    return a + b", "", "def divide(a, b):", "    return a / b", ""].join(
+      "\n",
+    ),
+  );
+  await sb.writeFile(
+    "/workspace/test_calc.py",
+    [
+      "from calc import add, divide",
+      "",
+      "def test_add():",
+      "    assert add(2, 3) == 5",
+      "",
+      "def test_divide():",
+      "    assert divide(10, 2) == 5",
+      "",
+      "def test_divide_by_zero():",
+      "    # deliberately wrong expectation — fails, to show a real failure report",
+      "    assert divide(1, 0) == 0",
+      "",
+    ].join("\n"),
+  );
+
+  // ── 2. Install and run ────────────────────────────────────────────────────
+  console.log("Installing test dependencies...");
+  await sb.exec("pip install --quiet pytest");
+
+  console.log("Running test suite...\n");
+  const { stdout, stderr, exitCode } = await sb.exec("cd /workspace && pytest -q", {
+    strict: false,
+    timeoutMs: 60_000,
+  });
+
+  // ── 3. Turn the raw log into a structured report ──────────────────────────
+  const summaryLine = stdout.trim().split("\n").pop() ?? "";
+  const passed = exitCode === 0;
+
+  console.log("=== CI Report ===");
+  console.log(`status:  ${passed ? "PASS" : "FAIL"}`);
+  console.log(`summary: ${summaryLine}`);
+  if (!passed) {
+    console.log("\n--- pytest output ---");
+    console.log(stdout || stderr);
+  }
+
+  if (!passed) process.exitCode = 1;
+} finally {
+  await sb.close();
+}

--- a/cookbooks/ci-test-runner/package.json
+++ b/cookbooks/ci-test-runner/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-cookbook-ci-test-runner",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/cookbooks/parallel-test-shards/README.md
+++ b/cookbooks/parallel-test-shards/README.md
@@ -1,0 +1,36 @@
+# parallel-test-shards
+
+Install dependencies once, then fork the sandbox into N independent copies that each run a shard
+of the test suite in parallel — cutting wall-clock time roughly by the number of shards, without
+repeating the install in every shard.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates one base sandbox, installs `pytest`, and writes three small test files to it
+2. Calls `base.fork()` three times — each fork branches off the base sandbox's state, so none of
+   them repeat the `pip install`
+3. Runs a different test file in each fork with `Promise.all`, in parallel
+4. Aggregates each shard's exit code and a one-line summary into an overall pass/fail report
+
+## Notes
+
+This generalizes directly to a real repo: install dependencies and discover shard boundaries once
+in the base sandbox, then fork once per shard (or per CPU core) instead of paying setup cost N
+times. See [Forking Sandboxes](/docs/examples/sandbox-fork) for the underlying `sb.fork()` primitive.
+
+All examples default to `useServerProxy: true` — traffic routes through the OpenSandbox server so
+Docker bridge IPs don't need to be reachable directly. Set `USE_SERVER_PROXY=false` to disable
+(e.g. when using `uvx opensandbox-server` on the host).

--- a/cookbooks/parallel-test-shards/index.ts
+++ b/cookbooks/parallel-test-shards/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Recipe: install dependencies once, then fork into N independent sandboxes
+ * that each run a shard of the test suite in parallel — cutting wall-clock
+ * time roughly by the number of shards, without repeating the install.
+ */
+import { Alineo } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const client = new Alineo({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
+});
+
+const TEST_FILES: Record<string, string> = {
+  "test_shard_a.py": [
+    "def test_one():",
+    "    assert 1 + 1 == 2",
+    "",
+    "def test_two():",
+    "    assert sorted([3, 1, 2]) == [1, 2, 3]",
+    "",
+  ].join("\n"),
+  "test_shard_b.py": [
+    "def test_three():",
+    "    assert 'ab'.upper() == 'AB'",
+    "",
+    "def test_four():",
+    "    assert len(range(10)) == 10",
+    "",
+  ].join("\n"),
+  "test_shard_c.py": [
+    "def test_five():",
+    "    assert max([4, 9, 2]) == 9",
+    "",
+    "def test_six():",
+    "    assert {'a': 1}.get('a') == 1",
+    "",
+  ].join("\n"),
+};
+
+console.log("=== Installing dependencies (once) ===\n");
+
+const base = await client.sandbox({
+  image: "python:3.11-slim",
+  resources: { cpu: "1", memory: "512Mi" },
+  name: "shard-base",
+});
+
+let forks: Awaited<ReturnType<typeof base.fork>>[] = [];
+
+try {
+  await base.createDirectory("/workspace");
+  await base.exec("pip install --quiet pytest").pipe(process.stdout);
+  for (const [path, content] of Object.entries(TEST_FILES)) {
+    await base.writeFile(`/workspace/${path}`, content);
+  }
+
+  const shardNames = Object.keys(TEST_FILES);
+  console.log(`\n=== Forking into ${shardNames.length} shards ===\n`);
+
+  forks = await Promise.all(shardNames.map((_, i) => base.fork(`shard-${i}`)));
+  for (const [i, f] of forks.entries()) console.log(`  shard-${i} → ${f.sandboxId}`);
+
+  console.log("\n=== Running shards in parallel ===\n");
+
+  const shardResults = await Promise.all(
+    shardNames.map(async (path, i) => {
+      const sb = forks[i];
+      const t0 = Date.now();
+      const { stdout, exitCode } = await sb.exec(`cd /workspace && pytest -q ${path}`, {
+        strict: false,
+      });
+      return {
+        path,
+        exitCode,
+        ms: Date.now() - t0,
+        summary: stdout.trim().split("\n").pop() ?? "",
+      };
+    }),
+  );
+
+  console.log("=== Shard results ===");
+  let allPassed = true;
+  for (const r of shardResults) {
+    allPassed = allPassed && r.exitCode === 0;
+    console.log(`  [${r.path}] ${r.exitCode === 0 ? "PASS" : "FAIL"} (${r.ms}ms) — ${r.summary}`);
+  }
+  console.log(`\nOverall: ${allPassed ? "PASS" : "FAIL"}`);
+  if (!allPassed) process.exitCode = 1;
+} finally {
+  await Promise.all([...forks.map((f) => f.close()), base.close()]);
+}

--- a/cookbooks/parallel-test-shards/package.json
+++ b/cookbooks/parallel-test-shards/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-cookbook-parallel-test-shards",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/cookbooks/resumable-etl-pipeline/README.md
+++ b/cookbooks/resumable-etl-pipeline/README.md
@@ -1,0 +1,47 @@
+# resumable-etl-pipeline
+
+A multi-stage ETL pipeline (extract → transform → load) that checkpoints after each stage, so a
+crash — or just wanting to re-run "load" in isolation — doesn't mean paying for extract and
+transform again.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+**Original run:**
+
+1. **Extract** — installs `pandas`, writes raw CSV data, then `sb.checkpoint("after-extract")`
+2. **Transform** — aggregates revenue by region with pandas, writes `transformed.csv`, then
+   `sb.checkpoint("after-transform")`
+3. **Load** — reads back the final output and "publishes" it (prints it)
+
+**Resumed run** — simulates picking the pipeline back up later:
+
+1. `client.resume(sandboxId)` restores the container from the last checkpoint (`after-transform`)
+2. Re-issuing the exact `pip install` command from the extract stage replays instantly from the
+   ledger — no network call, no re-install
+3. `transformed.csv` is already present on the restored container's filesystem, so the load stage
+   reads it straight away — the transform never re-runs
+
+## Notes
+
+Every `sb.checkpoint(tag)` is a real container snapshot, not just a ledger bookmark — the restored
+container genuinely has extract and transform's output on disk. The ledger replay on top of that is
+an optimization: an exec that exactly matches one already recorded before the checkpoint returns
+its cached result instead of re-running. See [Checkpoint & Resume](/docs/examples/snapshot-replay)
+for the primitive this recipe builds on.
+
+All examples default to `useServerProxy: true` — traffic routes through the OpenSandbox server so
+Docker bridge IPs don't need to be reachable directly. Set `USE_SERVER_PROXY=false` to disable
+(e.g. when using `uvx opensandbox-server` on the host).

--- a/cookbooks/resumable-etl-pipeline/index.ts
+++ b/cookbooks/resumable-etl-pipeline/index.ts
@@ -1,0 +1,90 @@
+/**
+ * Recipe: a multi-stage ETL pipeline that can pick up where it left off.
+ *
+ * Each stage checkpoints on completion. If the process crashes — or you just
+ * want to re-run the "load" stage without paying for extract/transform again —
+ * `client.resume(sandboxId)` restores the container from the last checkpoint.
+ * The restored container's filesystem already has extract/transform's output
+ * on it, and any exec that exactly matches one issued before the checkpoint
+ * replays from the ledger instead of re-running.
+ */
+import { Alineo } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const client = new Alineo({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
+});
+
+const sandboxOpts = {
+  image: "python:3.11-slim",
+  resources: { cpu: "1", memory: "512Mi" },
+  name: "resumable-etl",
+};
+
+const transformScript = [
+  "import pandas as pd",
+  "",
+  "df = pd.read_csv('/workspace/raw.csv')",
+  "df['revenue'] = df['units'] * df['price']",
+  "out = df.groupby('region')['revenue'].sum().reset_index()",
+  "out.to_csv('/workspace/transformed.csv', index=False)",
+  "print(out.to_string(index=False))",
+].join("\n");
+
+console.log("=== Original run ===\n");
+
+const sb = await client.sandbox(sandboxOpts);
+const sandboxId = sb.sandboxId;
+console.log(`Sandbox ID: ${sandboxId}`);
+
+try {
+  // ── Extract ────────────────────────────────────────────────────────────
+  console.log("\n[extract] installing pandas + writing raw data...");
+  await sb.exec("pip install --quiet pandas");
+  await sb.writeFile(
+    "/workspace/raw.csv",
+    ["region,units,price", "west,10,4.5", "east,7,4.5", "west,3,4.5", "east,12,4.5"].join("\n"),
+  );
+  await sb.checkpoint("after-extract");
+  console.log("[extract] checkpoint: after-extract");
+
+  // ── Transform ──────────────────────────────────────────────────────────
+  console.log("\n[transform] aggregating revenue by region...");
+  await sb.writeFile("/workspace/transform.py", transformScript);
+  await sb.exec("python3 /workspace/transform.py").pipe(process.stdout);
+  await sb.checkpoint("after-transform");
+  console.log("[transform] checkpoint: after-transform");
+
+  // ── Load ───────────────────────────────────────────────────────────────
+  console.log("\n[load] publishing results...");
+  const result = await sb.readFile("/workspace/transformed.csv");
+  console.log("[load] final output:\n" + result);
+} finally {
+  await sb.close();
+}
+
+// ── Resumed run — e.g. after a crash, or just re-running the "load" stage ──
+
+console.log("\n=== Resumed run (skips extract + transform) ===\n");
+
+const resumed = await client.resume(sandboxId);
+
+try {
+  console.log(`Resumed sandbox ID: ${resumed.sandboxId}`);
+
+  // Same command as the original "extract" step — replayed from the ledger,
+  // returns instantly without hitting the network or re-installing anything.
+  const t0 = Date.now();
+  await resumed.exec("pip install --quiet pandas");
+  console.log(`[extract] (replayed) pip install — ${Date.now() - t0}ms`);
+
+  // transformed.csv is already on the restored container's filesystem — the
+  // transform stage doesn't need to run again.
+  const result = await resumed.readFile("/workspace/transformed.csv");
+  console.log("[load] (live) re-publishing from restored state:\n" + result);
+} finally {
+  await resumed.close();
+}

--- a/cookbooks/resumable-etl-pipeline/package.json
+++ b/cookbooks/resumable-etl-pipeline/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-cookbook-resumable-etl-pipeline",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/cookbooks/untrusted-code-execution/README.md
+++ b/cookbooks/untrusted-code-execution/README.md
@@ -1,0 +1,42 @@
+# untrusted-code-execution
+
+Safely execute untrusted or LLM-generated Python snippets — each one gets its own throwaway,
+resource-capped sandbox with a wall-clock timeout, and failures are captured as data instead of
+crashing the batch.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+Runs three Python snippets in parallel, each in its own sandbox:
+
+1. `well-behaved` — a snippet that just prints a value
+2. `raises` — a snippet that raises an uncaught exception
+3. `infinite-loop` — a snippet that never terminates on its own
+
+Each sandbox is created with tight `resources` (`250m` CPU / `128Mi` memory), a 30s container
+`timeout`, and a 5s `timeoutMs` on the exec call itself. `strict: false` means a non-zero exit is
+returned as data (`exitCode`, `stdout`, `stderr`) instead of throwing, so one bad snippet doesn't
+abort the batch. Every sandbox is closed in `finally`, even on timeout or crash.
+
+## Notes
+
+Reach for this pattern any time you're executing code you didn't write yourself — an LLM's
+generated code, a user-submitted script, a plugin. Swap `runUntrusted()`'s body for
+`execCode()`/`createCodeContext()` (see [Code Interpreter](/docs/examples/exec-code)) if you want a
+stateful REPL instead of one-shot scripts.
+
+All examples default to `useServerProxy: true` — traffic routes through the OpenSandbox server so
+Docker bridge IPs don't need to be reachable directly. Set `USE_SERVER_PROXY=false` to disable
+(e.g. when using `uvx opensandbox-server` on the host).

--- a/cookbooks/untrusted-code-execution/index.ts
+++ b/cookbooks/untrusted-code-execution/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Recipe: safely run untrusted (e.g. LLM-generated) Python snippets.
+ *
+ * Every snippet gets its own throwaway sandbox with tight resource caps and a
+ * wall-clock timeout, so a runaway or malicious snippet can't starve the host
+ * or hang the batch. Failures are captured as data (never thrown) so one bad
+ * snippet doesn't take down the rest of the run.
+ */
+import { Alineo, CommandError } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const client = new Alineo({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
+});
+
+interface RunResult {
+  label: string;
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+/** Runs one untrusted snippet in its own disposable, resource-capped sandbox. */
+async function runUntrusted(label: string, code: string): Promise<RunResult> {
+  const sb = await client.sandbox({
+    image: "python:3.11-slim",
+    resources: { cpu: "250m", memory: "128Mi" }, // tight caps — this is untrusted code
+    timeout: 30, // hard container lifetime (seconds)
+    name: `untrusted-${label}`,
+  });
+
+  try {
+    await sb.writeFile("/tmp/snippet.py", code);
+    const { stdout, stderr, exitCode } = await sb.exec("python3 /tmp/snippet.py", {
+      strict: false, // never throw — a non-zero exit is just a result
+      timeoutMs: 5_000, // kill a runaway loop after 5s instead of hanging the batch
+    });
+    return { label, ok: exitCode === 0, stdout, stderr };
+  } catch (e) {
+    // Only connection-level failures land here — strict: false already turns
+    // ordinary non-zero exits into data, but a timed-out exec still throws.
+    const message = e instanceof CommandError ? e.message : (e as Error).message;
+    return { label, ok: false, stdout: "", stderr: "", error: message };
+  } finally {
+    await sb.close();
+  }
+}
+
+const snippets: Record<string, string> = {
+  "well-behaved": 'print("2 + 2 =", 2 + 2)',
+  raises: 'raise ValueError("bad input")',
+  "infinite-loop": "while True:\n    pass",
+};
+
+console.log("Running 3 untrusted snippets in parallel, each in its own sandbox...\n");
+
+const results = await Promise.all(
+  Object.entries(snippets).map(([label, code]) => runUntrusted(label, code)),
+);
+
+for (const r of results) {
+  console.log(`[${r.label}] ${r.ok ? "OK" : "FAILED"}`);
+  if (r.stdout.trim()) console.log(`  stdout: ${r.stdout.trim()}`);
+  if (r.stderr.trim()) console.log(`  stderr: ${r.stderr.trim().split("\n").pop()}`);
+  if (r.error) console.log(`  error:  ${r.error}`);
+}
+
+const anyFailed = results.some((r) => !r.ok);
+console.log(`\n${anyFailed ? "Some" : "All"} snippets handled without crashing the runner.`);

--- a/cookbooks/untrusted-code-execution/package.json
+++ b/cookbooks/untrusted-code-execution/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-cookbook-untrusted-code-execution",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "packages/model-providers",
     "packages/cli",
     "examples/*",
+    "cookbooks/*",
     "tests/integration",
     "apps/docs",
     "apps/registry",
@@ -28,10 +29,10 @@
     "typecheck": "bun scripts/workspace-run.ts typecheck",
     "test": "bun scripts/workspace-run.ts test",
     "test:integration": "bun run --cwd tests/integration test",
-    "lint": "oxlint packages examples",
-    "lint:fix": "oxlint --fix packages examples",
-    "format": "oxfmt packages examples apps \"!**/CHANGELOG.md\"",
-    "format:check": "oxfmt --check packages examples apps \"!**/CHANGELOG.md\"",
+    "lint": "oxlint packages examples cookbooks",
+    "lint:fix": "oxlint --fix packages examples cookbooks",
+    "format": "oxfmt packages examples cookbooks apps \"!**/CHANGELOG.md\"",
+    "format:check": "oxfmt --check packages examples cookbooks apps \"!**/CHANGELOG.md\"",
     "release:publish": "bun scripts/resolve-workspace-protocol.ts && bun changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a top-level cookbooks/ folder alongside examples/ — five small, standalone, runnable packages that each compose several alineo SDK primitives to solve one real end-to-end task, in the spirit of Composio's python/examples (github.com/ComposioHQ/composio):

- untrusted-code-execution — run LLM-generated/untrusted code safely with per-snippet isolation, resource caps, and timeouts
- ci-test-runner — run a repo's test suite in a disposable sandbox and turn the output into a structured pass/fail report
- parallel-test-shards — install once, fork() into parallel sandboxes to shard test work
- resumable-etl-pipeline — a checkpointed multi-stage pipeline that resumes without redoing completed work
- ai-agent-bugfix — an @alineo-labs/agent agent that debugs and fixes a failing test, independently re-verified afterwards

Wires cookbooks/* into the root workspaces array and lint/format scripts (mirroring examples/*; out of scope for build/typecheck, same as examples).

Docs: adds a new "Cookbooks" section under /docs/cookbooks, matching the existing Examples fumadocs collection exactly — source.config.ts, lib/source.ts, sidebar tab, per-recipe MDX pages that <include> each README, sitemap/llms.txt/llms-full.txt/OG-image wiring. The standalone /cookbook page now lists these recipes instead of "Coming soon".

Verified with a full `next build` of apps/docs (TypeScript + static generation for all new routes) and oxlint/oxfmt on every touched file.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #... -->

## Checklist

- [ ] Tests added or updated
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Changeset added (`bunx changeset`) for any changes to publishable packages
- [ ] Docs updated if this changes public API or behaviour
