### PR TITLE
fix(docs): version switcher — use hard navigation, not router.push

### DIFF
--- a/.changeset/young-rooms-jump.md
+++ b/.changeset/young-rooms-jump.md
@@ -1,0 +1,13 @@
+---
+---
+
+Docs site only, no publishable package changes: fix the version switcher still
+double-prefixing the target URL (e.g. /docs/core/0.2/0.1) after #195's path-computation
+fix. Reproduced live with Playwright + network tracing: the path computation was
+already correct (it requested the right .../0.1.txt flight payload first), but
+Next's client-side RSC-flight navigation between two sibling values of the same
+[version] dynamic segment (output:"export" + dynamicParams:false) 404s on that
+request and wrongly retries relative to the current path, landing on a real 404
+with the mangled URL. Switched to a full page navigation (window.location.href)
+for version switches instead of router.push — verified with a real build served
+locally and driven with Playwright, both directions and from a subpage.

--- a/apps/docs/src/components/version-switcher.tsx
+++ b/apps/docs/src/components/version-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Check, ChevronsUpDown, Tag } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
 import type { VersionedProduct, DocProductVersions } from "@/lib/doc-versions";
@@ -22,21 +22,27 @@ export function VersionSwitcher({
   data: DocProductVersions;
 }) {
   const [open, setOpen] = useState(false);
-  const router = useRouter();
   const pathname = usePathname();
 
   function switchTo(version: string) {
     setOpen(false);
     if (version === currentVersion) return;
     // Derived from the URL's own segment structure (["", "docs", product, version,
-    // ...rest]), not by string-matching pathname against a prefix built from the
-    // currentVersion prop — that prefix-match silently falls through to "" (no rest,
-    // no error) whenever it's wrong for any reason (stale prop, hydration timing),
-    // which previously double-prefixed the target path onto the current one instead
-    // of replacing it (e.g. /docs/core/0.2/0.1 instead of /docs/core/0.1). Splitting
-    // the real pathname doesn't depend on currentVersion matching anything.
+    // ...rest]) rather than string-matching pathname against a prefix built from the
+    // currentVersion prop — robust regardless of whether that prop is stale.
     const rest = pathname.split("/").slice(4).join("/");
-    router.push(`/docs/${product}/${version}${rest ? `/${rest}` : ""}`);
+    const target = `/docs/${product}/${version}${rest ? `/${rest}` : ""}`;
+    // Hard navigation (not next/navigation's router.push), deliberately: each
+    // version is a fully independent loader()/pageTree (see
+    // plans/versioned-docs.md), not a sibling leaf under shared data. Reproduced
+    // live (Playwright + network trace) that Next's client-side RSC-flight fetch
+    // for a cross-version jump — two different values of the same [version]
+    // dynamic segment, output:"export" + dynamicParams:false — requests the
+    // *correct* target payload (".../0.1.txt"), gets a 404, then wrongly retries
+    // relative to the current path (".../0.2/0.1.txt"), lands on a real 404 page
+    // with the mangled URL in the address bar. A full page load bypasses that
+    // fetch entirely.
+    window.location.href = target;
   }
 
   return (


### PR DESCRIPTION
## Follow-up to #195

#195 fixed the path-computation logic in `switchTo()` (deriving the "rest of
path" from the URL's own segments instead of a fragile prefix match built
from the `currentVersion` prop). That fix was real and correct, but the bug
persisted: clicking a different version in the dropdown still landed on
`/docs/core/0.2/0.1` — a real 404 — confirmed live on `docs.alineo.tech` via
a headless Playwright session (not a caching artifact; reproduced in a fresh
browser context hitting the live site directly).

## Root cause

Network-traced the actual click. The **very first request** the browser made
was `GET /docs/core/0.1.txt` — the RSC flight payload for the *correct*
target. So `switchTo()`'s path arithmetic (from #195) was already right. That
request 404s, and Next's client-side router then wrongly retries **relative
to the current path** — `GET /docs/core/0.2/0.1.txt` — which also 404s, and
the router falls back to a hard navigation using that mangled URL, landing on
the real Next.js 404 page with the broken path in the address bar.

This is Next's client-side RSC-flight navigation misbehaving for a jump
between two sibling values of the *same* `[version]` dynamic route segment
under `output: "export"` + `dynamicParams: false` — not a bug in
`switchTo()`'s own logic.

## Fix

Use `window.location.href` instead of `next/navigation`'s `router.push()` for
a version switch — a deliberate hard navigation rather than an App Router
soft transition, since each version is a fully independent
`loader()`/pageTree (`plans/versioned-docs.md`), not a sibling leaf sharing
data with the current one anyway.

## Verification

Ran a real `bun run build`, served the static output locally with a small
script that mimics Cloudflare Pages' clean-URL file resolution (generic
static file servers like `serve` don't match that exact behavior — they
prioritize a same-named directory over the sibling `.html` file, which broke
my first local repro attempt), and drove it with Playwright:

- `0.2 → 0.1` ✅ (`final pathname: /docs/core/0.1`)
- `0.1 → 0.2` ✅ (`final pathname: /docs/core/0.2`)
- Switching versions from a subpage (`/docs/core/0.2/getting-started`) → `0.1`
  ✅ (`final pathname: /docs/core/0.1/getting-started`, rest-of-path
  preserved)

Also:
- `bunx tsc --noEmit` — clean
- `bun run format:check` — clean
- `bunx changeset status --since origin/main` — passes (empty changeset,
  `apps/docs` is private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)