### PR TITLE
fix(docs): version switcher double-prefixes target URL

### DIFF
--- a/.changeset/ten-maps-stay.md
+++ b/.changeset/ten-maps-stay.md
@@ -1,0 +1,10 @@
+---
+---
+
+Docs site only, no publishable package changes: fix the version switcher
+double-prefixing the target URL (e.g. /docs/core/0.2/0.1 instead of
+/docs/core/0.1) when switching versions. It derived the "rest of path" by
+string-matching the current pathname against a prefix built from the
+currentVersion prop, which silently produced no match — and no rest — in some
+cases; it now splits the real pathname's own segments instead, independent of
+that prop.

--- a/apps/docs/src/components/version-switcher.tsx
+++ b/apps/docs/src/components/version-switcher.tsx
@@ -28,9 +28,15 @@ export function VersionSwitcher({
   function switchTo(version: string) {
     setOpen(false);
     if (version === currentVersion) return;
-    const prefix = `/docs/${product}/${currentVersion}`;
-    const rest = pathname.startsWith(prefix) ? pathname.slice(prefix.length) : "";
-    router.push(`/docs/${product}/${version}${rest}`);
+    // Derived from the URL's own segment structure (["", "docs", product, version,
+    // ...rest]), not by string-matching pathname against a prefix built from the
+    // currentVersion prop — that prefix-match silently falls through to "" (no rest,
+    // no error) whenever it's wrong for any reason (stale prop, hydration timing),
+    // which previously double-prefixed the target path onto the current one instead
+    // of replacing it (e.g. /docs/core/0.2/0.1 instead of /docs/core/0.1). Splitting
+    // the real pathname doesn't depend on currentVersion matching anything.
+    const rest = pathname.split("/").slice(4).join("/");
+    router.push(`/docs/${product}/${version}${rest ? `/${rest}` : ""}`);
   }
 
   return (


### PR DESCRIPTION
## Bug

Clicking a different version in the sidebar version dropdown could navigate
to `/docs/core/0.2/0.1` instead of `/docs/core/0.1` — the target version got
appended onto the current path instead of replacing it.

## Root cause

`switchTo()` derived the "rest of path" (anything after the version segment)
by string-matching `pathname` against a prefix built from the
`currentVersion` **prop**:

```ts
const prefix = `/docs/${product}/${currentVersion}`;
const rest = pathname.startsWith(prefix) ? pathname.slice(prefix.length) : "";
```

Pulled the actual deployed JS chunk from `docs.alineo.tech` and confirmed the
shipped code matches this source exactly — not a stale-build/cache issue.
So the prefix match itself was silently failing under some real condition
(prop staleness, hydration timing — this app runs a very recent Next.js per
its own `AGENTS.md` warning) and falling through to the `""` branch, which
doesn't error, it just means "no rest" — then the push template appended the
target version directly onto whatever the raw current pathname was.

## Fix

Derive the rest-of-path from the URL's own segment structure instead
(`["", "docs", product, version, ...rest]`), independent of whether
`currentVersion` matches anything:

```ts
const rest = pathname.split("/").slice(4).join("/");
router.push(`/docs/${product}/${version}${rest ? `/${rest}` : ""}`);
```

## Verification
- `bunx tsc --noEmit` — clean
- `bun run format:check` — clean
- `bun run build` (full `next build`) — succeeds
- `bunx changeset status --since origin/main` — passes (empty changeset,
  `apps/docs` is private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)