### PR TITLE
docs: comment out the version dropdown for now

### DIFF
--- a/.changeset/silly-doors-sort.md
+++ b/.changeset/silly-doors-sort.md
@@ -1,0 +1,8 @@
+---
+---
+
+Docs site only, no publishable package changes: comment out the version dropdown
+(sidebar.banner) on core/alineo docs for now. The underlying versioning (v0.1/v0.2
+content, dynamic registry, redirects) is untouched — this only hides the switcher
+UI. Re-enable by uncommenting the sidebar/import blocks in both
+`[version]/layout.tsx` files.

--- a/apps/docs/src/app/docs/alineo/[version]/layout.tsx
+++ b/apps/docs/src/app/docs/alineo/[version]/layout.tsx
@@ -2,8 +2,8 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { notFound } from "next/navigation";
 import { alineoVersions } from "@/lib/source";
 import { docsTabs } from "@/lib/nav-tabs";
-import { docVersions } from "@/lib/doc-versions";
-import { VersionSwitcher } from "@/components/version-switcher";
+// import { docVersions } from "@/lib/doc-versions";
+// import { VersionSwitcher } from "@/components/version-switcher";
 
 export default async function AlineoLayout({
   params,
@@ -23,19 +23,18 @@ export default async function AlineoLayout({
       themeSwitch={{ enabled: false }}
       searchToggle={{ enabled: false }}
       tabs={docsTabs}
-      sidebar={{
-        // Hidden while only one version exists — see core's [version]/layout.tsx.
-        banner:
-          docVersions.alineo.versions.length > 1 ? (
-            // See core's [version]/layout.tsx for why this needs an explicit key.
-            <VersionSwitcher
-              key="alineo-version-switcher"
-              product="alineo"
-              currentVersion={version}
-              data={docVersions.alineo}
-            />
-          ) : undefined,
-      }}
+      // Version dropdown (sidebar.banner) commented out for now — see core's
+      // [version]/layout.tsx.
+      // sidebar={{
+      //   banner: (
+      //     <VersionSwitcher
+      //       key="alineo-version-switcher"
+      //       product="alineo"
+      //       currentVersion={version}
+      //       data={docVersions.alineo}
+      //     />
+      //   ),
+      // }}
     >
       {children}
     </DocsLayout>

--- a/apps/docs/src/app/docs/core/[version]/layout.tsx
+++ b/apps/docs/src/app/docs/core/[version]/layout.tsx
@@ -2,8 +2,8 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { notFound } from "next/navigation";
 import { coreVersions } from "@/lib/source";
 import { docsTabs } from "@/lib/nav-tabs";
-import { docVersions } from "@/lib/doc-versions";
-import { VersionSwitcher } from "@/components/version-switcher";
+// import { docVersions } from "@/lib/doc-versions";
+// import { VersionSwitcher } from "@/components/version-switcher";
 
 export default async function CoreLayout({
   params,
@@ -23,25 +23,18 @@ export default async function CoreLayout({
       themeSwitch={{ enabled: false }}
       searchToggle={{ enabled: false }}
       tabs={docsTabs}
-      sidebar={{
-        // Hidden while only one version exists — a dropdown with a single entry
-        // has nothing to switch between. Versions come from disk
-        // (content/docs/core/vX.Y/, see discoverVersions() in
-        // scripts/doc-versions.ts), so this reappears on its own the moment a
-        // second version folder is added — nothing here needs editing on a cut.
-        banner:
-          docVersions.core.versions.length > 1 ? (
-            // fumadocs-ui's Sidebar renders `banner` in two subtrees (desktop content +
-            // mobile drawer), reusing this same element instance in both — React warns
-            // ("each child in a list should have a unique key prop") without an explicit key.
-            <VersionSwitcher
-              key="core-version-switcher"
-              product="core"
-              currentVersion={version}
-              data={docVersions.core}
-            />
-          ) : undefined,
-      }}
+      // Version dropdown (sidebar.banner) commented out for now — re-enable by
+      // uncommenting this block plus the docVersions/VersionSwitcher imports above.
+      // sidebar={{
+      //   banner: (
+      //     <VersionSwitcher
+      //       key="core-version-switcher"
+      //       product="core"
+      //       currentVersion={version}
+      //       data={docVersions.core}
+      //     />
+      //   ),
+      // }}
     >
       {children}
     </DocsLayout>


### PR DESCRIPTION
## Summary

Hides the version switcher (`sidebar.banner`) again on both `/docs/core` and
`/docs/alineo` layouts, per request. The underlying versioning work is
untouched — `v0.1`/`v0.2` content, the dynamic registry
(`scripts/sync-doc-versions.ts`/`sync-redirects.ts`), and `public/_redirects`
all still work exactly as before (unversioned aliases still default to
`0.2`, `0.1` is still reachable directly). This only comments out the
switcher's rendering (and its now-unused imports) in both
`[version]/layout.tsx` files — re-enable by uncommenting.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run format:check` — clean
- `bun run build` (full `next build`) — succeeds; confirmed
  `core-version-switcher`/`alineo-version-switcher` no longer present in the
  built HTML, product tabs (`Core SDK` etc.) still render normally
- `bunx changeset status --since origin/main` — passes (empty changeset,
  `apps/docs` is private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)