### PR TITLE
fix(ci): make workspace typecheck self-sufficient, use it in CI

### DIFF
--- a/.changeset/silent-lions-drum.md
+++ b/.changeset/silent-lions-drum.md
@@ -1,0 +1,23 @@
+---
+---
+
+Internal only, no publishable package changes: fix `bun run typecheck` (`scripts/workspace-run.ts`)
+so it builds every `packages/**` workspace before typechecking it, then swap CI's hand-maintained
+per-package `tsc` chain in `.github/workflows/ci.yml` for that single `bun run typecheck` step.
+
+`typecheck` resolves cross-package `workspace:*` imports against each dependency's built `types`
+entry point (e.g. `opensandbox`'s `package.json` points `types` at `dist/index.d.mts`), not its
+source, so a package that hadn't been built yet was unresolvable to anything depending on it —
+`core`'s own typecheck failed with `Cannot find module '@alineo-labs/opensandbox'` when run on a
+clean checkout. CI never hit this because its old hardcoded chain always ran after a separate
+"Build all packages" step, which is also exactly how it stayed hidden that the chain itself was
+missing `packages/model-providers`, `packages/adapters/flue`, `packages/agent-browser`, and
+`packages/harness` — none of those were getting typechecked in CI at all (see #199/#201, where
+this gap let two `@ai-sdk/*` major bumps show green CI despite failing `tsc --noEmit --strict`).
+
+Verified: clean checkout, `bun run typecheck` now passes standalone with no prior build step, and
+covers all 13 `packages/**` workspaces including the 4 that were previously silently skipped.
+Full CI job simulated locally end to end (build, typecheck packages, typecheck sandbox, lint,
+format check, tests) — all green, no new warnings.
+
+Closes #201.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,33 +23,8 @@ jobs:
       - name: Build all packages
         run: bun run build
 
-      - name: Typecheck opensandbox
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/opensandbox
-
-      - name: Typecheck core
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/core
-
-      - name: Typecheck SDK
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/sdks/typescript
-
-      - name: Typecheck workflow
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/workflow
-
-      - name: Typecheck postgres adapter
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/adapters/postgres
-
-      - name: Typecheck sqlite adapter
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/adapters/sqlite
-
-      - name: Typecheck otel adapter
-        run: bunx tsc --noEmit --strict
-        working-directory: packages/adapters/otel
+      - name: Typecheck packages
+        run: bun run typecheck
 
       - name: Typecheck sandbox
         run: bun run typecheck

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "@alineo-labs/sqlite": "workspace:*",
         "@fontsource-variable/geist": "^5.1.1",
         "@fontsource-variable/geist-mono": "^5.2.2",
-        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
         "alineo": "workspace:*",
         "astro": "^7.2.2",
@@ -1428,7 +1428,7 @@
 
     "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
-    "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 

--- a/scripts/workspace-run.ts
+++ b/scripts/workspace-run.ts
@@ -75,6 +75,21 @@ async function run(cmd: string[]): Promise<number> {
   return proc.exited;
 }
 
+// typecheck resolves cross-package "workspace:*" imports against each package's built
+// `types` entry point (e.g. opensandbox's package.json points "types" at dist/index.d.mts),
+// not its source — so a package that hasn't been built yet is unresolvable to a dependent's
+// tsc run. Build every package first (in the same topological order) so typecheck is
+// self-sufficient and doesn't rely on a separate build step having already run.
+if (task === "typecheck") {
+  for (const pkg of sorted) {
+    const scripts = pkg.json.scripts as Record<string, string> | undefined;
+    if (!scripts?.build) continue;
+    console.log(`\n> build ${pkg.name}`);
+    const code = await run(["bun", "run", "--cwd", pkg.dir, "build"]);
+    if (code !== 0) process.exit(code);
+  }
+}
+
 for (const pkg of sorted) {
   if (task === "typecheck") {
     const tsconfig = join(pkg.dir, "tsconfig.json");


### PR DESCRIPTION
Closes #201.

## Why

CI's \`Typecheck & Lint\` job hand-lists specific packages to \`tsc --noEmit --strict\` (opensandbox,
core, SDK, workflow, postgres/sqlite/otel adapters). \`packages/model-providers\`,
\`packages/adapters/flue\`, \`packages/agent-browser\`, and \`packages/harness\` were entirely missing
from that list — none of them got typechecked in CI. That's exactly why #177/#176 showed all-green
CI while actually failing \`tsc --noEmit --strict\` in \`packages/model-providers\` (see #199/#200).

The root \`bun run typecheck\` script (\`scripts/workspace-run.ts\`) already exists specifically to
avoid this — it auto-discovers every \`packages/**\` workspace by scanning for a \`tsconfig.json\` —
but CI never actually called it. Turns out there's a reason: it didn't pass on a clean checkout.
\`typecheck\` resolves cross-package \`workspace:*\` imports against each dependency's *built* \`types\`
entry point (e.g. \`opensandbox\`'s \`package.json\` points \`types\` at \`dist/index.d.mts\`), not its
source. Nothing built \`opensandbox\` before typechecking \`core\` against it, so it failed with
\`Cannot find module '@alineo-labs/opensandbox'\`. The old hand-written CI chain only worked because
a separate "Build all packages" step happened to run before it.

## What

- \`scripts/workspace-run.ts\`: for the \`typecheck\` task, build every \`packages/**\` workspace (same
  topological order already computed) before typechecking any of them — makes the script
  self-sufficient regardless of what ran before it.
- \`.github/workflows/ci.yml\`: replace the 7-step hand-written \`tsc\` chain with one
  \`bun run typecheck\` step. (\`apps/sandbox\`'s own separate typecheck step is untouched —
  \`workspace-run.ts\` is deliberately scoped to \`packages/**\` only, apps/examples are out of scope
  by design.)
- Incidental fix: \`bun.lock\` was drifted from \`apps/sandbox/package.json\` — #130's merge updated
  the declared \`@xterm/addon-fit\` range to \`^0.11.0\` but never touched the lockfile (the original
  dependabot PR only diffed \`package.json\`), so the checked-in lock was still pinning \`0.10.0\` on
  \`main\`. Running \`bun install\` here reconciled it.

## Verification

- Clean checkout (\`dist/\` removed everywhere): \`bun run typecheck\` passes standalone, no prior
  build step needed, and now covers all 13 \`packages/**\` workspaces (including the 4 that were
  previously silently skipped).
- Full \`Typecheck & Lint\` job simulated locally end to end: build → typecheck packages → typecheck
  sandbox → lint → format check — all green, no new warnings (lint warnings present are pre-existing
  and unrelated).
- \`bun run test\` at root: all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)