### PR TITLE
Enable type-aware Oxlint and fix all 681 findings

### DIFF
--- a/.changeset/thirteen-lints-heal.md
+++ b/.changeset/thirteen-lints-heal.md
@@ -1,0 +1,32 @@
+---
+"@alineo-labs/flue": patch
+"@alineo-labs/postgres": patch
+"@alineo-labs/sqlite": patch
+"@alineo-labs/agent-browser": patch
+"alineo": patch
+"alineo-cli": patch
+"@alineo-labs/core": patch
+"@alineo-labs/harness": patch
+"@alineo-labs/model-providers": patch
+"@alineo-labs/opensandbox": patch
+"@alineo-labs/sandbox": patch
+"@alineo-labs/workflow": patch
+---
+
+Internal: enabled Oxlint's type-aware linting repo-wide and fixed every finding it surfaced
+(681 → 0). Almost entirely non-behavioral (removing unnecessary type assertions, replacing
+non-null assertions with real invariant checks, fixing tsconfig gaps that were masking latent
+type errors) — flagged the couple of exceptions below since they do change observable behavior.
+
+- `alineo-cli`'s Pi bootstrap extension (`pi-extension/alineo.ts`) no longer replaces an
+  empty-but-present `stderr` string with a generic fallback message in its install/init failure
+  notifications — only a genuinely missing `stderr` falls back now.
+- `@alineo-labs/core`'s `SandboxCore` gained a couple of small correctness fixes surfaced along the
+  way: `bun:sqlite`'s deprecated `exec()` alias replaced with `run()`, and a `finally`-block cleanup
+  path in a test that could previously mask a real assertion failure with an unrelated error now
+  logs instead of throwing.
+- `packages/cli/src/tui/chat.ts`'s `AgentEvent` switch now lists all 14 previously-implicit
+  "ignored" event kinds explicitly instead of a bare `default`, so a future new event kind fails
+  exhaustiveness and forces a conscious decision, rather than silently landing in "ignored".
+
+No public API changes. Full `typecheck`/`test`/`build` suite passes for every package.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,7 +41,7 @@
     "typescript/no-deprecated": "warn",
     "typescript/no-unsafe-enum-comparison": "warn",
 
-    "typescript/no-unnecessary-condition": "warn",
+    "typescript/no-unnecessary-condition": ["warn", { "allowConstantLoopConditions": true }],
     "typescript/require-await": "warn",
     "typescript/no-confusing-void-expression": "warn",
     "typescript/prefer-nullish-coalescing": "warn",
