### PR TITLE
docs: show real code instead of link-outs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,81 @@ await sb.exec('echo "hello from a sandbox"').pipe(process.stdout);
 await sb.close();
 ```
 
+---
+
+## What you can build
+
+**Run untrusted code safely** — every snippet gets its own disposable, resource-capped sandbox, and
+a bad one can't take down the batch:
+
+```ts
+const sb = await client.sandbox({
+  image: "python:3.11-slim",
+  resources: { cpu: "250m", memory: "128Mi" },
+  timeout: 60,
+});
+await sb.writeFile("/tmp/snippet.py", untrustedCode);
+const { stdout, exitCode } = await sb.exec("python3 /tmp/snippet.py", {
+  strict: false, // a non-zero exit comes back as data, not a throw
+  timeoutMs: 5_000, // kill a runaway loop instead of hanging the batch
+});
+await sb.close();
+```
+
+**[Full recipe →](cookbooks/untrusted-code-execution)**
+
+**Fan out across sandboxes in parallel** — one pipeline, several environments, flushed in a single
+`await`:
+
+```ts
+import { workflow } from "@alineo-labs/workflow";
+
+await workflow(client)
+  .parallel(
+    [
+      { image: "node:18-slim", resources: { cpu: "500m", memory: "256Mi" } },
+      { image: "node:20-slim", resources: { cpu: "500m", memory: "256Mi" } },
+    ],
+    (sb) => sb.exec("npm ci && npm test"),
+  )
+  .pipe(process.stdout);
+```
+
+**[`@alineo-labs/workflow` docs →](packages/workflow)**
+
+**Run a coding agent inside a sandbox** — [Pi](https://pi.ai) reads and writes files and runs shell
+commands, streamed back over a plain TypeScript API:
+
+```ts
+import { Alineo, textOnly } from "alineo";
+
+const spec = await Bun.file("./agents/my-agent.json").json(); // { cli: "pi", model, resources, ... }
+const agent = await Alineo.load(spec, { adapter });
+for await (const chunk of textOnly(agent.prompt("Fix the failing test in src/math.ts"))) {
+  process.stdout.write(chunk);
+}
+await agent.close();
+```
+
+**[`alineo` agent docs →](packages/agent)**
+
 **[Full documentation →](https://docs.alineo.tech)**
 
 ---
 
 ## Cookbook
 
-Task-oriented recipes for real end-to-end scenarios — untrusted code execution, parallel test
-sharding, resumable pipelines, and more — built by composing sandboxes, exec, checkpoints, forks,
-and agents. Each one is a small, standalone package you can copy out and adapt.
+More task-oriented recipes for real end-to-end scenarios — CI test runners, parallel test
+sharding, resumable pipelines, LLM bugfix agents, and more — built by composing sandboxes, exec,
+checkpoints, forks, and agents. Each one is a small, standalone package you can copy out and adapt.
 
 **[Browse the cookbook →](cookbooks)**
 
 ---
 
 ## Packages
+
+Full reference — every package above lives here, plus the storage adapters and CLI:
 
 | Package                                                 | Description                                                 |
 | -------------------------------------------------------- | ----------------------------------------------------------- |


### PR DESCRIPTION
## Why

Feedback: the README's hero snippet is good, but right after it we immediately push readers out to "Full documentation" / "Browse the cookbook" links before showing them anything else — devs want to see what they can actually do with this, not click into destinations they don't have context for yet. The Packages table below is the same problem: all links, no code.

## What changed

- Added a **"What you can build"** section right after the hero snippet, with three more real, working snippets pulled from the actual source (not invented):
  - Safe untrusted-code execution — trimmed from `cookbooks/untrusted-code-execution/index.ts`
  - Parallel sandbox fan-out via `@alineo-labs/workflow` — from `packages/workflow/README.md`
  - Running a Pi coding agent in a sandbox — from `packages/agent/README.md`
- The "Full documentation" link now comes *after* this section, once there's something to be convinced by.
- Cookbook section is now framed as "more recipes" (we've already shown one) rather than the first pointer out.
- Packages table stays, reframed as the reference list rather than the pitch.

Follows up on the earlier README PRs (#207, #208) and the noted follow-up to add per-package code snippets / de-emphasize the bare table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)