### PR TITLE
docs: simplify README further — drop Cookbook and Windows Support sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,81 +26,11 @@ await sb.exec('echo "hello from a sandbox"').pipe(process.stdout);
 await sb.close();
 ```
 
----
-
-## What you can build
-
-**Run untrusted code safely** — every snippet gets its own disposable, resource-capped sandbox, and
-a bad one can't take down the batch:
-
-```ts
-const sb = await client.sandbox({
-  image: "python:3.11-slim",
-  resources: { cpu: "250m", memory: "128Mi" },
-  timeout: 60,
-});
-await sb.writeFile("/tmp/snippet.py", untrustedCode);
-const { stdout, exitCode } = await sb.exec("python3 /tmp/snippet.py", {
-  strict: false, // a non-zero exit comes back as data, not a throw
-  timeoutMs: 5_000, // kill a runaway loop instead of hanging the batch
-});
-await sb.close();
-```
-
-**[Full recipe →](cookbooks/untrusted-code-execution)**
-
-**Fan out across sandboxes in parallel** — one pipeline, several environments, flushed in a single
-`await`:
-
-```ts
-import { workflow } from "@alineo-labs/workflow";
-
-await workflow(client)
-  .parallel(
-    [
-      { image: "node:18-slim", resources: { cpu: "500m", memory: "256Mi" } },
-      { image: "node:20-slim", resources: { cpu: "500m", memory: "256Mi" } },
-    ],
-    (sb) => sb.exec("npm ci && npm test"),
-  )
-  .pipe(process.stdout);
-```
-
-**[`@alineo-labs/workflow` docs →](packages/workflow)**
-
-**Run a coding agent inside a sandbox** — [Pi](https://pi.ai) reads and writes files and runs shell
-commands, streamed back over a plain TypeScript API:
-
-```ts
-import { Alineo, textOnly } from "alineo";
-
-const spec = await Bun.file("./agents/my-agent.json").json(); // { cli: "pi", model, resources, ... }
-const agent = await Alineo.load(spec, { adapter });
-for await (const chunk of textOnly(agent.prompt("Fix the failing test in src/math.ts"))) {
-  process.stdout.write(chunk);
-}
-await agent.close();
-```
-
-**[`alineo` agent docs →](packages/agent)**
-
 **[Full documentation →](https://docs.alineo.tech)**
 
 ---
 
-## Cookbook
-
-More task-oriented recipes for real end-to-end scenarios — CI test runners, parallel test
-sharding, resumable pipelines, LLM bugfix agents, and more — built by composing sandboxes, exec,
-checkpoints, forks, and agents. Each one is a small, standalone package you can copy out and adapt.
-
-**[Browse the cookbook →](cookbooks)**
-
----
-
 ## Packages
-
-Full reference — every package above lives here, plus the storage adapters and CLI:
 
 | Package                                                 | Description                                                 |
 | -------------------------------------------------------- | ----------------------------------------------------------- |
@@ -136,14 +66,6 @@ storage adapters that AI coding agents can load directly. Install it with the
 ```bash
 npx skills add DrejT/alineo --skill alineo
 ```
-
----
-
-## Windows Support
-
-This repo features native cross-platform support and can be developed directly on Windows without requiring WSL or Git Bash.
-- **Native Scripts**: All repository scripts (e.g., `bun run setup`, `bun run build`) leverage Bun's native shell APIs.
-- **Docker Integration**: The local `alineo init` command dynamically detects Windows and uses Named Pipes (`//./pipe/docker_engine`) for Docker socket injection automatically.
 
 ---
 


### PR DESCRIPTION
## Why

Follow-up to #209. Feedback: only show code samples for the main sandbox package (not spread across sandbox/workflow/agent), drop the Cookbook section, drop Windows Support.

Supersedes #210, which was closed — that branch had already been squash-merged into main via #209, so reopening a PR from the same branch put it in an unresolvable content conflict. This is the same diff, opened fresh off current `main`.

## What changed

- Removed the "What you can build" section (workflow fan-out + Pi agent snippets) — the hero snippet (`@alineo-labs/sandbox`) is now the only code sample.
- Removed the Cookbook section.
- Removed the Windows Support section.
- Packages table now sits directly below the hero snippet / docs link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)