### PR TITLE
docs: replace hero snippet with agent package examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,88 @@
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/XGkPu3YBH4)
 
-Sandboxes as objects. Spawn live containers, run code, checkpoint state — from TypeScript.
+Run [Pi](https://pi.ai) coding agents inside isolated sandbox containers — read/write files, run
+shell commands, execute scripts, streamed back over a plain TypeScript API.
 
 <!-- TODO: demo GIF/video — drop in here once recorded -->
 
 ```ts
-import { Sandbox } from "@alineo-labs/sandbox";
+import { Alineo, textOnly } from "alineo";
 import { SQLiteAdapter } from "@alineo-labs/sqlite";
 
-const client = new Sandbox({
-  baseUrl: "http://127.0.0.1:8080",
-  adapter: new SQLiteAdapter("./ledger.db"),
-});
-
-const sb = await client.sandbox({
-  image: "ubuntu:22.04",
-  resources: { cpu: "500m", memory: "512Mi" },
-});
-await sb.exec('echo "hello from a sandbox"').pipe(process.stdout);
-await sb.close();
+const adapter = new SQLiteAdapter("./.alineo/ledger.db");
+const spec = await Bun.file("./agents/my-agent.json").json();
+const agent = await Alineo.load(spec, { adapter });
+try {
+  for await (const chunk of textOnly(agent.prompt("Write and run a Python hello world script."))) {
+    process.stdout.write(chunk);
+  }
+} finally {
+  await agent.close();
+}
 ```
 
-**[Full documentation →](https://docs.alineo.tech)**
+**[Full documentation →](https://docs.alineo.tech/docs/agent)**
+
+---
+
+## More things you can do
+
+**Watch every tool call** — iterate the raw stream instead of `textOnly()` for full observability:
+
+```ts
+for await (const ev of agent.prompt("Run /workspace/script.py with python3.")) {
+  switch (ev.type) {
+    case "text":
+      process.stdout.write(ev.text);
+      break;
+    case "tool_start":
+      console.log(`[tool] ${ev.toolName} args=${JSON.stringify(ev.args)}`);
+      break;
+    case "tool_end":
+      console.log(`[tool] ${ev.toolName} done  isError=${ev.isError}`);
+      break;
+  }
+}
+```
+
+**Spawn child agents** — fork this agent's live sandbox (filesystem, installed packages,
+everything currently on disk) into an independent sub-agent:
+
+```ts
+const child = await agent.spawn("./agents/worker.json", { spawnDepth: 2, maxAgents: 5 });
+try {
+  for await (const chunk of textOnly(child.prompt("Handle the auth module"))) {
+    process.stdout.write(chunk);
+  }
+} finally {
+  await child.close();
+}
+```
+
+**Steer mid-response** — redirect Pi while it's still generating, no need to wait or restart:
+
+```ts
+const stream = textOnly(agent.prompt("Write an essay on every sorting algorithm..."));
+setTimeout(() => agent.steer("Stop — give me 3 bullet points instead."), 1500);
+for await (const chunk of stream) process.stdout.write(chunk);
+```
+
+**Resume after a restart** — reconnect to a sandbox from a previous process without touching Pi's
+running state:
+
+```ts
+const agent = await Alineo.resume(savedSandboxId, { adapter });
+```
+
+**Inspect session cost and usage**:
+
+```ts
+const stats = await agent.getSessionStats();
+console.log(`${stats.tokens.total} tokens used, $${stats.cost.toFixed(6)} cost`);
+```
+
+**[More in the agent docs →](packages/agent)**
 
 ---
 


### PR DESCRIPTION
## Why

Follow-up to #211. Feedback: show code snippets for the `alineo` agent package instead of the raw sandbox client, and add several more.

## What changed

- Hero snippet swapped from `@alineo-labs/sandbox` to the `alineo` agent-package quickstart (this also lines up the hero with what the npm badge actually links to — `alineo` is the agent package, not the sandbox client).
- Added a "More things you can do" section with 5 more real snippets sourced from `packages/agent/README.md`:
  - Watching every tool call (raw stream vs. `textOnly()`)
  - Spawning child agents from a live sandbox
  - Steering a response mid-flight
  - Resuming an agent after a process restart
  - Reading session cost/token stats
- Tagline updated to describe the agent runtime.

## Mergeability

Fresh branch off current `main` (post-#211) — verified clean, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)