### PR TITLE
docs: drop the 'More things you can do' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ try {
 
 ---
 
-## More things you can do
-
 **Watch every tool call** — iterate the raw stream instead of `textOnly()` for full observability:
 
 ```ts


### PR DESCRIPTION
## Why

Feedback on #212: the "More things you can do" wrapper header wasn't helpful — the snippets underneath already have their own bold feature name as a lead-in.

Note: I'd pushed this exact fix to #212's branch, but that push landed after #212 had already merged, so it never reached `main`. This is a fresh branch/PR carrying the same one-line diff.

## What changed

Removed `## More things you can do`. Snippets now flow directly after the quickstart/docs link, each still introduced by its own bold lead-in (**Watch every tool call**, **Spawn child agents**, etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)