### PR TITLE
docs: hide version switcher, trim product switcher, add Examples to top nav

### DIFF
--- a/.changeset/empty-cases-rest.md
+++ b/.changeset/empty-cases-rest.md
@@ -1,0 +1,6 @@
+---
+---
+
+Docs site only, no publishable package changes: temporarily hide the version switcher
+(only one version exists per product right now) and drop the Examples/Cookbooks tabs from
+the product switcher.

--- a/apps/docs/src/app/docs/alineo/[version]/layout.tsx
+++ b/apps/docs/src/app/docs/alineo/[version]/layout.tsx
@@ -2,8 +2,6 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { notFound } from "next/navigation";
 import { alineoVersions } from "@/lib/source";
 import { docsTabs } from "@/lib/nav-tabs";
-import { docVersions } from "@/lib/doc-versions";
-import { VersionSwitcher } from "@/components/version-switcher";
 
 export default async function AlineoLayout({
   params,
@@ -23,17 +21,7 @@ export default async function AlineoLayout({
       themeSwitch={{ enabled: false }}
       searchToggle={{ enabled: false }}
       tabs={docsTabs}
-      sidebar={{
-        // See core's [version]/layout.tsx for why this needs an explicit key.
-        banner: (
-          <VersionSwitcher
-            key="alineo-version-switcher"
-            product="alineo"
-            currentVersion={version}
-            data={docVersions.alineo}
-          />
-        ),
-      }}
+      // sidebar.banner (VersionSwitcher) hidden for now — see core's [version]/layout.tsx.
     >
       {children}
     </DocsLayout>

--- a/apps/docs/src/app/docs/core/[version]/layout.tsx
+++ b/apps/docs/src/app/docs/core/[version]/layout.tsx
@@ -2,8 +2,6 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { notFound } from "next/navigation";
 import { coreVersions } from "@/lib/source";
 import { docsTabs } from "@/lib/nav-tabs";
-import { docVersions } from "@/lib/doc-versions";
-import { VersionSwitcher } from "@/components/version-switcher";
 
 export default async function CoreLayout({
   params,
@@ -23,19 +21,10 @@ export default async function CoreLayout({
       themeSwitch={{ enabled: false }}
       searchToggle={{ enabled: false }}
       tabs={docsTabs}
-      sidebar={{
-        // fumadocs-ui's Sidebar renders `banner` in two subtrees (desktop content +
-        // mobile drawer), reusing this same element instance in both — React warns
-        // ("each child in a list should have a unique key prop") without an explicit key.
-        banner: (
-          <VersionSwitcher
-            key="core-version-switcher"
-            product="core"
-            currentVersion={version}
-            data={docVersions.core}
-          />
-        ),
-      }}
+      // sidebar.banner (VersionSwitcher) hidden for now — only one version exists,
+      // so a dropdown with a single entry has nothing useful to switch between.
+      // Re-add via `sidebar={{ banner: <VersionSwitcher ... /> }}` once v0.2 ships;
+      // see core/[version]/layout.tsx's git history for the exact prior wiring.
     >
       {children}
     </DocsLayout>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -68,6 +68,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             themeSwitch={{ enabled: false }}
             links={[
               { text: "Docs", url: `/docs/core/${coreLatestVersion}`, active: "nested-url" },
+              { text: "Examples", url: "/docs/examples", active: "nested-url" },
               { text: "Cookbook", url: "/cookbook", active: "nested-url" },
               { text: "FAQ", url: "/faq", active: "nested-url" },
               { text: "Use Cases", url: "/use-cases", active: "nested-url" },

--- a/apps/docs/src/lib/nav-tabs.tsx
+++ b/apps/docs/src/lib/nav-tabs.tsx
@@ -1,4 +1,4 @@
-import { Package, Workflow, Bot, Terminal, FlaskConical, ChefHat } from "lucide-react";
+import { Package, Workflow, Bot, Terminal } from "lucide-react";
 import type { LayoutTab } from "fumadocs-ui/layouts/shared";
 import { coreLatestVersion, alineoLatestVersion } from "@/lib/source";
 
@@ -30,16 +30,5 @@ export const docsTabs: LayoutTab[] = [
     description: "alineo-cli",
     icon: <Terminal className="size-4" />,
   },
-  {
-    url: "/docs/examples",
-    title: "Examples",
-    description: "Runnable examples",
-    icon: <FlaskConical className="size-4" />,
-  },
-  {
-    url: "/docs/cookbooks",
-    title: "Cookbooks",
-    description: "Task-oriented recipes",
-    icon: <ChefHat className="size-4" />,
-  },
+  // Examples/Cookbooks tabs removed from the switcher for now — see PR description.
 ];


### PR DESCRIPTION
## Summary
- Hide the in-docs version switcher (`VersionSwitcher` in the sidebar banner) on both `/docs/core` and `/docs/alineo` — only one version (`v0.1`) exists per product right now, so a dropdown with a single entry has nothing to switch between. `VersionSwitcher` itself is untouched; re-wire `sidebar={{ banner: <VersionSwitcher ... /> }}` once v0.2 docs ship.
- Remove the **Examples** and **Cookbooks** tabs from the in-docs product switcher (`docsTabs`). The underlying `/docs/examples` and `/docs/cookbooks` content routes are untouched, just no longer linked from that switcher.
- Add an **Examples** link to the site-wide top nav bar (`HomeLayout` links in `apps/docs/src/app/layout.tsx`), pointing at `/docs/examples`, alongside Docs/Cookbook/FAQ/Use Cases/Changelog.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run build` (full `next build`) — succeeds, all 207 pages generated including `/docs/examples/*` and `/docs/cookbooks/*`
- `apps/docs` is a private app (no npm-publishable package touched); included an empty changeset to satisfy the changeset-check CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)