### PR TITLE
docs: drop Star History section — GitHub restricted the stargazer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,6 @@ This repo features native cross-platform support and can be developed directly o
 
 ---
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=DrejT/alineo&type=Date)](https://star-history.com/#DrejT/alineo&Date)
-
----
-
 ## License
 
 Apache 2.0


### PR DESCRIPTION
Fast-follow to #207, which merged before this fix landed.

`api.star-history.com/svg` is currently rendering a public "GitHub restricted access to star data" placeholder instead of an actual chart — GitHub locked the stargazer API to repo admins/collaborators on 2026-06-30 (see [star-history.com/blog/github-stargazer-api-restriction](https://www.star-history.com/blog/github-stargazer-api-restriction)). It's broken for everyone right now, including our own README on main. Pulling the section until GitHub/star-history.com resolve the restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)