### PR TITLE
docs: add Discord link, star history, and cookbook section to README

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Chat on Discord
+    url: https://discord.com/invite/XGkPu3YBH4
+    about: Ask questions or discuss ideas in real time.
   - name: Feature request or idea
     url: https://github.com/DrejT/alineo/discussions/categories/ideas
     about: Brainstorm and propose new features in GitHub Discussions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to alineo
 
+Questions, proposing a non-trivial change, or just want to talk it through first? Come say hi on
+[Discord](https://discord.com/invite/XGkPu3YBH4) — it's the fastest way to get an answer before
+opening a PR.
+
 ## Prerequisites
 
 - [Bun](https://bun.sh) >= 1.3

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 [![CI](https://github.com/DrejT/alineo/actions/workflows/ci.yml/badge.svg)](https://github.com/DrejT/alineo/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/alineo)](https://www.npmjs.com/package/alineo)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/XGkPu3YBH4)
 
 Sandboxes as objects. Spawn live containers, run code, checkpoint state — from TypeScript.
+
+<!-- TODO: demo GIF/video — drop in here once recorded -->
 
 ```ts
 import { Sandbox } from "@alineo-labs/sandbox";
@@ -24,6 +27,16 @@ await sb.close();
 ```
 
 **[Full documentation →](https://docs.alineo.tech)**
+
+---
+
+## Cookbook
+
+Task-oriented recipes for real end-to-end scenarios — untrusted code execution, parallel test
+sharding, resumable pipelines, and more — built by composing sandboxes, exec, checkpoints, forks,
+and agents. Each one is a small, standalone package you can copy out and adapt.
+
+**[Browse the cookbook →](cookbooks)**
 
 ---
 
@@ -71,6 +84,20 @@ npx skills add DrejT/alineo --skill alineo
 This repo features native cross-platform support and can be developed directly on Windows without requiring WSL or Git Bash.
 - **Native Scripts**: All repository scripts (e.g., `bun run setup`, `bun run build`) leverage Bun's native shell APIs.
 - **Docker Integration**: The local `alineo init` command dynamically detects Windows and uses Named Pipes (`//./pipe/docker_engine`) for Docker socket injection automatically.
+
+---
+
+## Community
+
+- **Discord**: [Join us](https://discord.com/invite/XGkPu3YBH4) — questions, discussion, and help in real time
+- **Issues**: [Report a bug](https://github.com/DrejT/alineo/issues) or request a feature
+- **Contributing**: see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+---
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=DrejT/alineo&type=Date)](https://star-history.com/#DrejT/alineo&Date)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a Discord badge + **Community** section (Discord, issues, contributing) to `README.md`
- Add a **Star History** chart section
- Surface the cookbook as its own top-level **Cookbook** section — was previously only discoverable by browsing the repo
- Add a placeholder comment for a demo GIF/video (not yet recorded — see follow-ups)
- Point `CONTRIBUTING.md` and the issue template contact links at Discord

GitHub Topics were also updated directly (not part of this diff): added `developer-tools`, `docker`, `sdk`, `nodejs` alongside the existing 6.

## Follow-ups (intentionally out of scope here)
- Record and embed the actual demo GIF/video
- Design a social preview image (1280×640, Settings → General)
- GitHub Discussions stays disabled for now (existing dead links in the issue template are a pre-existing gap, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)