@@ -57,6 +57,12 @@
     },
     {
       "files": ["**/workflow/test/sandbox-builder.test.ts"],
+      "rules": {
+        "typescript/require-await": "off"
+      }
+    },
+    {
+      "files": ["**/opensandbox/test/*.test.ts"],
       "rules": {
         "typescript/require-await": "off"
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -68,6 +68,12 @@
       }
     },
     {
+      "files": ["**/sdks/typescript/test/client.test.ts"],
+      "rules": {
+        "typescript/unbound-method": "off"
+      }
+    },
+    {
       "files": ["**/pi-bridge.js"],
       "rules": {
         "typescript/no-unsafe-assignment": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -74,6 +74,14 @@
       }
     },
     {
+      "files": ["**/cli/test/docker.test.ts"],
+      "rules": {
+        "typescript/require-await": "off",
+        "typescript/await-thenable": "off",
+        "typescript/no-confusing-void-expression": "off"
+      }
+    },
+    {
       "files": ["**/pi-bridge.js"],
       "rules": {
         "typescript/no-unsafe-assignment": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -50,6 +50,12 @@
   "ignorePatterns": ["**/dist/**", "**/node_modules/**", "**/*.d.ts"],
   "overrides": [
     {
+      "files": ["**/adapters/sqlite/src/adapter.ts"],
+      "rules": {
+        "typescript/require-await": "off"
+      }
+    },
+    {
       "files": ["**/pi-bridge.js"],
       "rules": {
         "typescript/no-unsafe-assignment": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,9 +4,98 @@
   "env": {
     "node": true
   },
+  "options": {
+    "typeAware": true
+  },
   "rules": {
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "warn"
+    "@typescript-eslint/no-unused-vars": "warn",
+
+    "typescript/no-floating-promises": "error",
+    "typescript/no-misused-promises": "error",
+    "typescript/await-thenable": "error",
+    "typescript/no-unsafe-assignment": "error",
+    "typescript/no-unsafe-call": "error",
+    "typescript/no-unsafe-member-access": "error",
+    "typescript/no-unsafe-return": "error",
+    "typescript/no-unsafe-argument": "error",
+    "typescript/no-unnecessary-type-assertion": "warn",
+    "typescript/restrict-template-expressions": "warn",
+    "typescript/no-explicit-any": "warn",
+    "typescript/consistent-type-imports": "warn",
+    "typescript/no-non-null-assertion": "warn",
+
+    "typescript/unbound-method": "warn",
+    "typescript/no-base-to-string": "warn",
+
+    "typescript/consistent-type-exports": "error",
+    "typescript/only-throw-error": "error",
+    "typescript/return-await": "error",
+    "typescript/no-misused-spread": "error",
+    "typescript/no-mixed-enums": "error",
+    "typescript/no-unnecessary-type-parameters": "error",
+    "typescript/related-getter-setter-pairs": "error",
+    "typescript/no-array-delete": "error",
+
+    "typescript/switch-exhaustiveness-check": "warn",
+    "typescript/no-deprecated": "warn",
+    "typescript/no-unsafe-enum-comparison": "warn",
+
+    "typescript/no-unnecessary-condition": "warn",
+    "typescript/require-await": "warn",
+    "typescript/no-confusing-void-expression": "warn",
+    "typescript/prefer-nullish-coalescing": "warn",
+    "typescript/prefer-optional-chain": "warn"
   },
-  "ignorePatterns": ["**/dist/**", "**/node_modules/**", "**/*.d.ts"]
+  "ignorePatterns": ["**/dist/**", "**/node_modules/**", "**/*.d.ts"],
+  "overrides": [
+    {
+      "files": ["**/pi-bridge.js"],
+      "rules": {
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-return": "off",
+        "typescript/no-unnecessary-condition": "off",
+        "typescript/prefer-nullish-coalescing": "off",
+        "typescript/prefer-optional-chain": "off",
+        "typescript/switch-exhaustiveness-check": "off"
+      }
+    },
+    {
+      "files": ["examples/**", "cookbooks/**"],
+      "rules": {
+        "typescript/no-floating-promises": "off",
+        "typescript/no-misused-promises": "off",
+        "typescript/await-thenable": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-return": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unnecessary-type-assertion": "off",
+        "typescript/restrict-template-expressions": "off",
+
+        "typescript/unbound-method": "off",
+        "typescript/no-base-to-string": "off",
+        "typescript/consistent-type-exports": "off",
+        "typescript/only-throw-error": "off",
+        "typescript/return-await": "off",
+        "typescript/no-misused-spread": "off",
+        "typescript/no-mixed-enums": "off",
+        "typescript/no-unnecessary-type-parameters": "off",
+        "typescript/related-getter-setter-pairs": "off",
+        "typescript/no-array-delete": "off",
+        "typescript/switch-exhaustiveness-check": "off",
+        "typescript/no-deprecated": "off",
+        "typescript/no-unsafe-enum-comparison": "off",
+        "typescript/no-unnecessary-condition": "off",
+        "typescript/require-await": "off",
+        "typescript/no-confusing-void-expression": "off",
+        "typescript/prefer-nullish-coalescing": "off",
+        "typescript/prefer-optional-chain": "off"
+      }
+    }
+  ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -68,7 +68,11 @@
       }
     },
     {
-      "files": ["**/sdks/typescript/test/client.test.ts"],
+      "files": [
+        "**/sdks/typescript/test/client.test.ts",
+        "**/core/test/sandbox-ledger-queue.test.ts",
+        "**/core/test/exec-handle-interactive.test.ts"
+      ],
       "rules": {
         "typescript/unbound-method": "off"
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -56,6 +56,12 @@
       }
     },
     {
+      "files": ["**/workflow/test/sandbox-builder.test.ts"],
+      "rules": {
+        "typescript/require-await": "off"
+      }
+    },
+    {
       "files": ["**/pi-bridge.js"],
       "rules": {
         "typescript/no-unsafe-assignment": "off",

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@changesets/cli": "2.31.0",
         "oxfmt": "^0.57.0",
         "oxlint": "^1.71.0",
+        "oxlint-tsgolint": "^7.0.2001",
       },
     },
     "apps/docs": {
@@ -1061,6 +1062,18 @@
     "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.57.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg=="],
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w=="],
+
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
+
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
+
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
+
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
+
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
+
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.71.0", "", { "os": "android", "cpu": "arm" }, "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g=="],
 
@@ -2525,6 +2538,8 @@
     "oxfmt": ["oxfmt@0.57.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.57.0", "@oxfmt/binding-android-arm64": "0.57.0", "@oxfmt/binding-darwin-arm64": "0.57.0", "@oxfmt/binding-darwin-x64": "0.57.0", "@oxfmt/binding-freebsd-x64": "0.57.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0", "@oxfmt/binding-linux-arm-musleabihf": "0.57.0", "@oxfmt/binding-linux-arm64-gnu": "0.57.0", "@oxfmt/binding-linux-arm64-musl": "0.57.0", "@oxfmt/binding-linux-ppc64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-musl": "0.57.0", "@oxfmt/binding-linux-s390x-gnu": "0.57.0", "@oxfmt/binding-linux-x64-gnu": "0.57.0", "@oxfmt/binding-linux-x64-musl": "0.57.0", "@oxfmt/binding-openharmony-arm64": "0.57.0", "@oxfmt/binding-win32-arm64-msvc": "0.57.0", "@oxfmt/binding-win32-ia32-msvc": "0.57.0", "@oxfmt/binding-win32-x64-msvc": "0.57.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA=="],
 
     "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 

--- a/examples/pi-agent/test-tool-calls.ts
+++ b/examples/pi-agent/test-tool-calls.ts
@@ -10,7 +10,7 @@
  *   - A tool_end event for each tool_start
  *   - The final text answer from Pi
  */
-import { Alineo, textOnly, type AgentEvent } from "alineo";
+import { Alineo, type AgentEvent } from "alineo";
 import { SQLiteAdapter } from "@alineo-labs/sqlite";
 
 const SPEC = "./agents/hello-agent.json";

--- a/examples/sandbox-fork/index.ts
+++ b/examples/sandbox-fork/index.ts
@@ -64,21 +64,27 @@ try {
           .join("; "),
     );
   }
+  // No failures above means both fork() calls fulfilled, so both handles were assigned.
+  if (!forkA || !forkB) {
+    throw new Error("internal error: fork() succeeded but a handle is missing");
+  }
+  const a = forkA;
+  const b = forkB;
 
-  console.log(`fork-a id: ${forkA!.sandboxId}`);
-  console.log(`fork-b id: ${forkB!.sandboxId}`);
+  console.log(`fork-a id: ${a.sandboxId}`);
+  console.log(`fork-b id: ${b.sandboxId}`);
 
   // ── Run different workloads in parallel ────────────────────────────────────
 
   console.log("\n=== Running in parallel ===\n");
 
   await Promise.all([
-    forkA!
+    a
       .writeFile("/tmp/run.py", scriptA)
-      .then(() => forkA!.exec("python3 /tmp/run.py").pipe(process.stdout)),
-    forkB!
+      .then(() => a.exec("python3 /tmp/run.py").pipe(process.stdout)),
+    b
       .writeFile("/tmp/run.py", scriptB)
-      .then(() => forkB!.exec("python3 /tmp/run.py").pipe(process.stdout)),
+      .then(() => b.exec("python3 /tmp/run.py").pipe(process.stdout)),
   ]);
 
   // ── Checkpoints are recorded in the original sandbox's ledger ─────────────

--- a/examples/snapshot-replay/index.ts
+++ b/examples/snapshot-replay/index.ts
@@ -37,7 +37,7 @@ print("requests is already installed — no pip install needed")
 console.log("=== Original run ===\n");
 
 const sb = await client.sandbox(sandboxOpts);
-let originalSandboxId: string;
+let originalSandboxId: string | undefined;
 
 try {
   originalSandboxId = sb.sandboxId;
@@ -57,7 +57,10 @@ try {
 
 console.log("\n=== Resumed run ===\n");
 
-const sbResume = await client.resume(originalSandboxId!);
+// The try block above always assigns originalSandboxId before completing without
+// throwing — if it threw, we wouldn't reach here at all.
+if (!originalSandboxId) throw new Error("internal error: originalSandboxId was never set");
+const sbResume = await client.resume(originalSandboxId);
 
 try {
   console.log(`Resumed sandbox ID: ${sbResume.sandboxId}`);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@changesets/cli": "2.31.0",
     "oxfmt": "^0.57.0",
-    "oxlint": "^1.71.0"
+    "oxlint": "^1.71.0",
+    "oxlint-tsgolint": "^7.0.2001"
   }
 }

--- a/packages/adapters/flue/src/index.ts
+++ b/packages/adapters/flue/src/index.ts
@@ -9,14 +9,16 @@ function esc(p: string): string {
 
 function rejectAfter(ms: number): Promise<never> {
   return new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error(`exec timed out after ${ms}ms`)), ms),
+    setTimeout(() => {
+      reject(new Error(`exec timed out after ${ms}ms`));
+    }, ms),
   );
 }
 
 // Encode Uint8Array → base64 string without using Buffer (portable Web API).
 function uint8ToBase64(buf: Uint8Array): string {
   let binary = "";
-  for (let i = 0; i < buf.length; i++) binary += String.fromCharCode(buf[i]!);
+  for (let i = 0; i < buf.length; i++) binary += String.fromCharCode(buf[i]);
   return btoa(binary);
 }
 
@@ -84,8 +86,8 @@ class AlineoSandboxApi implements SandboxApi {
       isFile: typeStr === "regular file",
       isDirectory: typeStr === "directory",
       isSymbolicLink: typeStr === "symbolic link",
-      size: parseInt(sizeStr!, 10),
-      mtime: new Date(parseInt(mtimeStr!, 10) * 1000),
+      size: parseInt(sizeStr, 10),
+      mtime: new Date(parseInt(mtimeStr, 10) * 1000),
     };
   }
 
@@ -138,8 +140,10 @@ class AlineoSandboxApi implements SandboxApi {
  */
 export function alineo(sandbox: SandboxHandle, opts?: { cwd?: string }): SandboxFactory {
   return {
-    async createSessionEnv(_: { id: string }) {
-      return createSandboxSessionEnv(new AlineoSandboxApi(sandbox), opts?.cwd ?? "/");
+    createSessionEnv(_: { id: string }) {
+      return Promise.resolve(
+        createSandboxSessionEnv(new AlineoSandboxApi(sandbox), opts?.cwd ?? "/"),
+      );
     },
   };
 }

--- a/packages/adapters/flue/test/adapter.test.ts
+++ b/packages/adapters/flue/test/adapter.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { SandboxHandle } from "@alineo-labs/sandbox";
+import type { SandboxApi } from "@flue/runtime";
 
 // ── Module mock ──────────────────────────────────────────────────────────────
 // Must be set up before the import of the module under test so bun can hoist it.
 
-let capturedApi: ReturnType<typeof buildApi> | null = null;
-mock.module("@flue/runtime", () => ({
-  createSandboxSessionEnv: (api: ReturnType<typeof buildApi>, cwd: string) => {
+type MockSessionEnv = { _cwd: string };
+
+let capturedApi: SandboxApi | null = null;
+void mock.module("@flue/runtime", () => ({
+  createSandboxSessionEnv: (api: SandboxApi, cwd: string): MockSessionEnv => {
     capturedApi = api;
     return { _cwd: cwd };
   },
 }));
+
+// Reading `capturedApi` through a function (rather than the bare module-level `let`)
+// gives the type checker a fresh `SandboxApi | null` read instead of the stale
+// "still null" narrowing it can't invalidate across the mocked async call above.
+function readCapturedApi(): SandboxApi | null {
+  return capturedApi;
+}
 
 import { alineo } from "../src/index.ts";
 
@@ -28,11 +38,14 @@ type FileInfoStub = {
   group: string;
 };
 
+type ExecOpts = { cwd?: string; env?: Record<string, string>; strict?: boolean };
+type ListDirectoryOpts = { depth?: number };
+
 type SandboxStub = {
-  exec: (cmd: string, opts?: any) => PromiseLike<ExecResult>;
+  exec: (cmd: string, opts?: ExecOpts) => PromiseLike<ExecResult>;
   readFile: (path: string) => Promise<string>;
   writeFile: (path: string, content: string) => Promise<void>;
-  listDirectory: (path: string, opts?: any) => Promise<FileInfoStub[]>;
+  listDirectory: (path: string, opts?: ListDirectoryOpts) => Promise<FileInfoStub[]>;
 };
 
 function makeStub(overrides: Partial<SandboxStub> = {}): SandboxHandle {
@@ -45,22 +58,20 @@ function makeStub(overrides: Partial<SandboxStub> = {}): SandboxHandle {
   } as unknown as SandboxHandle;
 }
 
-function buildApi(sb: SandboxHandle) {
-  return {} as any; // placeholder type; real shape captured at runtime
-}
-
-async function getApi(sb: SandboxHandle): Promise<any> {
+async function getApi(sb: SandboxHandle): Promise<SandboxApi> {
   capturedApi = null;
   const factory = alineo(sb);
   await factory.createSessionEnv({ id: "test-ctx" });
-  return capturedApi!;
+  const api = readCapturedApi();
+  if (!api) throw new Error("mock createSandboxSessionEnv was not invoked");
+  return api;
 }
 
 // ── exec ─────────────────────────────────────────────────────────────────────
 
 describe("exec", () => {
   it("delegates command, cwd, env and strict:false to sb.exec", async () => {
-    let lastCall: any;
+    let lastCall: { cmd: string; opts?: ExecOpts } | undefined;
     const sb = makeStub({
       exec: (cmd, opts) => {
         lastCall = { cmd, opts };
@@ -69,10 +80,10 @@ describe("exec", () => {
     });
     const api = await getApi(sb);
     const result = await api.exec("echo hi", { cwd: "/tmp", env: { X: "1" } });
-    expect(lastCall.cmd).toBe("echo hi");
-    expect(lastCall.opts.cwd).toBe("/tmp");
-    expect(lastCall.opts.env).toEqual({ X: "1" });
-    expect(lastCall.opts.strict).toBe(false);
+    expect(lastCall?.cmd).toBe("echo hi");
+    expect(lastCall?.opts?.cwd).toBe("/tmp");
+    expect(lastCall?.opts?.env).toEqual({ X: "1" });
+    expect(lastCall?.opts?.strict).toBe(false);
     expect(result).toEqual({ stdout: "hello", stderr: "", exitCode: 0 });
   });
 
@@ -88,6 +99,9 @@ describe("exec", () => {
   it("rejects after timeoutMs with the ceiling applied", async () => {
     const sb = makeStub({ exec: () => new Promise(() => {}) }); // never resolves
     const api = await getApi(sb);
+    // bun-types types `.rejects` as `Matchers<unknown>`, whose `toThrow` returns `void` —
+    // the actual runtime behavior (awaiting the rejection) isn't reflected in the type.
+    // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression
     await expect(api.exec("sleep 999", { timeoutMs: 10 })).rejects.toThrow("timed out after 10ms");
   });
 
@@ -155,7 +169,7 @@ describe("readFileBuffer", () => {
 
 describe("writeFile", () => {
   it("delegates string content to sb.writeFile", async () => {
-    let wrote: any;
+    let wrote: { p: string; c: string } | undefined;
     const sb = makeStub({
       writeFile: (p, c) => {
         wrote = { p, c };
@@ -226,6 +240,7 @@ describe("stat", () => {
       exec: () => Promise.resolve({ stdout: "", stderr: "no such file", exitCode: 1 }),
     });
     const api = await getApi(sb);
+    // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression -- see comment on the earlier .rejects. usage above
     await expect(api.stat("/nope")).rejects.toThrow("No such file or directory");
   });
 });
@@ -426,14 +441,14 @@ describe("alineo factory", () => {
   it("passes cwd '/' by default to createSandboxSessionEnv", async () => {
     const sb = makeStub();
     const factory = alineo(sb);
-    const env = (await factory.createSessionEnv({ id: "x" })) as any;
+    const env = (await factory.createSessionEnv({ id: "x" })) as unknown as MockSessionEnv;
     expect(env._cwd).toBe("/");
   });
 
   it("forwards custom cwd option", async () => {
     const sb = makeStub();
     const factory = alineo(sb, { cwd: "/workspace" });
-    const env = (await factory.createSessionEnv({ id: "x" })) as any;
+    const env = (await factory.createSessionEnv({ id: "x" })) as unknown as MockSessionEnv;
     expect(env._cwd).toBe("/workspace");
   });
 });

--- a/packages/adapters/flue/tsconfig.json
+++ b/packages/adapters/flue/tsconfig.json
@@ -9,5 +9,5 @@
     "allowImportingTsExtensions": true,
     "types": ["bun-types"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/adapters/postgres/src/adapter.ts
+++ b/packages/adapters/postgres/src/adapter.ts
@@ -49,7 +49,10 @@ function aggRowToDetails(row: AggRow): SandboxDetails {
 
 function applyOpts(details: SandboxDetails[], opts?: ListSandboxOptions): SandboxDetails[] {
   let result = details;
-  if (opts?.before != null) result = result.filter((d) => d.startedAt < opts.before!);
+  if (opts?.before != null) {
+    const before = opts.before;
+    result = result.filter((d) => d.startedAt < before);
+  }
   if (opts?.status != null) result = result.filter((d) => d.status === opts.status);
   if (opts?.runId != null) result = result.filter((d) => d.runId === opts.runId);
   if (opts?.limit != null) result = result.slice(0, opts.limit);

--- a/packages/adapters/sqlite/src/adapter.ts
+++ b/packages/adapters/sqlite/src/adapter.ts
@@ -59,11 +59,18 @@ const AGG_SQL = (whereClause: string) => `
 `;
 
 function aggRowToDetails(row: AggRow): SandboxDetails {
+  if (row.started_at == null) {
+    // AGG_SQL's WHERE clause already excludes rows with no started_at; this only
+    // trips if that invariant is ever broken.
+    throw new Error(
+      `corrupt ledger: aggregated row for ${row.name}/${row.sandbox_id} has no started_at`,
+    );
+  }
   return {
     name: row.name,
     sandboxId: row.sandbox_id,
     status: row.is_closed ? SandboxStatus.Completed : SandboxStatus.Running,
-    startedAt: row.started_at!,
+    startedAt: row.started_at,
     completedAt: row.completed_at ?? undefined,
     execCount: row.exec_count,
     // Older ledger rows written before this field existed have no runId recorded at
@@ -75,7 +82,10 @@ function aggRowToDetails(row: AggRow): SandboxDetails {
 
 function applyOpts(details: SandboxDetails[], opts?: ListSandboxOptions): SandboxDetails[] {
   let result = details;
-  if (opts?.before != null) result = result.filter((d) => d.startedAt < opts.before!);
+  if (opts?.before != null) {
+    const before = opts.before;
+    result = result.filter((d) => d.startedAt < before);
+  }
   if (opts?.status != null) result = result.filter((d) => d.status === opts.status);
   if (opts?.runId != null) result = result.filter((d) => d.runId === opts.runId);
   if (opts?.limit != null) result = result.slice(0, opts.limit);
@@ -106,16 +116,16 @@ export class SQLiteAdapter implements IStorageAdapter {
     // a no-op.
     try {
       mkdirSync(dirname(path), { recursive: true });
-    } catch (e: any) {
-      if (e.code !== "EEXIST") throw e;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
     }
     this.db = new Database(path, { create: true });
   }
 
   async connect(): Promise<void> {
-    this.db.exec(MIGRATION_SQL);
+    this.db.run(MIGRATION_SQL);
     // WAL mode prevents writer from blocking readers on concurrent access
-    this.db.exec("PRAGMA journal_mode = WAL;");
+    this.db.run("PRAGMA journal_mode = WAL;");
   }
 
   async close(): Promise<void> {

--- a/packages/adapters/sqlite/test/adapter.test.ts
+++ b/packages/adapters/sqlite/test/adapter.test.ts
@@ -102,7 +102,8 @@ describe("SQLiteAdapter", () => {
         }),
       );
       const cp = await db.lastCheckpoint("test-session", "session-1");
-      expect((cp!.payload as any).snapshotId).toBe("snap-2");
+      if (!cp) throw new Error("expected a checkpoint");
+      expect((cp.payload as { snapshotId: string }).snapshotId).toBe("snap-2");
     });
 
     it("ignores non-checkpoint events", async () => {
@@ -158,7 +159,7 @@ describe("SQLiteAdapter", () => {
       expect(d?.sandboxId).toBe("abc-123");
       expect(d?.name).toBe("my-sb");
       expect(d?.runId).toBe("abc-123");
-      expect((d as any)?.workflowName).toBeUndefined();
+      expect((d as unknown as { workflowName?: unknown } | null)?.workflowName).toBeUndefined();
     });
   });
 
@@ -266,6 +267,9 @@ describe("SQLiteAdapter", () => {
     });
 
     it("deleteEnvironment is a no-op for unknown name", async () => {
+      // bun-types types `.resolves`/`.rejects` as Matchers<unknown>, whose assertion methods
+      // return void — the actual async runtime behavior isn't reflected in the type.
+      // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression
       await expect(db.deleteEnvironment("no-such")).resolves.toBeUndefined();
     });
 
@@ -327,8 +331,13 @@ describe("SQLiteAdapter", () => {
         await nested.close();
         try {
           rmSync(root, { recursive: true, force: true });
-        } catch (e: any) {
-          if (e.code !== "EBUSY" && e.code !== "EPERM") throw e;
+        } catch (e) {
+          // Don't throw from a finally block — that would silently replace any real
+          // assertion failure from the try block above with this cleanup error instead.
+          const code = (e as NodeJS.ErrnoException).code;
+          if (code !== "EBUSY" && code !== "EPERM") {
+            console.error("temp dir cleanup failed:", e);
+          }
         }
       }
     });

--- a/packages/adapters/sqlite/tsconfig.json
+++ b/packages/adapters/sqlite/tsconfig.json
@@ -9,5 +9,5 @@
     "allowImportingTsExtensions": true,
     "types": ["bun-types"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/agent-browser/pi-extension/agent-browser.ts
+++ b/packages/agent-browser/pi-extension/agent-browser.ts
@@ -117,11 +117,17 @@ export default function (pi: ExtensionAPI) {
       if (Boolean(params.text) === Boolean(params.envVar)) {
         throw new Error("browser_fill requires exactly one of `text` or `envVar`");
       }
-      const value = params.envVar ? process.env[params.envVar] : params.text!;
-      if (params.envVar && value === undefined) {
-        throw new Error(`"${params.envVar}" is not set in this sandbox's environment`);
+      let value: string;
+      if (params.envVar) {
+        const envValue = process.env[params.envVar];
+        if (envValue === undefined) {
+          throw new Error(`"${params.envVar}" is not set in this sandbox's environment`);
+        }
+        value = envValue;
+      } else {
+        value = params.text ?? "";
       }
-      const res = await pi.exec("agent-browser", ["fill", params.ref, value!, "--json"], {
+      const res = await pi.exec("agent-browser", ["fill", params.ref, value, "--json"], {
         cwd: ctx.cwd,
         signal,
       });

--- a/packages/agent/src/adapters/pi-bridge.js
+++ b/packages/agent/src/adapters/pi-bridge.js
@@ -29,7 +29,7 @@ function buildPiArgs() {
       if (cfg.model) args.push("--model", cfg.model);
       if (cfg.resume) args.push("--continue");
     }
-  } catch (e) {}
+  } catch {}
   return args;
 }
 
@@ -53,7 +53,7 @@ function startHeartbeat(res) {
   return setInterval(function () {
     try {
       res.write(": ping\n\n");
-    } catch (e) {}
+    } catch {}
   }, 3000);
 }
 function stopHeartbeat(iv) {
@@ -82,7 +82,7 @@ function cleanupPendingCmds(reason) {
       try {
         p.res.write("data: " + JSON.stringify({ error: reason }) + "\n\n");
         p.res.end();
-      } catch (e) {}
+      } catch {}
     } else {
       respond(p.res, 500, { ok: false, error: reason });
     }
@@ -103,12 +103,12 @@ function startPi() {
   if (state.rl) {
     try {
       state.rl.close();
-    } catch (e) {}
+    } catch {}
   }
   if (state.proc) {
     try {
       state.proc.kill("SIGTERM");
-    } catch (e) {}
+    } catch {}
   }
   state.proc = null;
   state.rl = null;
@@ -180,7 +180,7 @@ function handleLine(line) {
   var ev;
   try {
     ev = JSON.parse(line);
-  } catch (e) {
+  } catch {
     return;
   }
 
@@ -222,11 +222,11 @@ function handleLine(line) {
       if (output)
         try {
           pending.res.write("data: " + JSON.stringify({ type: "text", text: output }) + "\n\n");
-        } catch (e) {}
+        } catch {}
       try {
         pending.res.write("data: [DONE]\n\n");
         pending.res.end();
-      } catch (e) {}
+      } catch {}
     } else if (ev.success) {
       respond(pending.res, 200, { ok: true, data: ev.data || null });
     } else {
@@ -515,7 +515,7 @@ function respond(res, status, body) {
   try {
     res.writeHead(status, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
-  } catch (e) {}
+  } catch {}
 }
 
 // --- HTTP server ---
@@ -565,7 +565,7 @@ http
       var data = {};
       try {
         if (body) data = JSON.parse(body);
-      } catch (e) {
+      } catch {
         res.writeHead(400);
         res.end("bad json");
         return;
@@ -597,7 +597,7 @@ http
               try {
                 res.write("data: " + JSON.stringify({ error: "bash timeout" }) + "\n\n");
                 res.end();
-              } catch (e) {}
+              } catch {}
             }
           }, 30000);
           res.writeHead(200, {

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -469,7 +469,11 @@ async function* sseStream(
 
       const result = await Promise.race([
         reader.read(),
-        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), remainingMs)),
+        new Promise<"timeout">((resolve) => {
+          setTimeout(() => {
+            resolve("timeout");
+          }, remainingMs);
+        }),
       ]);
       if (result === "timeout") throw new PromptTimeoutError(inactivityTimeoutMs, bridgeUrl);
 
@@ -480,7 +484,7 @@ async function* sseStream(
       }
       buf += decoder.decode(value, { stream: true });
       const lines = buf.split("\n");
-      buf = lines.pop()!;
+      buf = lines.pop() ?? ""; // split() on a string always yields at least one element
       for (const line of lines) {
         if (!line.startsWith("data: ")) continue;
         const payload = line.slice(6).trim();
@@ -495,7 +499,7 @@ async function* sseStream(
         const raw = JSON.parse(payload) as AgentEvent & { error?: string };
         if (raw.error) throw new Error(`Bridge error: ${raw.error}`);
         lastEventAt = Date.now();
-        yield raw as AgentEvent;
+        yield raw;
       }
     }
   } finally {

--- a/packages/agent/src/agent/factory.ts
+++ b/packages/agent/src/agent/factory.ts
@@ -90,7 +90,7 @@ export async function loadAgent(
   const setupHash = computeSetupHash(spec);
 
   const adapter = new PiAdapter();
-  let sb: SandboxHandle;
+  let sb: SandboxHandle | undefined;
   let fromSnapshot = false;
 
   // ── Snapshot fast path ────────────────────────────────────────────────────
@@ -135,20 +135,20 @@ export async function loadAgent(
 
     console.log(`[agent] installing Pi CLI...`);
     const t2 = Date.now();
-    await adapter.install(sb!, spec);
+    await adapter.install(sb, spec);
     console.log(`[agent] Pi CLI ready    ${elapsed(t2)}`);
 
     for (const step of spec.setup ?? []) {
       console.log(`[agent] setup: ${step.name}...`);
       const ts = Date.now();
       const cmd = step.cwd ? `cd ${step.cwd} && ${step.run}` : step.run;
-      await sb!.exec(cmd);
+      await sb.exec(cmd);
       console.log(`[agent] setup done      ${elapsed(ts)} (${step.name})`);
     }
 
     console.log(`[agent] checkpointing...`);
     const t3 = Date.now();
-    const snapshotId = await sb!.checkpoint();
+    const snapshotId = await sb.checkpoint();
     await store.save({
       specName: spec.name,
       setupHash,
@@ -158,24 +158,29 @@ export async function loadAgent(
     console.log(`[agent] checkpoint done ${elapsed(t3)}`);
   }
 
+  // Both paths above (snapshot fast path setting fromSnapshot=true, or the full
+  // install path just above) assign sb before getting here — this only trips if
+  // that invariant is ever broken.
+  if (!sb) throw new Error("internal error: sandbox was neither restored nor created");
+
   // Applied on every load() (fresh or from-snapshot) — the vault is sidecar-runtime-only, so
   // whichever path just created `sb` needs these re-registered against its own sandboxId.
   for (const { name, value, binding, source } of credentialBindings) {
-    await sb!.credentials.set(name, value, binding, source);
+    await sb.credentials.set(name, value, binding, source);
   }
 
   // ── Always: write fresh config + start bridge ─────────────────────────────
-  resolvedEnv.ALINEO_SANDBOX_ID = sb!.sandboxId;
-  await adapter.configure(sb!, spec, resolvedEnv);
+  resolvedEnv.ALINEO_SANDBOX_ID = sb.sandboxId;
+  await adapter.configure(sb, spec, resolvedEnv);
 
   console.log(`[agent] starting bridge...`);
   const t4 = Date.now();
-  await adapter.startBridge(sb!);
+  await adapter.startBridge(sb);
   await adapter.waitReady();
   console.log(`[agent] bridge ready    ${elapsed(t4)}`);
   console.log(`[agent] total           ${elapsed(t0)}${fromSnapshot ? " (from snapshot)" : ""}`);
 
-  return { sandbox: sb!, spec, env: resolvedEnv, adapter, fromSnapshot, runId };
+  return { sandbox: sb, spec, env: resolvedEnv, adapter, fromSnapshot, runId };
 }
 
 /**
@@ -292,7 +297,9 @@ export async function attachAgent(
   const env = parseShellExports(envFile);
   // Falls back to a fresh UUID only when attaching to a sandbox created before this
   // field existed — every sandbox created going forward always has ALINEO_RUN_ID baked in.
-  const runId = env.ALINEO_RUN_ID ?? crypto.randomUUID();
+  // parseShellExports()'s Record<string, string> is optimistic about which keys are
+  // actually present; this specific key genuinely may be missing.
+  const runId = (env.ALINEO_RUN_ID as string | undefined) ?? crypto.randomUUID();
   const stubSpec: AgentSpec = { name: opts.name, cli: "pi" };
   return {
     sandbox: sb,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,6 +4,7 @@ export { validateAgentSpec } from "./schema";
 export type {
   AgentEvent,
   AgentStream,
+  // eslint-disable-next-line typescript/no-deprecated -- deliberately still re-exported for backward compat until PromptStream's own removal
   PromptStream,
   PiModel,
   ThinkingLevel,

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -1,6 +1,22 @@
 import * as z from "zod";
 import { AgentSpecValidationError } from "./errors";
 
+/** Renders an arbitrary invalid field value for an error message without risking "[object Object]". */
+function describeValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    // JSON.stringify's type says it always returns string, but at runtime it returns
+    // undefined for values it can't represent (function, symbol, undefined itself).
+    const json = JSON.stringify(value) as string | undefined;
+    if (json !== undefined) return json;
+  } catch {
+    // circular reference or similar -- fall through to the primitive-safe rendering below
+  }
+  return typeof value === "object" && value !== null
+    ? Object.prototype.toString.call(value)
+    : String(value);
+}
+
 /**
  * Opt-in alternative to a plain `AgentSpec.env` string value — instead of interpolating
  * straight into the container's environment, `credential` is registered with the sandbox's
@@ -186,7 +202,7 @@ const AgentSpecSchema = z
       error: (issue) =>
         issue.input === undefined
           ? "Agent spec must have a 'cli' field. Supported values: pi"
-          : `Unsupported CLI: '${String(issue.input)}'. Supported values: pi`,
+          : `Unsupported CLI: '${describeValue(issue.input)}'. Supported values: pi`,
     }),
     cliVersion: z.string().optional(),
     provider: z.string().optional(),
@@ -228,5 +244,5 @@ export function validateAgentSpec(data: unknown): AgentSpec {
       })),
     );
   }
-  return result.data as AgentSpec;
+  return result.data;
 }

--- a/packages/agent/test/pi-prompt-timeout.test.ts
+++ b/packages/agent/test/pi-prompt-timeout.test.ts
@@ -61,12 +61,15 @@ describe("PiAdapter.prompt inactivity timeout", () => {
   it("times out when only heartbeat pings arrive, never a real event", async () => {
     globalThis.fetch = (() =>
       Promise.resolve(
-        sseResponse(Array(50).fill(": ping\n\n"), { intervalMs: 10, keepOpenAfter: true }),
+        sseResponse(Array<string>(50).fill(": ping\n\n"), { intervalMs: 10, keepOpenAfter: true }),
       )) as unknown as typeof fetch;
 
     const adapter = await adapterWithBridge();
     const stream = adapter.prompt("hi", { inactivityTimeoutMs: 80 });
 
+    // bun-types types `.rejects` as Matchers<unknown>, whose assertion methods return void —
+    // the actual async runtime behavior isn't reflected in the type.
+    // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression
     await expect(
       (async () => {
         for await (const _ev of stream) {

--- a/packages/agent/test/schema.test.ts
+++ b/packages/agent/test/schema.test.ts
@@ -133,6 +133,9 @@ describe("validateAgentSpec", () => {
       expect(err.issues.length).toBe(5);
       const paths = err.issues.map((i) => i.path.join("."));
       expect(paths).toEqual(
+        // bun-types' expect.arrayContaining()'s generic defaults to `any`, which leaks into
+        // toEqual's argument here even though the array literal itself is fully typed.
+        // eslint-disable-next-line typescript/no-unsafe-argument
         expect.arrayContaining(["name", "cli", "spawnDepth", "resources.cpu", "resources.memory"]),
       );
     }

--- a/packages/cli/pi-extension/alineo.ts
+++ b/packages/cli/pi-extension/alineo.ts
@@ -153,12 +153,12 @@ async function ensureAlineoReady(pi: ExtensionAPI, ctx: ExtensionContext): Promi
   bootstrapped = true;
 
   const check = await execOk(pi, "alineo", ["--version"]);
-  if (!check || check.code !== 0) {
+  if (check?.code !== 0) {
     ctx.ui.notify("Installing alineo...", "info");
     const install = await execOk(pi, "npm", ["install", "-g", "alineo-cli"]);
-    if (!install || install.code !== 0) {
+    if (install?.code !== 0) {
       ctx.ui.notify(
-        `Failed to install alineo: ${install?.stderr || "npm not available"}. ` +
+        `Failed to install alineo: ${install?.stderr ?? "npm not available"}. ` +
           `RLM flows won't work until this is resolved — install manually with "npm install -g alineo-cli".`,
         "error",
       );
@@ -168,9 +168,9 @@ async function ensureAlineoReady(pi: ExtensionAPI, ctx: ExtensionContext): Promi
   }
 
   const init = await execOk(pi, "alineo", ["init"]);
-  if (!init || init.code !== 0) {
+  if (init?.code !== 0) {
     ctx.ui.notify(
-      `"alineo init" failed: ${init?.stderr || "unknown error"}. ` +
+      `"alineo init" failed: ${init?.stderr ?? "unknown error"}. ` +
         `RLM flows won't work until OpenSandbox is reachable — see "alineo init" for manual setup.`,
       "warning",
     );

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -18,7 +18,9 @@ export async function logs(name: string, opts: { json?: boolean } = {}): Promise
   // listByName() connects the adapter as a side effect, so the direct
   // adapter.readAll() call below is safe to make on the same instance.
   const sessions = await client.sandboxes.listByName(name);
-  const session = sessions[0]; // newest first
+  // TS's array indexing types this as SandboxDetails (not | undefined), but an empty
+  // `sessions` array makes this genuinely undefined at runtime — this guard is real.
+  const session = sessions[0] as (typeof sessions)[number] | undefined; // newest first
   if (!session) {
     throw new Error(`No session named '${name}' found in the ledger.`);
   }

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -34,7 +34,7 @@ export async function spawn(
   const adapter = new SQLiteAdapter(config.adapterPath);
   // Alineo.load() no longer does its own file I/O (see #184) -- read the spec file ourselves.
   // load() validates it internally regardless, so no need to call validateAgentSpec() here too.
-  const spec = await Bun.file(specPath).json();
+  const spec = (await Bun.file(specPath).json()) as Record<string, unknown>;
   const agent = await Alineo.load(spec, {
     adapter,
     rebuild: opts.rebuild,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,8 +34,8 @@ function fillDefaults(data: Partial<AlineoConfig>): AlineoConfig {
     agentsDir: data.agentsDir ?? "./agents",
     defaults: {
       resources: {
-        cpu: data.defaults?.resources?.cpu ?? "1000m",
-        memory: data.defaults?.resources?.memory ?? "1Gi",
+        cpu: data.defaults?.resources.cpu ?? "1000m",
+        memory: data.defaults?.resources.memory ?? "1Gi",
       },
     },
   };

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -1,7 +1,7 @@
 export type ContainerState = "running" | "stopped" | "missing";
 
 async function spawn(cmd: string[]): Promise<{ ok: boolean; stdout: string; stderr: string }> {
-  let proc: ReturnType<typeof Bun.spawn>;
+  let proc;
   try {
     proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
   } catch {

--- a/packages/cli/src/sessions-data.ts
+++ b/packages/cli/src/sessions-data.ts
@@ -44,7 +44,11 @@ export async function getSessions(config?: AlineoConfig): Promise<SessionSnapsho
     // rather than showing nothing.
   }
 
-  const tracked = liveIds ? ledgerRunning.filter((s) => liveIds!.has(s.sandboxId)) : ledgerRunning;
+  let tracked = ledgerRunning;
+  if (liveIds) {
+    const ids = liveIds;
+    tracked = ledgerRunning.filter((s) => ids.has(s.sandboxId));
+  }
 
   const trackedIds = new Set(tracked.map((s) => s.sandboxId));
   const untracked = liveIds ? [...liveIds].filter((id) => !trackedIds.has(id)) : [];

--- a/packages/cli/src/tui/chat.ts
+++ b/packages/cli/src/tui/chat.ts
@@ -86,7 +86,23 @@ export function createChatView(renderer: CliRenderer, agent: Alineo, onBack: () 
           case "extension_error":
             appendLine(`[extension error] ${ev.extensionPath}: ${ev.error}`);
             break;
-          default:
+          // Deliberately ignored per this function's doc comment above — listed
+          // explicitly (rather than a bare `default`) so a future new AgentEvent
+          // kind fails exhaustiveness and forces a conscious decision here.
+          case "agent_start":
+          case "agent_end":
+          case "tool_update":
+          case "compaction_start":
+          case "compaction_end":
+          case "auto_retry_start":
+          case "auto_retry_end":
+          case "message_start":
+          case "message_update":
+          case "message_end":
+          case "turn_start":
+          case "turn_end":
+          case "extension_ui":
+          case "queue_update":
             break;
         }
       }

--- a/packages/cli/src/tui/index.ts
+++ b/packages/cli/src/tui/index.ts
@@ -37,7 +37,13 @@ export async function launchTui(): Promise<void> {
       (session) => void openSession(session),
       quit,
       showNewSession,
-      (session) => mount(createLogsView(renderer, session, () => showDashboard())),
+      (session) => {
+        mount(
+          createLogsView(renderer, session, () => {
+            showDashboard();
+          }),
+        );
+      },
     );
     mount(view);
     if (initialStatus) view.setStatus(initialStatus);
@@ -48,7 +54,9 @@ export async function launchTui(): Promise<void> {
       createNewSessionView(
         renderer,
         (specPath) => void launchNewAgent(specPath),
-        () => showDashboard(),
+        () => {
+          showDashboard();
+        },
       ),
     );
   }
@@ -61,7 +69,11 @@ export async function launchTui(): Promise<void> {
         adapter,
         specPath: `${config.agentsDir}/${session.name}.json`,
       });
-      mount(createChatView(renderer, agent, () => showDashboard()));
+      mount(
+        createChatView(renderer, agent, () => {
+          showDashboard();
+        }),
+      );
     } catch (err) {
       showDashboard(
         `failed to open '${session.name}': ${err instanceof Error ? err.message : String(err)}`,
@@ -74,9 +86,13 @@ export async function launchTui(): Promise<void> {
     const adapter = new SQLiteAdapter(config.adapterPath);
     try {
       // Alineo.load() no longer does its own file I/O (see #184) -- read the spec ourselves.
-      const spec = await Bun.file(specPath).json();
+      const spec = (await Bun.file(specPath).json()) as Record<string, unknown>;
       const agent = await Alineo.load(spec, { adapter });
-      mount(createChatView(renderer, agent, () => showDashboard()));
+      mount(
+        createChatView(renderer, agent, () => {
+          showDashboard();
+        }),
+      );
     } catch (err) {
       showDashboard(
         `failed to start '${specPath}': ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/cli/test/agent-prompt.test.ts
+++ b/packages/cli/test/agent-prompt.test.ts
@@ -4,6 +4,7 @@ import { collectReply } from "../src/agent-prompt";
 
 function fakeAgent(events: AgentEvent[]): Alineo {
   return {
+    // eslint-disable-next-line typescript/require-await -- must be async to match Alineo.prompt's real signature; nothing here needs to await
     prompt: async function* () {
       for (const ev of events) yield ev;
     },

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -9,6 +9,7 @@ import {
   sendTelemetryEvent,
   withTelemetry,
   writeTelemetryConfig,
+  type CliTelemetryEvent,
 } from "../src/telemetry.js";
 
 let originalConfigPath: string | undefined;
@@ -106,6 +107,9 @@ describe("sendTelemetryEvent", () => {
     globalThis.fetch = mock(() =>
       Promise.reject(new Error("network down")),
     ) as unknown as typeof fetch;
+    // bun-types types `.resolves`/`.rejects` as Matchers<unknown>, whose assertion methods
+    // return void — the actual async runtime behavior isn't reflected in the type.
+    // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression
     await expect(
       sendTelemetryEvent(event, "http://example.invalid/v1/events"),
     ).resolves.toBeUndefined();
@@ -119,7 +123,9 @@ describe("sendTelemetryEvent", () => {
     globalThis.fetch = mock(
       (_url: string, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+          init?.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
         }),
     ) as unknown as typeof fetch;
     const start = performance.now();
@@ -149,6 +155,7 @@ describe("withTelemetry", () => {
     });
     globalThis.fetch = fetchSpy as unknown as typeof fetch;
     let ran = false;
+    // eslint-disable-next-line typescript/require-await -- run must return a Promise per withTelemetry's signature; nothing here needs to await
     await withTelemetry("spawn", [], async () => {
       ran = true;
     });
@@ -165,13 +172,15 @@ describe("withTelemetry", () => {
     }) as unknown as typeof fetch;
 
     const boom = new Error("boom");
+    // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression -- see comment on the earlier .resolves. usage above
     await expect(
+      // eslint-disable-next-line typescript/require-await -- run must return a Promise per withTelemetry's signature; nothing here needs to await
       withTelemetry("spawn", [], async () => {
         throw boom;
       }),
     ).rejects.toBe(boom);
 
-    const sent = JSON.parse(capturedBody ?? "{}");
+    const sent = JSON.parse(capturedBody ?? "{}") as CliTelemetryEvent;
     expect(sent.outcome).toBe("error");
     expect(sent.errorClass).toBe("Error");
   });
@@ -187,7 +196,7 @@ describe("withTelemetry", () => {
     // "agents" only allowlists --json; --not-a-real-flag must never appear in the sent event.
     await withTelemetry("agents", ["--json", "--not-a-real-flag"], async () => {});
 
-    const sent = JSON.parse(capturedBody ?? "{}");
+    const sent = JSON.parse(capturedBody ?? "{}") as CliTelemetryEvent;
     expect(sent.flags).toEqual({ json: true });
   });
 

--- a/packages/core/src/exec-handle.ts
+++ b/packages/core/src/exec-handle.ts
@@ -84,7 +84,9 @@ export class ExecHandle implements PromiseLike<ExecResult> {
           const result: ExecResult = { stdout: this._chunks.join(""), stderr: "", exitCode };
           this._notify();
           driver.onDone(result).then(
-            () => resolve(result),
+            () => {
+              resolve(result);
+            },
             (err) => {
               this._err = err;
               this._hasErr = true;
@@ -151,7 +153,7 @@ export class ExecHandle implements PromiseLike<ExecResult> {
     onfulfilled?: ((value: ExecResult) => T | PromiseLike<T>) | null,
     onrejected?: ((reason: unknown) => E | PromiseLike<E>) | null,
   ): Promise<T | E> {
-    return this._promise.then(onfulfilled, onrejected) as Promise<T | E>;
+    return this._promise.then(onfulfilled, onrejected);
   }
 
   /** Resolve the full result: `{ stdout, stderr, exitCode }`. */
@@ -233,6 +235,7 @@ export class InteractiveExecHandle extends ExecHandle {
   }
 
   /** Force-end the session. No-op if it already ended on its own. */
+  // eslint-disable-next-line typescript/require-await -- kept async/Promise-returning for a consistent await-able API alongside this class's other async methods; the underlying control is synchronous
   async close(): Promise<void> {
     this._controls?.close();
   }
@@ -246,7 +249,9 @@ export class InteractiveExecHandle extends ExecHandle {
     readable: AttachableSource,
     writable: { write(chunk: string): unknown },
   ): Promise<void> {
-    const onData = (chunk: Buffer | string) => this.write(chunk.toString());
+    const onData = (chunk: Buffer | string) => {
+      this.write(chunk.toString());
+    };
     readable.on("data", onData);
     try {
       await this.pipe(writable);

--- a/packages/core/src/sandbox/core.ts
+++ b/packages/core/src/sandbox/core.ts
@@ -1,5 +1,5 @@
-import { ExecClient, PtyClient, SnapshotState, SandboxState } from "@alineo-labs/opensandbox";
-import type { SSEEvent, RunInSessionRequest } from "@alineo-labs/opensandbox";
+import { type ExecClient, PtyClient, SnapshotState, SandboxState } from "@alineo-labs/opensandbox";
+import type { SSEEvent, CodeLanguage, CodeContext } from "@alineo-labs/opensandbox";
 import { SandboxError, CommandError } from "../errors";
 import type { LedgerEntry } from "../ledger";
 import { LedgerEvent } from "../ledger";
@@ -95,13 +95,11 @@ export class SandboxCore implements SandboxInternal {
   async getExecClient(): Promise<ExecClient> {
     if (this._paused)
       throw new SandboxError("sandbox is paused — call resume() first", this.sandboxId);
-    if (!this._execClient) {
-      this._execClient = await resolveExecClient(
-        this.deps.control,
-        this.sandboxId,
-        this.deps.useServerProxy,
-      );
-    }
+    this._execClient ??= await resolveExecClient(
+      this.deps.control,
+      this.sandboxId,
+      this.deps.useServerProxy,
+    );
     return this._execClient;
   }
 
@@ -213,10 +211,12 @@ export class SandboxCore implements SandboxInternal {
 
     const seq = ++this._seq;
 
-    if (this.replayCache.has(seq)) {
-      return new ExecHandle({ type: "replay", result: this.replayCache.get(seq)! });
+    const cachedResult = this.replayCache.get(seq);
+    if (cachedResult) {
+      return new ExecHandle({ type: "replay", result: cachedResult });
     }
 
+    // eslint-disable-next-line typescript/no-this-alias -- arrow functions can't be generators, and stream() below must be a generator, so this is the only way it can reach outer `this`
     const self = this;
     async function* stream(): AsyncGenerator<SSEEvent> {
       const execClient = await self.getExecClient();
@@ -254,11 +254,13 @@ export class SandboxCore implements SandboxInternal {
     const seq = ++this._seq;
 
     // Session had already exited before the last checkpoint — nothing live to attach to.
-    if (this.replayCache.has(seq)) {
-      return new InteractiveExecHandle({ type: "replay", result: this.replayCache.get(seq)! });
+    const cachedResult = this.replayCache.get(seq);
+    if (cachedResult) {
+      return new InteractiveExecHandle({ type: "replay", result: cachedResult });
     }
 
     const pending = this.pendingInteractive.get(seq);
+    // eslint-disable-next-line typescript/no-this-alias -- arrow functions can't be generators, and stream() below must be a generator, so this is the only way it can reach outer `this`
     const self = this;
     let closer: (() => Promise<void>) | undefined;
 
@@ -297,9 +299,12 @@ export class SandboxCore implements SandboxInternal {
           void self.emit(LedgerEvent.ExecEvent, seq, { seq, type: "stdout", text: chunk });
           push(chunk);
         },
-        (exitCode) => finish(exitCode),
+        (exitCode) => {
+          finish(exitCode);
+        },
       );
 
+      // eslint-disable-next-line typescript/require-await -- closer's declared type is () => Promise<void>; pty.close() is synchronous
       closer = async () => {
         if (closer) self.openSessionClosers.delete(closer);
         pty.close();
@@ -347,16 +352,24 @@ export class SandboxCore implements SandboxInternal {
         void execStartLogged.then(() =>
           self.emit(LedgerEvent.ExecEvent, seq, { seq, type: "stdin", text: data }),
         );
-        void ptyPromise.then((pty) => pty.write(data));
+        void ptyPromise.then((pty) => {
+          pty.write(data);
+        });
       },
       resize: (cols, rows) => {
-        void ptyPromise.then((pty) => pty.resize(cols, rows));
+        void ptyPromise.then((pty) => {
+          pty.resize(cols, rows);
+        });
       },
       signal: (name) => {
-        void ptyPromise.then((pty) => pty.signal(name));
+        void ptyPromise.then((pty) => {
+          pty.signal(name);
+        });
       },
       close: () => {
-        void ptyPromise.then((pty) => pty.close());
+        void ptyPromise.then((pty) => {
+          pty.close();
+        });
       },
     };
 
@@ -378,11 +391,9 @@ export class SandboxCore implements SandboxInternal {
    * await sb.execCode('print(x)', { context: ctx }); // prints 42
    * ```
    */
-  async createCodeContext(
-    language: import("@alineo-labs/opensandbox").CodeLanguage,
-  ): Promise<import("@alineo-labs/opensandbox").CodeContext> {
+  async createCodeContext(language: CodeLanguage): Promise<CodeContext> {
     const ec = await this.getExecClient();
-    return ec.createContext(language as string);
+    return ec.createContext(language);
   }
 
   /**
@@ -395,10 +406,12 @@ export class SandboxCore implements SandboxInternal {
   execCode(code: string, opts: ExecCodeOptions = {}): ExecHandle {
     const seq = ++this._seq;
 
-    if (this.replayCache.has(seq)) {
-      return new ExecHandle({ type: "replay", result: this.replayCache.get(seq)! });
+    const cachedResult = this.replayCache.get(seq);
+    if (cachedResult) {
+      return new ExecHandle({ type: "replay", result: cachedResult });
     }
 
+    // eslint-disable-next-line typescript/no-this-alias -- arrow functions can't be generators, and stream() below must be a generator, so this is the only way it can reach outer `this`
     const self = this;
     async function* stream(): AsyncGenerator<SSEEvent> {
       const execClient = await self.getExecClient();
@@ -442,6 +455,7 @@ export class SandboxCore implements SandboxInternal {
     const resp = await ec.createSession(opts);
     const sessionId = resp.session_id;
 
+    // eslint-disable-next-line typescript/no-this-alias -- arrow functions can't be generators, and stream() below must be a generator, so this is the only way it can reach outer `this`
     const self = this;
 
     const execInSession = (
@@ -456,7 +470,7 @@ export class SandboxCore implements SandboxInternal {
           command,
           cwd: cmdOpts?.cwd,
           timeout: cmdOpts?.timeoutMs,
-        } as RunInSessionRequest)) {
+        })) {
           await self.emit(LedgerEvent.ExecEvent, seq, { seq, ...ev });
           yield ev;
         }

--- a/packages/core/src/sandbox/files.ts
+++ b/packages/core/src/sandbox/files.ts
@@ -16,7 +16,7 @@ export async function readFile(sb: SandboxInternal, path: string): Promise<strin
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    if (value) chunks.push(value);
+    chunks.push(value);
   }
   const total = chunks.reduce((n, c) => n + c.length, 0);
   const merged = new Uint8Array(total);

--- a/packages/core/src/sandbox/hooks.ts
+++ b/packages/core/src/sandbox/hooks.ts
@@ -48,63 +48,97 @@ export function composeHooks(
 
   return {
     onSandboxCreated(sandboxId, name) {
-      active.forEach(
-        (h, i) =>
-          h.onSandboxCreated &&
-          call("onSandboxCreated", i, () => h.onSandboxCreated!(sandboxId, name)),
-      );
+      active.forEach((h, i) => {
+        // .bind(h) preserves the same `this`-bound-to-h semantics a direct
+        // `h.onSandboxCreated(...)` call would have, while still giving us a
+        // capturable reference the closure below can call after a null check.
+        const fn = h.onSandboxCreated?.bind(h);
+        if (fn) {
+          call("onSandboxCreated", i, () => {
+            fn(sandboxId, name);
+          });
+        }
+      });
     },
     onExecStart(sandboxId, seq, cmd) {
-      active.forEach(
-        (h, i) =>
-          h.onExecStart && call("onExecStart", i, () => h.onExecStart!(sandboxId, seq, cmd)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onExecStart?.bind(h);
+        if (fn) {
+          call("onExecStart", i, () => {
+            fn(sandboxId, seq, cmd);
+          });
+        }
+      });
     },
     onExecComplete(sandboxId, seq, result) {
-      active.forEach(
-        (h, i) =>
-          h.onExecComplete &&
-          call("onExecComplete", i, () => h.onExecComplete!(sandboxId, seq, result)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onExecComplete?.bind(h);
+        if (fn) {
+          call("onExecComplete", i, () => {
+            fn(sandboxId, seq, result);
+          });
+        }
+      });
     },
     onCheckpoint(sandboxId, snapshotId, name) {
-      active.forEach(
-        (h, i) =>
-          h.onCheckpoint &&
-          call("onCheckpoint", i, () => h.onCheckpoint!(sandboxId, snapshotId, name)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onCheckpoint?.bind(h);
+        if (fn) {
+          call("onCheckpoint", i, () => {
+            fn(sandboxId, snapshotId, name);
+          });
+        }
+      });
     },
     onSandboxClosed(sandboxId) {
-      active.forEach(
-        (h, i) =>
-          h.onSandboxClosed && call("onSandboxClosed", i, () => h.onSandboxClosed!(sandboxId)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onSandboxClosed?.bind(h);
+        if (fn) {
+          call("onSandboxClosed", i, () => {
+            fn(sandboxId);
+          });
+        }
+      });
     },
     onSandboxFailed(sandboxId, error) {
-      active.forEach(
-        (h, i) =>
-          h.onSandboxFailed &&
-          call("onSandboxFailed", i, () => h.onSandboxFailed!(sandboxId, error)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onSandboxFailed?.bind(h);
+        if (fn) {
+          call("onSandboxFailed", i, () => {
+            fn(sandboxId, error);
+          });
+        }
+      });
     },
     onSandboxPaused(sandboxId) {
-      active.forEach(
-        (h, i) =>
-          h.onSandboxPaused && call("onSandboxPaused", i, () => h.onSandboxPaused!(sandboxId)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onSandboxPaused?.bind(h);
+        if (fn) {
+          call("onSandboxPaused", i, () => {
+            fn(sandboxId);
+          });
+        }
+      });
     },
     onSandboxResumed(sandboxId) {
-      active.forEach(
-        (h, i) =>
-          h.onSandboxResumed && call("onSandboxResumed", i, () => h.onSandboxResumed!(sandboxId)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onSandboxResumed?.bind(h);
+        if (fn) {
+          call("onSandboxResumed", i, () => {
+            fn(sandboxId);
+          });
+        }
+      });
     },
     onCredentialInjected(sandboxId, name, binding) {
-      active.forEach(
-        (h, i) =>
-          h.onCredentialInjected &&
-          call("onCredentialInjected", i, () => h.onCredentialInjected!(sandboxId, name, binding)),
-      );
+      active.forEach((h, i) => {
+        const fn = h.onCredentialInjected?.bind(h);
+        if (fn) {
+          call("onCredentialInjected", i, () => {
+            fn(sandboxId, name, binding);
+          });
+        }
+      });
     },
   };
 }

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -1,4 +1,4 @@
-import type { ControlClient, NetworkPolicy } from "@alineo-labs/opensandbox";
+import type { ControlClient, NetworkPolicy, CodeLanguage } from "@alineo-labs/opensandbox";
 import type { IStorageAdapter } from "../ledger";
 import type { ExecResult } from "../exec-handle";
 import type { CredentialBinding, CredentialBroker } from "../credentials";
@@ -45,7 +45,7 @@ export interface PendingInteractiveExec {
 
 export interface ExecCodeOptions {
   /** Execution context (stateful interpreter session). */
-  context?: { id: string; language: import("@alineo-labs/opensandbox").CodeLanguage };
+  context?: { id: string; language: CodeLanguage };
 }
 
 /** Lifecycle hooks for observability. Pass via `SandboxDeps.hooks`. */

--- a/packages/core/test/exec-handle-interactive.test.ts
+++ b/packages/core/test/exec-handle-interactive.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { InteractiveExecHandle } from "../src/exec-handle.ts";
 import type { ExecDriver, ExecResult, PtyControls } from "../src/exec-handle.ts";
 
-function makePtyDriver(onDone: (r: ExecResult) => Promise<void> = async () => {}) {
+function makePtyDriver(
+  // eslint-disable-next-line typescript/require-await -- the default onDone must match ExecDriver's Promise-returning signature; nothing here needs to await
+  onDone: (r: ExecResult) => Promise<void> = async () => {},
+) {
   let push: (chunk: string) => void = () => {};
   let finish: (exitCode: number) => void = () => {};
   let fail: (err: unknown) => void = () => {};
@@ -19,9 +22,15 @@ function makePtyDriver(onDone: (r: ExecResult) => Promise<void> = async () => {}
 
   return {
     driver,
-    emitOutput: (chunk: string) => push(chunk),
-    emitExit: (exitCode: number) => finish(exitCode),
-    emitFail: (err: unknown) => fail(err),
+    emitOutput: (chunk: string) => {
+      push(chunk);
+    },
+    emitExit: (exitCode: number) => {
+      finish(exitCode);
+    },
+    emitFail: (err: unknown) => {
+      fail(err);
+    },
   };
 }
 
@@ -59,6 +68,7 @@ describe("InteractiveExecHandle — pty driver", () => {
         push("live output\n");
         finish(0);
       },
+      // eslint-disable-next-line typescript/require-await -- must match ExecDriver's Promise-returning onDone signature; nothing here needs to await
       onDone: async () => {},
     };
     const handle = new InteractiveExecHandle(driver);
@@ -90,10 +100,18 @@ describe("InteractiveExecHandle — pty driver", () => {
   it("write()/resize()/signal()/close() are no-ops without controls (finished/replayed session)", () => {
     const { driver } = makePtyDriver();
     const handle = new InteractiveExecHandle(driver);
-    expect(() => handle.write("x")).not.toThrow();
-    expect(() => handle.resize(1, 1)).not.toThrow();
-    expect(() => handle.signal("SIGTERM")).not.toThrow();
-    expect(() => void handle.close()).not.toThrow();
+    expect(() => {
+      handle.write("x");
+    }).not.toThrow();
+    expect(() => {
+      handle.resize(1, 1);
+    }).not.toThrow();
+    expect(() => {
+      handle.signal("SIGTERM");
+    }).not.toThrow();
+    expect(() => {
+      void handle.close();
+    }).not.toThrow();
   });
 
   it("rejects if the driver reports a setup failure", async () => {
@@ -105,9 +123,12 @@ describe("InteractiveExecHandle — pty driver", () => {
 
   it("calls onDone with the completed result", async () => {
     let captured: unknown;
-    const { driver, emitExit } = makePtyDriver(async (r) => {
-      captured = r;
-    });
+    const { driver, emitExit } = makePtyDriver(
+      // eslint-disable-next-line typescript/require-await -- onDone must match ExecDriver's Promise-returning signature; nothing here needs to await
+      async (r) => {
+        captured = r;
+      },
+    );
     const handle = new InteractiveExecHandle(driver);
     emitExit(3);
     await handle;
@@ -125,11 +146,14 @@ describe("InteractiveExecHandle — replay driver (already finished before check
     expect(result.stdout).toBe("cached\n");
   });
 
+  // eslint-disable-next-line typescript/require-await -- vitest `it` callbacks are conventionally async even when this one has nothing to await
   it("write() is a no-op — nothing left to attach to", async () => {
     const handle = new InteractiveExecHandle({
       type: "replay",
       result: { stdout: "", stderr: "", exitCode: 0 },
     });
-    expect(() => handle.write("too late")).not.toThrow();
+    expect(() => {
+      handle.write("too late");
+    }).not.toThrow();
   });
 });

--- a/packages/core/test/exec-handle.test.ts
+++ b/packages/core/test/exec-handle.test.ts
@@ -4,6 +4,7 @@ import { SSEEventType } from "@alineo-labs/opensandbox";
 import type { SSEEvent } from "@alineo-labs/opensandbox";
 
 function makeStream(events: SSEEvent[]): AsyncGenerator<SSEEvent> {
+  // eslint-disable-next-line typescript/require-await -- must be an async generator to match the return type; nothing here needs to await
   return (async function* () {
     for (const ev of events) yield ev;
   })();
@@ -85,6 +86,7 @@ describe("ExecHandle — streaming mode", () => {
     const handle = new ExecHandle({
       type: "stream",
       gen: makeStream([stdout("out"), error(42)]),
+      // eslint-disable-next-line typescript/require-await -- onDone must match ExecDriver's Promise-returning signature; nothing here needs to await
       onDone: async (r) => {
         capturedResult = r;
       },

--- a/packages/core/test/resolve-exec-client.test.ts
+++ b/packages/core/test/resolve-exec-client.test.ts
@@ -24,6 +24,7 @@ describe("resolveExecClient", () => {
       vi.fn().mockImplementation(() => {
         calls++;
         if (calls <= 2) return Promise.reject(new Error("ECONNREFUSED"));
+        // eslint-disable-next-line typescript/require-await -- must match fetch's Response.json() signature; nothing here needs to await
         return Promise.resolve({ ok: true, status: 200, json: async () => [] });
       }),
     );
@@ -55,6 +56,7 @@ describe("resolveExecClient", () => {
       vi.fn().mockImplementation(() => {
         calls++;
         if (calls < 40) return Promise.reject(new Error("ECONNREFUSED"));
+        // eslint-disable-next-line typescript/require-await -- must match fetch's Response.json() signature; nothing here needs to await
         return Promise.resolve({ ok: true, status: 200, json: async () => [] });
       }),
     );

--- a/packages/core/test/sandbox-close.test.ts
+++ b/packages/core/test/sandbox-close.test.ts
@@ -20,11 +20,28 @@ function makeAdapter(): IStorageAdapter {
   };
 }
 
+function makeControl() {
+  return { deleteSandbox: vi.fn().mockResolvedValue(undefined) };
+}
+
+function asControl(control: ReturnType<typeof makeControl>): SandboxDeps["control"] {
+  return control as unknown as SandboxDeps["control"];
+}
+
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
   return {
-    control: { deleteSandbox: vi.fn().mockResolvedValue(undefined) } as any,
+    control: asControl(makeControl()),
     adapter,
   };
+}
+
+interface SandboxTestInternals {
+  _execClient: unknown;
+}
+
+/** SandboxCore._execClient is private; this reaches it for tests that need to inject a fake. */
+function setExecClient(sb: SandboxHandle, client: unknown): void {
+  (sb as unknown as SandboxTestInternals)._execClient = client;
 }
 
 describe("SandboxHandle.close()", () => {
@@ -34,7 +51,7 @@ describe("SandboxHandle.close()", () => {
     // Simulates a client already resolved by a prior exec() call — exercised directly
     // rather than via a real exec() round-trip, matching how sibling tests in this file
     // poke at private sandbox state (e.g. sandbox-interactive.test.ts's openSessionClosers).
-    (sb as any)._execClient = fakeExecClient;
+    setExecClient(sb, fakeExecClient);
 
     await sb.close();
 
@@ -43,8 +60,8 @@ describe("SandboxHandle.close()", () => {
 
   it("does not resolve a new exec client just to dispose it when none was ever created", async () => {
     const adapter = makeAdapter();
-    const control = { deleteSandbox: vi.fn().mockResolvedValue(undefined) };
-    const sb = new SandboxHandle("sb-1", "test", { control: control as any, adapter });
+    const control = makeControl();
+    const sb = new SandboxHandle("sb-1", "test", { control: asControl(control), adapter });
 
     await expect(sb.close()).resolves.toBeUndefined();
     // No fetch/control call was ever made to resolve an exec client — deleteSandbox is
@@ -55,7 +72,7 @@ describe("SandboxHandle.close()", () => {
   it("is idempotent — a second close() does not dispose the exec client again", async () => {
     const sb = new SandboxHandle("sb-1", "test", makeDeps(makeAdapter()));
     const fakeExecClient = { disposeConnections: vi.fn() };
-    (sb as any)._execClient = fakeExecClient;
+    setExecClient(sb, fakeExecClient);
 
     await sb.close();
     await sb.close();

--- a/packages/core/test/sandbox-fork.test.ts
+++ b/packages/core/test/sandbox-fork.test.ts
@@ -3,7 +3,7 @@ import { SandboxHandle } from "../src/sandbox/index.ts";
 import { SandboxError } from "../src/errors.ts";
 import { SnapshotState } from "@alineo-labs/opensandbox";
 import type { SandboxDeps } from "../src/sandbox/index.ts";
-import type { IStorageAdapter } from "../src/ledger.ts";
+import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
 import { LedgerEvent } from "../src/ledger.ts";
 
 function makeAdapter(): IStorageAdapter {
@@ -31,12 +31,20 @@ function makeControl(snapshotId = "snap-abc") {
   };
 }
 
+function asControl(control: ReturnType<typeof makeControl>): SandboxDeps["control"] {
+  return control as unknown as SandboxDeps["control"];
+}
+
 function makeDeps(adapter: IStorageAdapter, overrides: Partial<SandboxDeps> = {}): SandboxDeps {
   return {
-    control: makeControl() as any,
+    control: asControl(makeControl()),
     adapter,
     ...overrides,
   };
+}
+
+function appendedEntries(adapter: IStorageAdapter): LedgerEntry[] {
+  return (adapter.append as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as LedgerEntry);
 }
 
 describe("SandboxHandle.fork()", () => {
@@ -47,7 +55,7 @@ describe("SandboxHandle.fork()", () => {
     const control = makeControl("snap-xyz");
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: control as any,
+      control: asControl(control),
       adapter,
       fork: forkFn,
     });
@@ -56,14 +64,12 @@ describe("SandboxHandle.fork()", () => {
 
     expect(control.createSnapshot).toHaveBeenCalledWith("sb-1");
 
-    const appendCalls = (adapter.append as ReturnType<typeof vi.fn>).mock.calls;
-    const events = appendCalls.map((c: [{ event: string }]) => c[0].event);
+    const entries = appendedEntries(adapter);
+    const events = entries.map((e) => e.event);
     expect(events).toContain(LedgerEvent.CheckpointCreated);
 
-    const cpEntry = appendCalls.find(
-      (c: [{ event: string }]) => c[0].event === LedgerEvent.CheckpointCreated,
-    );
-    expect((cpEntry![0] as any).payload.snapshotId).toBe("snap-xyz");
+    const cpEntry = entries.find((e) => e.event === LedgerEvent.CheckpointCreated);
+    expect((cpEntry?.payload as { snapshotId: string } | undefined)?.snapshotId).toBe("snap-xyz");
 
     expect(forkFn).toHaveBeenCalledWith("snap-xyz", undefined, undefined, {
       networkPolicy: undefined,
@@ -78,7 +84,7 @@ describe("SandboxHandle.fork()", () => {
     const control = makeControl("snap-tagged");
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: control as any,
+      control: asControl(control),
       adapter,
       fork: forkFn,
     });
@@ -90,11 +96,8 @@ describe("SandboxHandle.fork()", () => {
       credentialProxy: false,
     });
 
-    const appendCalls = (adapter.append as ReturnType<typeof vi.fn>).mock.calls;
-    const cpEntry = appendCalls.find(
-      (c: [{ event: string }]) => c[0].event === LedgerEvent.CheckpointCreated,
-    );
-    expect((cpEntry![0] as any).payload.name).toBe("after-install");
+    const cpEntry = appendedEntries(adapter).find((e) => e.event === LedgerEvent.CheckpointCreated);
+    expect((cpEntry?.payload as { name?: string } | undefined)?.name).toBe("after-install");
   });
 
   it("returns the SandboxHandle returned by the fork dep", async () => {
@@ -103,7 +106,7 @@ describe("SandboxHandle.fork()", () => {
     const forkFn = vi.fn().mockResolvedValue(forkedSandbox);
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: makeControl() as any,
+      control: asControl(makeControl()),
       adapter,
       fork: forkFn,
     });
@@ -127,7 +130,7 @@ describe("SandboxHandle.fork()", () => {
     const onCheckpoint = vi.fn();
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: makeControl("snap-hook") as any,
+      control: asControl(makeControl("snap-hook")),
       adapter,
       hooks: { onCheckpoint },
       fork: forkFn,

--- a/packages/core/test/sandbox-interactive.test.ts
+++ b/packages/core/test/sandbox-interactive.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { SandboxHandle } from "../src/sandbox/index.ts";
 import type { SandboxDeps, PendingInteractiveExec } from "../src/sandbox/index.ts";
-import type { IStorageAdapter } from "../src/ledger.ts";
+import { LedgerEvent } from "../src/ledger.ts";
+import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
 import type { ExecResult } from "../src/exec-handle.ts";
+import type { PtyOutputListener, PtyExitListener } from "@alineo-labs/opensandbox";
 
 function makeAdapter(): IStorageAdapter {
   return {
@@ -22,23 +24,27 @@ function makeAdapter(): IStorageAdapter {
 }
 
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
+  const control = { deleteSandbox: vi.fn().mockResolvedValue(undefined) };
   return {
-    control: { deleteSandbox: vi.fn().mockResolvedValue(undefined) } as any,
+    control: control as unknown as SandboxDeps["control"],
     adapter,
   };
 }
 
 /** A controllable fake PtyClient — connect() resolves without ending the session until emitExit() is called. */
 function makeFakePty() {
-  let onOutputCb: (chunk: string) => void = () => {};
-  let onExitCb: (exitCode: number) => void = () => {};
+  let onOutputCb: PtyOutputListener = () => {};
+  let onExitCb: PtyExitListener = () => {};
   const pty = {
     create: vi.fn().mockResolvedValue("session-1"),
-    connect: vi.fn().mockImplementation(async (_sessionId: string, onOutput: any, onExit: any) => {
-      onOutputCb = onOutput;
-      onExitCb = onExit;
-      onOutput("$ "); // simulate the shell's initial prompt — the readiness signal exec() waits for
-    }),
+    connect: vi.fn().mockImplementation(
+      // eslint-disable-next-line typescript/require-await -- must be async to match PtyClient.connect's real signature; nothing here needs to await
+      async (_sessionId: string, onOutput: PtyOutputListener, onExit: PtyExitListener) => {
+        onOutputCb = onOutput;
+        onExitCb = onExit;
+        onOutput("$ "); // simulate the shell's initial prompt — the readiness signal exec() waits for
+      },
+    ),
     write: vi.fn(),
     resize: vi.fn(),
     signal: vi.fn(),
@@ -46,13 +52,17 @@ function makeFakePty() {
   };
   return {
     pty,
-    emitOutput: (chunk: string) => onOutputCb(chunk),
-    emitExit: (exitCode: number) => onExitCb(exitCode),
+    emitOutput: (chunk: string) => {
+      onOutputCb(chunk);
+    },
+    emitExit: (exitCode: number) => {
+      onExitCb(exitCode);
+    },
   };
 }
 
-function appendedEvents(adapter: IStorageAdapter) {
-  return (adapter.append as ReturnType<typeof vi.fn>).mock.calls.map((c: [any]) => c[0]);
+function appendedEvents(adapter: IStorageAdapter): LedgerEntry[] {
+  return (adapter.append as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as LedgerEntry);
 }
 
 describe("SandboxHandle interactive exec", () => {
@@ -60,12 +70,14 @@ describe("SandboxHandle interactive exec", () => {
     const adapter = makeAdapter();
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const { pty } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     sb.exec("bash", { interactive: true });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
-    const start = appendedEvents(adapter).find((e) => e.event === "exec_start");
+    const start = appendedEvents(adapter).find((e) => e.event === LedgerEvent.ExecStart);
     expect(start?.payload).toMatchObject({ cmd: "bash", interactive: true, seq: 1 });
   });
 
@@ -73,36 +85,49 @@ describe("SandboxHandle interactive exec", () => {
     const adapter = makeAdapter();
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const { pty } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     const handle = sb.exec("bash", { interactive: true });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
     handle.write("whoami\n");
-    await vi.waitFor(() => expect(pty.write).toHaveBeenCalledWith("whoami\n"));
+    await vi.waitFor(() => {
+      expect(pty.write).toHaveBeenCalledWith("whoami\n");
+    });
 
     const stdinEvents = appendedEvents(adapter).filter(
-      (e) => e.event === "exec_event" && e.payload?.type === "stdin",
+      (e) =>
+        e.event === LedgerEvent.ExecEvent &&
+        (e.payload as { type?: string } | undefined)?.type === "stdin",
     );
-    expect(stdinEvents.map((e) => e.payload.text)).toEqual(["whoami\n"]);
+    expect(stdinEvents.map((e) => (e.payload as { text: string }).text)).toEqual(["whoami\n"]);
   });
 
   it("logs output chunks as exec_event with type stdout", async () => {
     const adapter = makeAdapter();
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const { pty, emitOutput } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     sb.exec("bash", { interactive: true });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
     emitOutput("hello\n");
     await vi.waitFor(() => {
       const stdoutEvents = appendedEvents(adapter).filter(
-        (e) => e.event === "exec_event" && e.payload?.type === "stdout",
+        (e) =>
+          e.event === LedgerEvent.ExecEvent &&
+          (e.payload as { type?: string } | undefined)?.type === "stdout",
       );
       // "$ " is the fake's simulated initial prompt (the readiness signal exec() waits for)
-      expect(stdoutEvents.map((e) => e.payload.text)).toEqual(["$ ", "hello\n"]);
+      expect(stdoutEvents.map((e) => (e.payload as { text: string }).text)).toEqual([
+        "$ ",
+        "hello\n",
+      ]);
     });
   });
 
@@ -110,15 +135,17 @@ describe("SandboxHandle interactive exec", () => {
     const adapter = makeAdapter();
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const { pty, emitExit } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     const handle = sb.exec("bash", { interactive: true, strict: false });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
     emitExit(0);
     const result = await handle;
     expect(result.exitCode).toBe(0);
-    const complete = appendedEvents(adapter).find((e) => e.event === "exec_complete");
+    const complete = appendedEvents(adapter).find((e) => e.event === LedgerEvent.ExecComplete);
     expect(complete?.payload).toMatchObject({ exitCode: 0, seq: 1 });
   });
 
@@ -126,10 +153,12 @@ describe("SandboxHandle interactive exec", () => {
     const adapter = makeAdapter();
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const { pty, emitExit } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     const handle = sb.exec("bash", { interactive: true });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
     emitExit(1);
     await expect(handle).rejects.toThrow("Command exited with code 1");
@@ -139,10 +168,12 @@ describe("SandboxHandle interactive exec", () => {
     const adapter = makeAdapter();
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const { pty, emitExit } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     const handle = sb.exec("bash", { interactive: true, strict: false });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
     emitExit(1);
     const result = await handle;
@@ -154,14 +185,16 @@ describe("SandboxHandle interactive exec", () => {
     const deps = makeDeps(adapter);
     const sb = new SandboxHandle("sb-1", "test", deps);
     const { pty } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     sb.exec("bash", { interactive: true });
-    await vi.waitFor(() => expect((sb as any).openSessionClosers.size).toBe(1));
+    await vi.waitFor(() => {
+      expect(sb.openSessionClosers.size).toBe(1);
+    });
 
     await sb.close();
     expect(pty.close).toHaveBeenCalled();
-    expect((sb as any).openSessionClosers.size).toBe(0);
+    expect(sb.openSessionClosers.size).toBe(0);
   });
 
   it("replayed (already-finished) interactive exec resolves instantly without opening a pty", async () => {
@@ -170,7 +203,7 @@ describe("SandboxHandle interactive exec", () => {
     const replayCache = new Map([[1, cached]]);
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter), replayCache);
     const resolvePty = vi.fn();
-    (sb as any).resolvePtyClient = resolvePty;
+    sb.resolvePtyClient = resolvePty;
 
     const handle = sb.exec("bash", { interactive: true });
     const result = await handle;
@@ -193,18 +226,25 @@ describe("SandboxHandle interactive exec", () => {
     ]);
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter), new Map(), pendingInteractive);
     const { pty } = makeFakePty();
-    (sb as any).resolvePtyClient = vi.fn().mockResolvedValue(pty);
+    sb.resolvePtyClient = vi.fn().mockResolvedValue(pty);
 
     const handle = sb.exec("bash", { interactive: true });
     // Resuming pays a fixed settle delay (see sandbox.ts) before replaying stdin.
-    await vi.waitFor(() => expect(pty.write).toHaveBeenCalledTimes(2), { timeout: 8000 });
-    expect(pty.write.mock.calls.map((c: [string]) => c[0])).toEqual([
+    await vi.waitFor(
+      () => {
+        expect(pty.write).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 8000 },
+    );
+    expect(pty.write.mock.calls.map((c) => c[0] as string)).toEqual([
       "export FOO=bar\n",
       "echo $FOO\n",
     ]);
 
     handle.write("echo new\n");
-    await vi.waitFor(() => expect(pty.write).toHaveBeenCalledTimes(3));
-    expect(pty.write.mock.calls[2][0]).toBe("echo new\n");
+    await vi.waitFor(() => {
+      expect(pty.write).toHaveBeenCalledTimes(3);
+    });
+    expect(pty.write.mock.calls[2]?.[0]).toBe("echo new\n");
   }, 10_000);
 });

--- a/packages/core/test/sandbox-ledger-queue.test.ts
+++ b/packages/core/test/sandbox-ledger-queue.test.ts
@@ -22,7 +22,7 @@ function makeAdapter(): IStorageAdapter {
 }
 
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
-  return { control: {} as any, adapter };
+  return { control: {} as unknown as SandboxDeps["control"], adapter };
 }
 
 describe("SandboxHandle — ledger write ordering (emit queue)", () => {
@@ -31,7 +31,7 @@ describe("SandboxHandle — ledger write ordering (emit queue)", () => {
     const appendOrder: string[] = [];
     let resolveSlow: (() => void) | undefined;
 
-    (adapter.append as ReturnType<typeof vi.fn>).mockImplementation((entry: LedgerEntry) => {
+    vi.mocked(adapter.append).mockImplementation((entry: LedgerEntry) => {
       const id = (entry.payload as { id: string }).id;
       if (id === "slow") {
         return new Promise<void>((resolve) => {
@@ -47,8 +47,8 @@ describe("SandboxHandle — ledger write ordering (emit queue)", () => {
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
 
-    const p1 = (sb as any).emit(LedgerEvent.ExecEvent, -1, { id: "slow" });
-    const p2 = (sb as any).emit(LedgerEvent.ExecEvent, -1, { id: "fast" });
+    const p1 = sb.emit(LedgerEvent.ExecEvent, -1, { id: "slow" });
+    const p2 = sb.emit(LedgerEvent.ExecEvent, -1, { id: "fast" });
 
     await new Promise((r) => setTimeout(r, 20));
     // The "fast" append must not be invoked before "slow" resolves, even though
@@ -64,31 +64,38 @@ describe("SandboxHandle — ledger write ordering (emit queue)", () => {
 
   it("keeps writing after a failed append — the failure only surfaces to that call's own caller", async () => {
     const adapter = makeAdapter();
-    (adapter.append as ReturnType<typeof vi.fn>)
+    vi.mocked(adapter.append)
       .mockRejectedValueOnce(new Error("write failed"))
       .mockResolvedValue(undefined);
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
 
-    await expect((sb as any).emit(LedgerEvent.ExecEvent, -1, {})).rejects.toThrow("write failed");
-    await expect((sb as any).emit(LedgerEvent.ExecEvent, -1, {})).resolves.toBeUndefined();
+    await expect(sb.emit(LedgerEvent.ExecEvent, -1, {})).rejects.toThrow("write failed");
+    await expect(sb.emit(LedgerEvent.ExecEvent, -1, {})).resolves.toBeUndefined();
     expect(adapter.append).toHaveBeenCalledTimes(2);
   });
 
   it("captures ts at call time, not at write time", async () => {
     const adapter = makeAdapter();
     let resolveSlow: (() => void) | undefined;
-    (adapter.append as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise<void>((resolve) => (resolveSlow = resolve)),
+    vi.mocked(adapter.append).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSlow = resolve;
+        }),
     );
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
     const before = Date.now();
-    void (sb as any).emit(LedgerEvent.ExecEvent, -1, {});
+    void sb.emit(LedgerEvent.ExecEvent, -1, {});
 
-    await vi.waitFor(() => expect(adapter.append).toHaveBeenCalledTimes(1));
-    const entryAtCallTime = (adapter.append as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as LedgerEntry;
+    await vi.waitFor(() => {
+      expect(adapter.append).toHaveBeenCalledTimes(1);
+    });
+    // TS's array indexing types this as always-defined; widen it so the guard below
+    // (real if append() is never called) is meaningful instead of dead code to the checker.
+    const entryAtCallTime = vi.mocked(adapter.append).mock.calls[0]?.[0] as LedgerEntry | undefined;
+    if (!entryAtCallTime) throw new Error("expected append() to have been called");
 
     await new Promise((r) => setTimeout(r, 50));
     resolveSlow?.();

--- a/packages/core/test/sandbox-replay.test.ts
+++ b/packages/core/test/sandbox-replay.test.ts
@@ -1,20 +1,26 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SandboxHandle } from "../src/sandbox/index.ts";
 import { SSEEventType } from "@alineo-labs/opensandbox";
 import type { SSEEvent } from "@alineo-labs/opensandbox";
 import type { SandboxDeps } from "../src/sandbox/index.ts";
-import type { IStorageAdapter } from "../src/ledger.ts";
-import { ExecResult } from "../src/exec-handle.ts";
+import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
+import { LedgerEvent } from "../src/ledger.ts";
+import type { ExecResult } from "../src/exec-handle.ts";
 
 function makeAdapter(): IStorageAdapter {
   return {
     append: vi.fn().mockResolvedValue(undefined),
     readAll: vi.fn().mockResolvedValue([]),
     lastCheckpoint: vi.fn().mockResolvedValue(null),
+    listCheckpoints: vi.fn().mockResolvedValue([]),
     listSandboxDetails: vi.fn().mockResolvedValue([]),
     listAllSandboxDetails: vi.fn().mockResolvedValue([]),
     getSandboxDetails: vi.fn().mockResolvedValue(null),
     deleteSandbox: vi.fn().mockResolvedValue(undefined),
+    getEnvironment: vi.fn().mockResolvedValue(null),
+    saveEnvironment: vi.fn().mockResolvedValue(undefined),
+    deleteEnvironment: vi.fn().mockResolvedValue(undefined),
+    listEnvironments: vi.fn().mockResolvedValue([]),
   };
 }
 
@@ -22,6 +28,7 @@ function makeExecClient(events: SSEEvent[] = []) {
   return {
     listContexts: vi.fn().mockResolvedValue([]),
     executeCommand: vi.fn().mockImplementation(() =>
+      // eslint-disable-next-line typescript/require-await -- an async generator needs no top-level await; it yields synchronously-known events
       (async function* () {
         for (const ev of events) yield ev;
       })(),
@@ -29,11 +36,24 @@ function makeExecClient(events: SSEEvent[] = []) {
   };
 }
 
+interface SandboxTestInternals {
+  _execClient: unknown;
+}
+
+/** SandboxCore._execClient is private; this reaches it for tests that need to inject a fake. */
+function setExecClient(sb: SandboxHandle, client: ReturnType<typeof makeExecClient>): void {
+  (sb as unknown as SandboxTestInternals)._execClient = client;
+}
+
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
   return {
-    control: {} as any,
+    control: {} as unknown as SandboxDeps["control"],
     adapter,
   };
+}
+
+function appendedEntries(adapter: IStorageAdapter): LedgerEntry[] {
+  return (adapter.append as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as LedgerEntry);
 }
 
 describe("SandboxHandle replay mode", () => {
@@ -44,7 +64,7 @@ describe("SandboxHandle replay mode", () => {
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter), replayCache);
 
     const execClient = makeExecClient();
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     const handle = sb.exec("npm ci");
     const result = await handle;
@@ -61,7 +81,7 @@ describe("SandboxHandle replay mode", () => {
       [2, { stdout: "build done\n", stderr: "", exitCode: 0 }],
     ]);
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter), replayCache);
-    (sb as any)._execClient = makeExecClient();
+    setExecClient(sb, makeExecClient());
 
     const r1 = await sb.exec("npm ci");
     const r2 = await sb.exec("npm run build");
@@ -83,7 +103,7 @@ describe("SandboxHandle replay mode", () => {
     const execClient = makeExecClient(liveEvents);
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter), replayCache);
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     const r1 = await sb.exec("npm ci"); // seq=1, cached
     const r2 = await sb.exec("npm test"); // seq=2, live
@@ -105,7 +125,7 @@ describe("SandboxHandle replay mode", () => {
     ]);
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter), replayCache);
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     const results = await Promise.all([
       sb.exec("cmd1"), // seq=1, cached
@@ -129,15 +149,14 @@ describe("SandboxHandle live mode", () => {
     const execClient = makeExecClient(liveEvents);
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     await sb.exec("echo hi");
 
-    const appendCalls = (adapter.append as ReturnType<typeof vi.fn>).mock.calls;
-    const events = appendCalls.map((c: [{ event: string }]) => c[0].event);
-    expect(events).toContain("exec_start");
-    expect(events).toContain("exec_event");
-    expect(events).toContain("exec_complete");
+    const events = appendedEntries(adapter).map((e) => e.event);
+    expect(events).toContain(LedgerEvent.ExecStart);
+    expect(events).toContain(LedgerEvent.ExecEvent);
+    expect(events).toContain(LedgerEvent.ExecComplete);
   });
 
   it("ledger entries use sandboxId, not runId", async () => {
@@ -148,14 +167,13 @@ describe("SandboxHandle live mode", () => {
     const execClient = makeExecClient(liveEvents);
 
     const sb = new SandboxHandle("session-abc", "test", makeDeps(adapter));
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     await sb.exec("true");
 
-    const appendCalls = (adapter.append as ReturnType<typeof vi.fn>).mock.calls;
-    for (const [entry] of appendCalls) {
+    for (const entry of appendedEntries(adapter)) {
       expect(entry.sandboxId).toBe("session-abc");
-      expect((entry as any).runId).toBeUndefined();
+      expect((entry as unknown as { runId?: unknown }).runId).toBeUndefined();
     }
   });
 
@@ -167,7 +185,7 @@ describe("SandboxHandle live mode", () => {
     const execClient = makeExecClient(liveEvents);
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     await expect(sb.exec("exit 1")).rejects.toThrow("Command exited with code 1");
   });
@@ -180,7 +198,7 @@ describe("SandboxHandle live mode", () => {
     const execClient = makeExecClient(liveEvents);
 
     const sb = new SandboxHandle("sb-1", "test", makeDeps(adapter));
-    (sb as any)._execClient = execClient;
+    setExecClient(sb, execClient);
 
     const result = await sb.exec("exit 1", { strict: false });
     expect(result.exitCode).toBe(1);

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,5 +9,5 @@
     "allowImportingTsExtensions": true,
     "types": ["bun-types"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -69,13 +69,13 @@ class HarnessImpl implements Harness {
 
   render(): string {
     return this.orderedSectionNames()
-      .map((name) => `<${name}>\n${this.sections.get(name)!.join("\n\n")}\n</${name}>`)
+      .map((name) => `<${name}>\n${(this.sections.get(name) ?? []).join("\n\n")}\n</${name}>`)
       .join("\n\n");
   }
 
   private toMarkdown(): string {
     return this.orderedSectionNames()
-      .map((name) => `## ${name}\n\n${this.sections.get(name)!.join("\n\n")}`)
+      .map((name) => `## ${name}\n\n${(this.sections.get(name) ?? []).join("\n\n")}`)
       .join("\n\n");
   }
 
@@ -96,7 +96,7 @@ class HarnessImpl implements Harness {
     // splitting on the header pattern (global) yields [preamble, name, body, name, body, ...].
     const parts = content.split(new RegExp(SECTION_HEADER.source, "gm"));
     for (let i = 1; i < parts.length; i += 2) {
-      const name = parts[i]!.trim();
+      const name = parts[i].trim();
       const body = (parts[i + 1] ?? "").trim();
       if (body) this.section(name, body);
     }

--- a/packages/model-providers/test/google.test.ts
+++ b/packages/model-providers/test/google.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type * as GoogleModule from "../src/google";
 
 let originalFetch: typeof fetch;
 let originalKey: string | undefined;
@@ -15,8 +16,8 @@ afterEach(() => {
   mock.restore();
 });
 
-async function freshModule() {
-  return import(`../src/google?t=${crypto.randomUUID()}`);
+async function freshModule(): Promise<typeof GoogleModule> {
+  return import(`../src/google?t=${crypto.randomUUID()}`) as Promise<typeof GoogleModule>;
 }
 
 describe("googleProvider", () => {

--- a/packages/model-providers/test/groq.test.ts
+++ b/packages/model-providers/test/groq.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type * as GroqModule from "../src/groq";
 
 let originalFetch: typeof fetch;
 let originalKey: string | undefined;
@@ -15,8 +16,8 @@ afterEach(() => {
   mock.restore();
 });
 
-async function freshModule() {
-  return import(`../src/groq?t=${crypto.randomUUID()}`);
+async function freshModule(): Promise<typeof GroqModule> {
+  return import(`../src/groq?t=${crypto.randomUUID()}`) as Promise<typeof GroqModule>;
 }
 
 describe("groqProvider", () => {

--- a/packages/model-providers/test/nvidia.test.ts
+++ b/packages/model-providers/test/nvidia.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type * as NvidiaModule from "../src/nvidia";
 
 let originalFetch: typeof fetch;
 let originalKey: string | undefined;
@@ -15,8 +16,8 @@ afterEach(() => {
   mock.restore();
 });
 
-async function freshModule() {
-  return import(`../src/nvidia?t=${crypto.randomUUID()}`);
+async function freshModule(): Promise<typeof NvidiaModule> {
+  return import(`../src/nvidia?t=${crypto.randomUUID()}`) as Promise<typeof NvidiaModule>;
 }
 
 describe("nvidiaProvider", () => {

--- a/packages/opensandbox/src/control.ts
+++ b/packages/opensandbox/src/control.ts
@@ -1,4 +1,4 @@
-import { SnapshotState } from "./types";
+import type { SnapshotState } from "./types";
 import type {
   Sandbox,
   CreateSandboxOptions,

--- a/packages/opensandbox/src/exec.ts
+++ b/packages/opensandbox/src/exec.ts
@@ -65,7 +65,10 @@ async function* parseSSE(
             else if (line.startsWith("data:")) data = line.slice(5).trim();
           }
           if (data !== undefined) {
-            event = { type: (type ?? SSEEventType.Message) as SSEEventType, ...JSON.parse(data) };
+            event = {
+              type: (type ?? SSEEventType.Message) as SSEEventType,
+              ...(JSON.parse(data) as Omit<SSEEvent, "type">),
+            };
           }
         }
         if (!event) continue;
@@ -224,7 +227,7 @@ export class ExecClient {
   }
 
   async getFileInfo(path: string): Promise<FileInfo> {
-    const map = await this.request<Record<string, FileInfo>>(
+    const map = await this.request<Record<string, FileInfo | undefined>>(
       "GET",
       `/files/info?path=${encodeURIComponent(path)}`,
     );

--- a/packages/opensandbox/src/pty.ts
+++ b/packages/opensandbox/src/pty.ts
@@ -59,8 +59,12 @@ export class PtyClient {
     let gotExitFrame = false;
 
     return new Promise((resolve, reject) => {
-      ws.onopen = () => resolve();
-      ws.onerror = (ev) => reject(new Error(`pty websocket error: ${String(ev)}`));
+      ws.onopen = () => {
+        resolve();
+      };
+      ws.onerror = (ev) => {
+        reject(new Error(`pty websocket error: ${ev.type}`));
+      };
       ws.onclose = () => {
         if (!gotExitFrame) onExit(-1);
       };

--- a/packages/opensandbox/test/pty.test.ts
+++ b/packages/opensandbox/test/pty.test.ts
@@ -52,7 +52,8 @@ async function connectFakeSocket(client: PtyClient, sessionId = "session-1") {
   const onOutput = vi.fn();
   const onExit = vi.fn();
   const connectPromise = client.connect(sessionId, onOutput, onExit);
-  const ws = FakeWebSocket.instances.at(-1)!;
+  const ws = FakeWebSocket.instances.at(-1);
+  if (!ws) throw new Error("expected a FakeWebSocket instance");
   ws.triggerOpen();
   await connectPromise;
   return { ws, onOutput, onExit };
@@ -83,7 +84,7 @@ describe("PtyClient", () => {
       "http://localhost:8080/pty",
       expect.objectContaining({
         method: "POST",
-        headers: expect.objectContaining({ "X-EXECD-ACCESS-TOKEN": "tok" }),
+        headers: expect.objectContaining({ "X-EXECD-ACCESS-TOKEN": "tok" }) as unknown,
         body: JSON.stringify({ cwd: "/root" }),
       }),
     );
@@ -149,9 +150,9 @@ describe("PtyClient", () => {
   it('a {"type":"connected"} frame is ignored without crashing', async () => {
     const client = new PtyClient({ baseUrl: "http://localhost:8080", accessToken: "tok" });
     const { ws, onExit, onOutput } = await connectFakeSocket(client);
-    expect(() =>
-      ws.triggerMessage(JSON.stringify({ type: "connected", session_id: "s1", mode: "pty" })),
-    ).not.toThrow();
+    expect(() => {
+      ws.triggerMessage(JSON.stringify({ type: "connected", session_id: "s1", mode: "pty" }));
+    }).not.toThrow();
     expect(onExit).not.toHaveBeenCalled();
     expect(onOutput).not.toHaveBeenCalled();
   });

--- a/packages/opensandbox/tsconfig.json
+++ b/packages/opensandbox/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
     "types": ["bun-types"]
   },
   "include": ["src", "test"]

--- a/packages/opensandbox/tsconfig.json
+++ b/packages/opensandbox/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["bun-types"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -1,14 +1,11 @@
 import {
   SandboxHandle,
   LedgerEvent,
-  SandboxStatus,
   type IStorageAdapter,
   type SandboxDetails,
   type ListSandboxOptions,
   type ExecResult,
-  type SandboxHooks,
   type EnvironmentRecord,
-  type CheckpointInfo,
   type PendingInteractiveExec,
   type CredentialBroker,
   type CredentialResolver,
@@ -203,7 +200,9 @@ export class Sandbox {
         adapter: this._adapter,
         credentialBroker: this._credentialBroker,
         hooks: opts.hooks,
-        onClose: () => this._releaseSlot(),
+        onClose: () => {
+          this._releaseSlot();
+        },
         shell: opts.shell,
         fork: (snapshotId, tag, overrideRunId, forkOpts) =>
           this._forkFromSnapshot(
@@ -398,9 +397,11 @@ export class Sandbox {
           control: this._control,
           adapter: this._adapter,
           credentialBroker: this._credentialBroker,
-          onClose: () => this._releaseSlot(),
+          onClose: () => {
+            this._releaseSlot();
+          },
           fork:
-            resources?.cpu && resources?.memory
+            resources?.cpu && resources.memory
               ? (snapshotId, tag, overrideRunId, forkOpts) =>
                   this._forkFromSnapshot(
                     snapshotId,
@@ -485,7 +486,9 @@ export class Sandbox {
       control: this._control,
       adapter: this._adapter,
       credentialBroker: this._credentialBroker,
-      onClose: () => this._releaseSlot(),
+      onClose: () => {
+        this._releaseSlot();
+      },
       fork: resources
         ? (snapshotId, tag, overrideRunId, forkOpts) =>
             this._forkFromSnapshot(
@@ -493,7 +496,7 @@ export class Sandbox {
               name,
               resources,
               undefined,
-              overrideRunId ?? opts?.runId,
+              overrideRunId ?? opts.runId,
               forkOpts,
             )
         : undefined,
@@ -563,7 +566,9 @@ export class Sandbox {
         control: this._control,
         adapter: this._adapter,
         credentialBroker: this._credentialBroker,
-        onClose: () => this._releaseSlot(),
+        onClose: () => {
+          this._releaseSlot();
+        },
         fork: (snapshotId, tag, overrideRunId, forkOpts) =>
           this._forkFromSnapshot(
             snapshotId,
@@ -771,7 +776,9 @@ export class Sandbox {
         adapter: this._adapter,
         credentialBroker: this._credentialBroker,
         hooks: extra?.hooks,
-        onClose: () => this._releaseSlot(),
+        onClose: () => {
+          this._releaseSlot();
+        },
         shell: extra?.shell ?? envShell,
         fork: (snapshotId, tag, overrideRunId, forkOpts) =>
           this._forkFromSnapshot(
@@ -836,7 +843,9 @@ export class Sandbox {
         control: this._control,
         adapter: this._adapter,
         credentialBroker: this._credentialBroker,
-        onClose: () => this._releaseSlot(),
+        onClose: () => {
+          this._releaseSlot();
+        },
         shell,
         fork: (sid, tag, overrideRunId, nextForkOpts) =>
           this._forkFromSnapshot(

--- a/packages/sdks/typescript/test/client.test.ts
+++ b/packages/sdks/typescript/test/client.test.ts
@@ -11,6 +11,7 @@ function makeAdapter(overrides: Partial<IStorageAdapter> = {}): IStorageAdapter 
     append: vi.fn().mockResolvedValue(undefined),
     readAll: vi.fn().mockResolvedValue([]),
     lastCheckpoint: vi.fn().mockResolvedValue(null),
+    listCheckpoints: vi.fn().mockResolvedValue([]),
     listSandboxDetails: vi.fn().mockResolvedValue([]),
     listAllSandboxDetails: vi.fn().mockResolvedValue([]),
     getSandboxDetails: vi.fn().mockResolvedValue(null),
@@ -29,6 +30,22 @@ function makeClient(adapter: IStorageAdapter, opts: { maxConcurrency?: number } 
     adapter,
     ...opts,
   });
+}
+
+/**
+ * Reaches Sandbox's private concurrency-semaphore internals for the tests below,
+ * instead of `as any` at every call site. `_control` is typed `unknown` because
+ * tests deliberately swap in a partial fake, not a real ControlClient.
+ */
+interface SandboxInternals {
+  _control: unknown;
+  _activeCount: number;
+  _acquireSlot(): Promise<void>;
+  _releaseSlot(): void;
+}
+
+function internals(client: Sandbox): SandboxInternals {
+  return client as unknown as SandboxInternals;
 }
 
 // ── lazy connect ───────────────────────────────────────────────────────────
@@ -65,6 +82,7 @@ describe("Sandbox.sandboxes", () => {
       {
         name: "ci",
         sandboxId: "s1",
+        runId: "s1",
         status: SandboxStatus.Completed,
         startedAt: 1000,
         execCount: 2,
@@ -99,6 +117,7 @@ describe("Sandbox.sandboxes", () => {
     const details: SandboxDetails = {
       name: "ci",
       sandboxId: "s1",
+      runId: "s1",
       status: SandboxStatus.Completed,
       startedAt: 1000,
       execCount: 1,
@@ -128,34 +147,36 @@ describe("Sandbox concurrency slot", () => {
     const adapter = makeAdapter();
     const client = makeClient(adapter, { maxConcurrency: 2 });
 
-    await (client as any)._acquireSlot();
-    expect((client as any)._activeCount).toBe(1);
+    await internals(client)._acquireSlot();
+    expect(internals(client)._activeCount).toBe(1);
 
-    await (client as any)._acquireSlot();
-    expect((client as any)._activeCount).toBe(2);
+    await internals(client)._acquireSlot();
+    expect(internals(client)._activeCount).toBe(2);
 
-    (client as any)._releaseSlot();
-    expect((client as any)._activeCount).toBe(1);
+    internals(client)._releaseSlot();
+    expect(internals(client)._activeCount).toBe(1);
   });
 
   it("third acquire blocks until a slot is released", async () => {
     const adapter = makeAdapter();
     const client = makeClient(adapter, { maxConcurrency: 2 });
 
-    await (client as any)._acquireSlot();
-    await (client as any)._acquireSlot();
+    await internals(client)._acquireSlot();
+    await internals(client)._acquireSlot();
 
     let resolved = false;
-    const pending = (client as any)._acquireSlot().then(() => {
-      resolved = true;
-    });
+    const pending = internals(client)
+      ._acquireSlot()
+      .then(() => {
+        resolved = true;
+      });
 
     // Not yet resolved — no free slot
     await Promise.resolve();
     expect(resolved).toBe(false);
 
     // Release one slot — pending acquire should resolve
-    (client as any)._releaseSlot();
+    internals(client)._releaseSlot();
     await pending;
     expect(resolved).toBe(true);
   });
@@ -165,9 +186,9 @@ describe("Sandbox concurrency slot", () => {
     const client = makeClient(adapter); // no maxConcurrency
 
     for (let i = 0; i < 10; i++) {
-      await (client as any)._acquireSlot();
+      await internals(client)._acquireSlot();
     }
-    expect((client as any)._activeCount).toBe(10);
+    expect(internals(client)._activeCount).toBe(10);
   });
 });
 
@@ -254,7 +275,7 @@ describe("Sandbox._getOrBuildEnvironment concurrency guard", () => {
       resolveBuild = r;
     });
     const buildSpy = vi.fn().mockReturnValue(buildPromise);
-    (client as any)._buildEnvironment = buildSpy;
+    client._buildEnvironment = buildSpy;
 
     const opts = {
       image: "debian:slim",
@@ -262,8 +283,8 @@ describe("Sandbox._getOrBuildEnvironment concurrency guard", () => {
       setup: async () => {},
     };
 
-    const p1 = (client as any)._getOrBuildEnvironment("py", opts);
-    const p2 = (client as any)._getOrBuildEnvironment("py", opts);
+    const p1 = client._getOrBuildEnvironment("py", opts);
+    const p2 = client._getOrBuildEnvironment("py", opts);
 
     // Both promises are the same object — build was invoked only once
     expect(buildSpy).toHaveBeenCalledTimes(1);
@@ -278,7 +299,7 @@ describe("Sandbox._getOrBuildEnvironment concurrency guard", () => {
     const client = makeClient(adapter);
 
     const buildSpy = vi.fn().mockResolvedValue("snap-1");
-    (client as any)._buildEnvironment = buildSpy;
+    client._buildEnvironment = buildSpy;
 
     const opts = {
       image: "debian:slim",
@@ -286,8 +307,8 @@ describe("Sandbox._getOrBuildEnvironment concurrency guard", () => {
       setup: async () => {},
     };
 
-    await (client as any)._getOrBuildEnvironment("py", opts);
-    await (client as any)._getOrBuildEnvironment("py", opts);
+    await client._getOrBuildEnvironment("py", opts);
+    await client._getOrBuildEnvironment("py", opts);
 
     expect(buildSpy).toHaveBeenCalledTimes(2);
   });
@@ -314,14 +335,14 @@ describe("Sandbox.restoreSnapshot() fork wiring", () => {
   it("wires a working fork() closure onto the restored SandboxHandle", async () => {
     const adapter = makeAdapter();
     const client = makeClient(adapter);
-    (client as any)._control = makeFakeControl();
+    internals(client)._control = makeFakeControl();
 
     const sb = await client.restoreSnapshot("snap-1", "my-agent", {
       cpu: "500m",
       memory: "256Mi",
     });
 
-    expect(typeof (sb as any).deps.fork).toBe("function");
+    expect(typeof sb.deps.fork).toBe("function");
   });
 });
 
@@ -329,22 +350,22 @@ describe("Sandbox.connect() fork wiring", () => {
   it("does not wire fork() when no resources are given", async () => {
     const adapter = makeAdapter();
     const client = makeClient(adapter);
-    (client as any)._control = makeFakeControl();
+    internals(client)._control = makeFakeControl();
 
     const sb = await client.connect("sandbox-1", "my-agent");
 
-    expect((sb as any).deps.fork).toBeUndefined();
+    expect(sb.deps.fork).toBeUndefined();
   });
 
   it("wires a working fork() closure when resources are given", async () => {
     const adapter = makeAdapter();
     const client = makeClient(adapter);
-    (client as any)._control = makeFakeControl();
+    internals(client)._control = makeFakeControl();
 
     const sb = await client.connect("sandbox-1", "my-agent", {
       resources: { cpu: "500m", memory: "256Mi" },
     });
 
-    expect(typeof (sb as any).deps.fork).toBe("function");
+    expect(typeof sb.deps.fork).toBe("function");
   });
 });

--- a/packages/sdks/typescript/tsconfig.json
+++ b/packages/sdks/typescript/tsconfig.json
@@ -9,5 +9,5 @@
     "declaration": true,
     "types": ["bun-types"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/sdks/typescript/tsconfig.json
+++ b/packages/sdks/typescript/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "types": ["bun-types"]
   },

--- a/packages/workflow/src/sandbox-builder.ts
+++ b/packages/workflow/src/sandbox-builder.ts
@@ -1,4 +1,4 @@
-import type { SandboxHandle, ExecOptions, ExecCodeOptions, ExecResult } from "@alineo-labs/sandbox";
+import type { SandboxHandle, ExecOptions, ExecCodeOptions } from "@alineo-labs/sandbox";
 
 /** An operation queued on a SandboxBuilder and executed later. */
 export type SandboxOp =

--- a/packages/workflow/src/workflow-builder.ts
+++ b/packages/workflow/src/workflow-builder.ts
@@ -122,7 +122,7 @@ export class WorkflowBuilder {
           combined.stdout += r.stdout;
           Object.assign(combined.vars, r.vars);
         }
-      } else if (stage.type === "sequence") {
+      } else {
         const result = await this._runSequence(stage.steps, sink);
         combined.stdout += result.stdout;
         Object.assign(combined.vars, result.vars);
@@ -173,7 +173,13 @@ export class WorkflowBuilder {
         timeout: step.timeout,
         name: step.name,
       };
-      const result = await this._runSandbox(opts, (sb) => step.run(sb, prev), sink);
+      const result = await this._runSandbox(
+        opts,
+        (sb) => {
+          step.run(sb, prev);
+        },
+        sink,
+      );
       combined.stdout += result.stdout;
       Object.assign(combined.vars, result.vars);
       prev = result;

--- a/packages/workflow/test/sandbox-builder.test.ts
+++ b/packages/workflow/test/sandbox-builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SandboxHandle } from "@alineo-labs/sandbox";
 import { SandboxBuilder, flushOps, type FlushContext } from "../src/sandbox-builder.ts";
 
 function makeCtx(overrides: Partial<FlushContext> = {}): FlushContext {
@@ -66,7 +67,7 @@ describe("SandboxBuilder — queue construction", () => {
 
   it("queues forEach op", () => {
     const sb = new SandboxBuilder();
-    sb.forEach(["a", "b"], (sb, item) => sb.exec(`echo ${item}`));
+    sb.forEach(["a", "b"], (sb, item) => sb.exec(`echo ${String(item)}`));
     expect(sb._ops[0]).toMatchObject({ kind: "forEach", items: ["a", "b"] });
   });
 });
@@ -78,7 +79,7 @@ describe("flushOps — execution", () => {
 
     const sandbox = makeSandbox();
     const ctx = makeCtx();
-    await flushOps(sandbox as any, sb._ops, ctx);
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, ctx);
 
     expect(sandbox.exec).toHaveBeenCalledWith("cmd1", {});
     expect(sandbox.exec).toHaveBeenCalledWith("cmd2", {});
@@ -89,7 +90,7 @@ describe("flushOps — execution", () => {
     sb.writeFile("/tmp/f", "hello");
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as any, sb._ops, makeCtx());
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
 
     expect(sandbox.writeFile).toHaveBeenCalledWith("/tmp/f", "hello");
   });
@@ -100,7 +101,7 @@ describe("flushOps — execution", () => {
 
     const sandbox = makeSandbox();
     const ctx = makeCtx();
-    await flushOps(sandbox as any, sb._ops, ctx);
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, ctx);
 
     expect(sandbox.readFile).toHaveBeenCalledWith("/tmp/f");
     expect(ctx.vars["content"]).toBe("file content");
@@ -111,7 +112,7 @@ describe("flushOps — execution", () => {
     sb.checkpoint("after-install");
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as any, sb._ops, makeCtx());
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
 
     expect(sandbox.checkpoint).toHaveBeenCalledWith("after-install");
   });
@@ -131,7 +132,7 @@ describe("flushOps — when primitive", () => {
     );
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as any, sb._ops, makeCtx({ exitCode: 0 }));
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx({ exitCode: 0 }));
 
     const calls = (sandbox.exec as ReturnType<typeof vi.fn>).mock.calls.map((c: string[]) => c[0]);
     expect(calls).toContain("echo pass");
@@ -151,7 +152,7 @@ describe("flushOps — when primitive", () => {
     );
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as any, sb._ops, makeCtx({ exitCode: 1 }));
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx({ exitCode: 1 }));
 
     const calls = (sandbox.exec as ReturnType<typeof vi.fn>).mock.calls.map((c: string[]) => c[0]);
     expect(calls).toContain("echo fail");
@@ -163,11 +164,11 @@ describe("flushOps — forEach primitive", () => {
   it("runs fn for each item sequentially", async () => {
     const sb = new SandboxBuilder();
     sb.forEach(["a", "b", "c"], (sb, item) => {
-      sb.exec(`echo ${item}`);
+      sb.exec(`echo ${String(item)}`);
     });
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as any, sb._ops, makeCtx());
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
 
     const calls = (sandbox.exec as ReturnType<typeof vi.fn>).mock.calls.map((c: string[]) => c[0]);
     expect(calls).toEqual(["echo a", "echo b", "echo c"]);
@@ -182,7 +183,7 @@ describe("flushOps — retry primitive", () => {
     });
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as any, sb._ops, makeCtx());
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
 
     expect(sandbox.exec).toHaveBeenCalledTimes(1);
   });
@@ -199,7 +200,7 @@ describe("flushOps — retry primitive", () => {
               throw new Error("failed");
             },
             then: (_ok: unknown, reject: (e: Error) => unknown) =>
-              Promise.resolve(reject!(new Error("failed"))),
+              Promise.resolve(reject(new Error("failed"))),
             pipe: async () => {
               throw new Error("failed");
             },
@@ -226,7 +227,7 @@ describe("flushOps — retry primitive", () => {
       { delayMs: 0 },
     );
 
-    await flushOps(sandbox as any, sb._ops, makeCtx());
+    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
     expect(attempts).toBe(3);
   });
 
@@ -238,7 +239,7 @@ describe("flushOps — retry primitive", () => {
           throw new Error("always fails");
         },
         then: (_ok: unknown, reject: (e: Error) => unknown) =>
-          Promise.resolve(reject!(new Error("always fails"))),
+          Promise.resolve(reject(new Error("always fails"))),
         pipe: async () => {
           throw new Error("always fails");
         },
@@ -254,7 +255,9 @@ describe("flushOps — retry primitive", () => {
       { delayMs: 0 },
     );
 
-    await expect(flushOps(sandbox as any, sb._ops, makeCtx())).rejects.toThrow("always fails");
+    await expect(flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx())).rejects.toThrow(
+      "always fails",
+    );
     expect(sandbox.exec).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary

Turns on Oxlint's type-aware linting (backed by `oxlint-tsgolint`) across the whole monorepo and
fixes every finding it surfaces — **681 → 0**. `bun run lint` is now clean, and the full
`typecheck`/`test`/`build` suite passes for every workspace package.

See `plans/oxlint-type-aware-linting.md` (gitignored, not part of this diff) for the full running
record of how the rule set was chosen and how the 681 findings broke down and were resolved.

## What changed

- **`.oxlintrc.json`**: enabled `options.typeAware`, added ~30 `typescript/*` rules across three
  tiers (zero-hit regression guards at `error`, real-signal rules at `warn`), plus a handful of
  narrow file-scoped overrides for rules that genuinely don't apply to a specific file (deliberately
  untyped JS glue code, fetch/mock-heavy test files hitting known bun-types/vitest typing gaps).
- **tsconfig fixes**: 7 packages had `include` gaps (missing `test/`) or a missing
  `allowImportingTsExtensions: true` that were invisible until type-aware linting exercised them.
- **Every workspace package** (`harness`, `adapters/postgres`, `agent-browser`, `model-providers`,
  `adapters/flue`, `adapters/sqlite`, `workflow`, `opensandbox`, `sdks/typescript`, `cli`, `core`,
  `agent`) plus `examples/*` — fixed package by package, smallest to biggest, no-impact fixes
  before anything touching real logic. One commit per package; see individual commit messages for
  the exact reasoning per file.

## Two real, previously-unconfirmed findings

- `packages/cli/src/tui/chat.ts` — the `AgentEvent` switch was missing 14 cases behind a bare
  `default`. Confirmed intentional (renders a documented subset); made it explicit by listing all
  14 kinds as named no-op cases instead of a silent default, so a future new event kind fails
  exhaustiveness instead of silently falling through.
- `packages/cli/src/commands/logs.ts` — turned out **not** to be a bug: TS's optimistic array
  indexing made an existing "no session found" guard look like dead code. Fixed the type, kept the
  guard.

## Deliberate (non-neutral) behavior changes, called out individually in their commits

- `packages/cli/pi-extension/alineo.ts`: an empty-but-present `stderr` string is no longer
  replaced by a generic fallback error message (`||` → `??`).
- `packages/adapters/sqlite/test/adapter.test.ts`: a `throw` inside a `finally` block's nested
  `catch` could mask a real test failure with an unrelated cleanup error — now logs instead.

Everything else is zero-behavior-change: capturing narrowed values into locals instead of
scattered non-null assertions, typed test-internals helpers instead of `as any`, and ~30 justified
suppressions (file-scoped overrides or inline `eslint-disable` comments, each with a comment
explaining why) for cases where the *rule* was wrong — JS has no arrow generators, a third-party
library's own type declarations don't reflect its real async behavior, etc. — not the code.

## Verification

- `bun run lint` — 0 findings (was 681)
- `bun run format:check` — clean, 550 files
- `bun run typecheck` — all 14 packages pass
- `bun run test` — all packages pass, 305 tests, 0 failures
- `bun run build` — all packages build

Additionally ran all 19 runnable `examples/*` against a real local `uvx opensandbox-server`
(Docker-backed): 16 pass, 3 fail for unrelated local-environment reasons (a server config flag,
an SDK/bridge race in an unrelated demo section, and a proxy bug in the local server build) — none
touched by this PR's changes, and the two examples this PR did edit (`sandbox-fork`,
`snapshot-replay`) both run correctly end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
