### PR TITLE
Add credential-scoped-agent cookbook + docs, fix persistent-agent-memory embedding model

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/gentle-llamas-slide.md
+++ b/.changeset/gentle-llamas-slide.md
@@ -1,0 +1,7 @@
+---
+---
+
+Cookbooks and docs only, no publishable package changes: add the `credential-scoped-agent`
+cookbook, publish it and `persistent-agent-memory` on the docs site, fix
+`persistent-agent-memory`'s end-of-life NVIDIA embedding model, and steady both recipes'
+output on a small model. Nothing under `packages/*` changed.

--- a/apps/docs/content/docs/cookbooks/credential-scoped-agent.mdx
+++ b/apps/docs/content/docs/cookbooks/credential-scoped-agent.mdx
@@ -1,0 +1,6 @@
+---
+title: Credential-Scoped Agent
+description: An agent that calls an authenticated API with a token it can never read — injected at the egress layer.
+---
+
+<include cwd>../../cookbooks/credential-scoped-agent/README.md</include>

--- a/apps/docs/content/docs/cookbooks/index.mdx
+++ b/apps/docs/content/docs/cookbooks/index.mdx
@@ -34,4 +34,14 @@ time, a cookbook recipe composes several of them to solve one real task.
     title="AI Agent Bugfix"
     description="An agent that debugs and fixes a failing test on its own, then gets independently verified."
   />
+  <Card
+    href="/docs/cookbooks/persistent-agent-memory"
+    title="Persistent Agent Memory"
+    description="An agent that remembers things about a customer across separate sandbox sessions, via @alineo-labs/memory."
+  />
+  <Card
+    href="/docs/cookbooks/credential-scoped-agent"
+    title="Credential-Scoped Agent"
+    description="An agent that calls an authenticated API with a token it can never read — injected at the egress layer."
+  />
 </Cards>

--- a/apps/docs/content/docs/cookbooks/meta.json
+++ b/apps/docs/content/docs/cookbooks/meta.json
@@ -5,6 +5,8 @@
     "ci-test-runner",
     "parallel-test-shards",
     "resumable-etl-pipeline",
-    "ai-agent-bugfix"
+    "ai-agent-bugfix",
+    "persistent-agent-memory",
+    "credential-scoped-agent"
   ]
 }

--- a/apps/docs/content/docs/cookbooks/persistent-agent-memory.mdx
+++ b/apps/docs/content/docs/cookbooks/persistent-agent-memory.mdx
@@ -1,0 +1,6 @@
+---
+title: Persistent Agent Memory
+description: An agent that remembers things about a customer across separate sandbox sessions, via @alineo-labs/memory.
+---
+
+<include cwd>../../cookbooks/persistent-agent-memory/README.md</include>

--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,15 @@
         "@alineo-labs/sqlite": "workspace:*",
       },
     },
+    "cookbooks/credential-scoped-agent": {
+      "name": "alineo-cookbook-credential-scoped-agent",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sandbox": "workspace:*",
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
     "cookbooks/parallel-test-shards": {
       "name": "alineo-cookbook-parallel-test-shards",
       "version": "0.0.3",
@@ -1561,6 +1570,8 @@
     "alineo-cookbook-ai-agent-bugfix": ["alineo-cookbook-ai-agent-bugfix@workspace:cookbooks/ai-agent-bugfix"],
 
     "alineo-cookbook-ci-test-runner": ["alineo-cookbook-ci-test-runner@workspace:cookbooks/ci-test-runner"],
+
+    "alineo-cookbook-credential-scoped-agent": ["alineo-cookbook-credential-scoped-agent@workspace:cookbooks/credential-scoped-agent"],
 
     "alineo-cookbook-parallel-test-shards": ["alineo-cookbook-parallel-test-shards@workspace:cookbooks/parallel-test-shards"],
 

--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -19,6 +19,7 @@ Every recipe below is also published on the [docs site](https://docs.alineo.tech
 | [`resumable-etl-pipeline`](resumable-etl-pipeline)     | A multi-stage pipeline that checkpoints after each stage and resumes without redoing completed work           |
 | [`ai-agent-bugfix`](ai-agent-bugfix)                   | An `alineo` agent that debugs and fixes a failing test on its own, then gets independently verified           |
 | [`persistent-agent-memory`](persistent-agent-memory)   | An agent that remembers things about a customer across separate sandbox sessions, via `@alineo-labs/memory`   |
+| [`credential-scoped-agent`](credential-scoped-agent)   | An agent that calls an authenticated API with a token it can never read — injected at the egress layer        |
 
 ## Setup
 

--- a/cookbooks/credential-scoped-agent/README.md
+++ b/cookbooks/credential-scoped-agent/README.md
@@ -1,0 +1,86 @@
+# credential-scoped-agent
+
+An agent that does real work against an authenticated API — GitHub, here — using a token it
+can never read. The token is registered as a **credential**, not an environment variable: it's
+injected into matching outbound requests at the egress layer, so the agent can call
+`api.github.com` as you while the value itself never enters the container's filesystem or
+environment. Revoking it takes effect immediately, mid-session, without touching the running
+sandbox.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+export NVIDIA_API_KEY=...   # the agent's model key — https://build.nvidia.com, free tier
+export GH_TOKEN=...         # a GitHub PAT (classic or fine-grained); read-only scopes are enough
+```
+
+`GH_TOKEN` is just the raw token — the agent spec (`agents/github-agent.json`) wraps it as
+`Bearer ${GH_TOKEN}` so the injected `Authorization` header is well-formed for GitHub.
+
+Credential injection rides on the same egress layer as network policy, so the server needs
+`egress.image` configured and `egress.mode = "dns+nft"` — the default for `alineo init` since
+this feature landed. On an older local config, add:
+
+```toml
+[egress]
+image = "opensandbox/egress:v1.1.7"
+mode = "dns+nft"
+```
+
+to `~/.config/alineo/server.toml` and restart the server.
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. **`Alineo.load()` reads `agents/github-agent.json`**, whose `env.GITHUB_TOKEN` is a
+   `{ credential, host, injection }` binding rather than a string. Because at least one binding
+   is present, `load()` creates the sandbox with `credentialProxy: true` and registers the
+   token with the egress sidecar's Credential Vault — it never becomes a container env var.
+   `env.NVIDIA_API_KEY`, an ordinary string, is exported the normal way.
+2. **The agent does authenticated GitHub work** — prompted to identify the token's account and
+   list its recently pushed repos, it writes and runs its own `curl … | jq …` against
+   `api.github.com`. The requests come back authenticated.
+3. **Audit** — `env | grep` inside the sandbox turns up nothing, and a bare
+   `curl https://api.github.com/user` with no `Authorization` header of its own still returns
+   `HTTP 200`: the credential reached the request at the sidecar, not through anything the
+   agent could see.
+4. **Revoke** — `agent.sandbox.credentials.remove("GITHUB_TOKEN")`, and the same bare request
+   now returns `HTTP 401`. The agent, asked to retry, reports the 401 itself.
+
+## The point
+
+`AgentSpec.env` is the obvious place to hand an agent a secret, but a plain env var is readable
+by anything running in the sandbox — including code the agent wrote itself, and including a
+prompt-injected instruction to print it. A credential binding gives the agent the _capability_
+(authenticated calls to one host) without the _secret_, and leaves you holding the leash: one
+`remove()` call cuts access at the network layer, with no redeploy and nothing to clean up
+inside the container.
+
+## Where to go next
+
+- [`examples/credential-injection`](https://github.com/DrejT/alineo/tree/main/examples/credential-injection)
+  — the same mechanism at the raw `Sandbox` level (no agent), plus `fork()` carrying a bound
+  credential to the child automatically and the `source` / `resolveCredential` contract for
+  `resume()`.
+- [Credentials](https://docs.alineo.tech/docs/core/0.2/concepts/credentials) in the docs for
+  the full `sb.credentials.*` API, `pathPrefix` scoping, and how bindings behave across
+  `resume()` / `fork()` / spawned children.
+
+## Notes
+
+The binding here uses `credential: "Bearer ${GH_TOKEN}"`, an interpolated string rather than a
+bare `${GH_TOKEN}` — so its `CredentialSource` is `{ type: "external" }`, not `{ type: "env" }`.
+That only matters for `resume()` / `fork()` (which would then need an explicit
+`resolveCredential` callback); this recipe loads the agent, uses it, and closes it, so it never
+comes up. Use a bare `${GH_TOKEN}` (and a token that already includes its scheme) if you want
+env-based auto-resolution.
+
+Header injection is currently the only supported `injection` type — `query` and `path` bindings
+are defined in the types but not yet wired to the sidecar's auth model.

--- a/cookbooks/credential-scoped-agent/README.md
+++ b/cookbooks/credential-scoped-agent/README.md
@@ -44,15 +44,16 @@ bun start
    is present, `load()` creates the sandbox with `credentialProxy: true` and registers the
    token with the egress sidecar's Credential Vault — it never becomes a container env var.
    `env.NVIDIA_API_KEY`, an ordinary string, is exported the normal way.
-2. **The agent does authenticated GitHub work** — prompted to identify the token's account and
-   list its recently pushed repos, it writes and runs its own `curl … | jq …` against
-   `api.github.com`. The requests come back authenticated.
+2. **The agent does authenticated GitHub work** — told to `curl https://api.github.com/user`
+   and report the login, it does — with no token and no `Authorization` header of its own, and
+   the call comes back authenticated as you. The recipe echoes the agent's `bash` command and
+   its output, so you see the real request and the real response.
 3. **Audit** — `env | grep` inside the sandbox turns up nothing, and a bare
    `curl https://api.github.com/user` with no `Authorization` header of its own still returns
    `HTTP 200`: the credential reached the request at the sidecar, not through anything the
    agent could see.
 4. **Revoke** — `agent.sandbox.credentials.remove("GITHUB_TOKEN")`, and the same bare request
-   now returns `HTTP 401`. The agent, asked to retry, reports the 401 itself.
+   now returns `HTTP 401`. The agent's own next call to `api.github.com` would fail the same way.
 
 ## The point
 

--- a/cookbooks/credential-scoped-agent/agents/github-agent.json
+++ b/cookbooks/credential-scoped-agent/agents/github-agent.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://registry.alineo.tech/spec/agent.json",
+  "name": "github-agent",
+  "title": "GitHub Agent",
+  "description": "A Pi agent that does real work against the GitHub API using a token it can never read — injected at the egress layer, never in its environment.",
+  "author": "alineo",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "packages": ["curl", "jq", "ca-certificates"],
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}",
+    "GITHUB_TOKEN": {
+      "credential": "Bearer ${GH_TOKEN}",
+      "host": "api.github.com",
+      "injection": { "type": "header", "name": "Authorization" }
+    }
+  },
+  "resources": { "cpu": "1000m", "memory": "2Gi" }
+}

--- a/cookbooks/credential-scoped-agent/index.ts
+++ b/cookbooks/credential-scoped-agent/index.ts
@@ -1,0 +1,111 @@
+/**
+ * Recipe: give an agent a capability, not a secret.
+ *
+ * A Pi agent is tasked with real work against the GitHub API — but the token that
+ * authorizes it is registered as a *credential*, not an env var. It gets injected into
+ * matching outbound requests at the egress layer, so the agent (which writes and runs its
+ * own shell commands) can call `api.github.com` as you, yet can never read, log, or
+ * exfiltrate the token itself. Revoking it mid-session takes effect immediately, without
+ * touching the running sandbox.
+ *
+ * Needs a running OpenSandbox server (`alineo init`) plus two things in the environment:
+ *
+ *   NVIDIA_API_KEY  the agent's own model key (NVIDIA NIM, free tier at build.nvidia.com).
+ *                   A plain env var — it's infrastructure the agent legitimately needs to
+ *                   think, not a user credential.
+ *   GH_TOKEN        a GitHub token (classic or fine-grained PAT). Read-only scopes are
+ *                   plenty for this recipe. Just the token — the agent spec adds the
+ *                   `Bearer` scheme. This value never enters the container's environment.
+ */
+import { Alineo, textOnly } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+function section(label: string) {
+  console.log(`\n── ${label} ${"─".repeat(Math.max(0, 58 - label.length))}\n`);
+}
+
+async function say(stream: AsyncIterable<string>) {
+  for await (const chunk of stream) process.stdout.write(chunk);
+  console.log();
+}
+
+if (!process.env.GH_TOKEN) {
+  console.error("Set GH_TOKEN to a GitHub token first — see this recipe's README.");
+  process.exit(1);
+}
+
+const adapter = new SQLiteAdapter("./.alineo/ledger.db");
+const spec = await Bun.file("./agents/github-agent.json").json();
+
+// `env.GITHUB_TOKEN` in the spec is a credential binding, not a string — so `Alineo.load()`
+// creates the sandbox with `credentialProxy: true` and registers the token with the egress
+// sidecar's Credential Vault instead of exporting it. `env.NVIDIA_API_KEY`, a plain string,
+// goes into the container's environment the ordinary way.
+const agent = await Alineo.load(spec, { adapter });
+
+try {
+  section("what the agent is allowed to reach");
+
+  // Binding metadata only — host + injection shape. The vault never echoes the value back,
+  // so there is nothing sensitive to print here even if we wanted to.
+  console.log("bound credentials:", await agent.sandbox.credentials.listBindings());
+
+  // ── 1. Delegate real work ───────────────────────────────────────────────────
+  section("1. the agent does authenticated GitHub work");
+
+  await say(
+    textOnly(
+      agent.prompt(
+        "Use the GitHub API at api.github.com, with curl and jq, to find out which account " +
+          "the ambient credentials belong to, then list that account's 3 most recently " +
+          "pushed repositories. Don't look for a token or an Authorization header — just " +
+          "make the requests, they're already authenticated. Keep your reply short.",
+      ),
+    ),
+  );
+
+  // ── 2. Audit what the agent could actually see ──────────────────────────────
+  section("2. the token was never in the sandbox");
+
+  // The agent just wrote and ran its own commands against an authenticated API. The token
+  // still isn't anywhere in the container it could have found it.
+  const leaked = await agent.sandbox.exec(
+    "env | grep -iE 'token|auth|github' || echo '(nothing — as expected)'",
+    { strict: false },
+  );
+  console.log("secrets in the environment:", leaked.stdout.trim());
+
+  // A bare request with no Authorization header of its own — the sidecar adds it because the
+  // host matches the binding. This is injection happening at the network layer, not anything
+  // the agent (or this script) did to the request.
+  const authed = await agent.sandbox.exec(
+    'curl -sS -o /dev/null -w "%{http_code}" https://api.github.com/user',
+    { strict: false },
+  );
+  console.log(`raw curl to api.github.com, no auth header:  HTTP ${authed.stdout.trim()}`);
+
+  // ── 3. Revoke — mid-session, without touching the sandbox ───────────────────
+  section("3. revoke, and the same request stops working");
+
+  await agent.sandbox.credentials.remove("GITHUB_TOKEN");
+  console.log("bound credentials now:", await agent.sandbox.credentials.listBindings());
+
+  const afterRevoke = await agent.sandbox.exec(
+    'curl -sS -o /dev/null -w "%{http_code}" https://api.github.com/user',
+    { strict: false },
+  );
+  console.log(`same request, after revoke:                   HTTP ${afterRevoke.stdout.trim()}`);
+
+  // And the agent notices it too, next time it tries.
+  await say(
+    textOnly(
+      agent.prompt(
+        "Try GET https://api.github.com/user again with curl and report just the HTTP " +
+          "status code you get back now.",
+      ),
+    ),
+  );
+} finally {
+  await agent.close();
+  console.log("\nAgent closed.");
+}

--- a/cookbooks/credential-scoped-agent/index.ts
+++ b/cookbooks/credential-scoped-agent/index.ts
@@ -17,15 +17,34 @@
  *                   plenty for this recipe. Just the token — the agent spec adds the
  *                   `Bearer` scheme. This value never enters the container's environment.
  */
-import { Alineo, textOnly } from "alineo";
+import { Alineo } from "alineo";
+import type { AgentStream } from "alineo";
 import { SQLiteAdapter } from "@alineo-labs/sqlite";
 
 function section(label: string) {
   console.log(`\n── ${label} ${"─".repeat(Math.max(0, 58 - label.length))}\n`);
 }
 
-async function say(stream: AsyncIterable<string>) {
-  for await (const chunk of stream) process.stdout.write(chunk);
+/**
+ * Run one agent turn, narrating the full event stream — not just `textOnly()`. The point of
+ * this recipe is watching the agent issue its *own* authenticated requests, so we echo each
+ * `bash` command it runs and the output that came back. The tool activity is the evidence
+ * that matters here, whether or not the model bothers with a prose summary afterward.
+ */
+async function runAgentTurn(stream: AgentStream) {
+  for await (const ev of stream) {
+    if (ev.type === "text") {
+      process.stdout.write(ev.text);
+    } else if (ev.type === "tool_start" && ev.toolName === "bash") {
+      const cmd = (ev.args as { command?: string }).command ?? "";
+      process.stdout.write(`\n  $ ${cmd}\n`);
+    } else if (ev.type === "tool_end") {
+      const out = (ev.result as { content?: { text?: string }[] }).content?.[0]?.text?.trim();
+      process.stdout.write(
+        out ? `${out.replace(/^/gm, "  ")}\n` : `  ${ev.isError ? "(failed)" : "(ok)"}\n`,
+      );
+    }
+  }
   console.log();
 }
 
@@ -53,14 +72,14 @@ try {
   // ── 1. Delegate real work ───────────────────────────────────────────────────
   section("1. the agent does authenticated GitHub work");
 
-  await say(
-    textOnly(
-      agent.prompt(
-        "Use the GitHub API at api.github.com, with curl and jq, to find out which account " +
-          "the ambient credentials belong to, then list that account's 3 most recently " +
-          "pushed repositories. Don't look for a token or an Authorization header — just " +
-          "make the requests, they're already authenticated. Keep your reply short.",
-      ),
+  // A directive prompt, not an open-ended one: the recipe is about the credential mechanism,
+  // not the model's planning. The agent runs the curl itself — no token, no Authorization
+  // header of its own — and it comes back authenticated as you.
+  await runAgentTurn(
+    agent.prompt(
+      "Run this command and report the value it prints. It's already authenticated — you " +
+        "don't need a token or an Authorization header:\n" +
+        "  curl -sS https://api.github.com/user | jq -r .login",
     ),
   );
 
@@ -95,16 +114,7 @@ try {
     { strict: false },
   );
   console.log(`same request, after revoke:                   HTTP ${afterRevoke.stdout.trim()}`);
-
-  // And the agent notices it too, next time it tries.
-  await say(
-    textOnly(
-      agent.prompt(
-        "Try GET https://api.github.com/user again with curl and report just the HTTP " +
-          "status code you get back now.",
-      ),
-    ),
-  );
+  console.log("\nThe agent's own next call to api.github.com would fail the same way.");
 } finally {
   await agent.close();
   console.log("\nAgent closed.");

--- a/cookbooks/credential-scoped-agent/package.json
+++ b/cookbooks/credential-scoped-agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "alineo-cookbook-credential-scoped-agent",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sandbox": "workspace:*",
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/cookbooks/persistent-agent-memory/index.ts
+++ b/cookbooks/persistent-agent-memory/index.ts
@@ -85,7 +85,15 @@ await agent.memory!.remember(agent.resourceRef, {
   sourceRef: { sandboxId: agent.sandboxId, entryIndex: entries.length - 1 },
 });
 
-for await (const chunk of textOnly(agent.prompt("What plan is this customer on?"))) {
+// Session 1 has no memory context wired into the prompt — so the agent genuinely can't know
+// this yet. The "if you don't know, say so" nudge just keeps a small model from going off to
+// grep the filesystem for an answer that isn't there. Session 2 asks with the context attached.
+for await (const chunk of textOnly(
+  agent.prompt(
+    "What plan is this customer on? If you don't have that information, say so in one sentence " +
+      "— don't go looking for it.",
+  ),
+)) {
   process.stdout.write(chunk);
 }
 console.log("\n");

--- a/cookbooks/persistent-agent-memory/index.ts
+++ b/cookbooks/persistent-agent-memory/index.ts
@@ -45,7 +45,7 @@ function nvidiaEmbeddings(): EmbeddingProvider {
         },
         body: JSON.stringify({
           input: texts,
-          model: "nvidia/nv-embedqa-e5-v5",
+          model: "nvidia/nemotron-3-embed-1b",
           input_type: opts?.type ?? "query",
         }),
       });


### PR DESCRIPTION
## What

- Adds a **`credential-scoped-agent`** cookbook — the agent-level counterpart to
  `examples/credential-injection`.
- Docs pages for it and for `persistent-agent-memory` (shipped in #220 without one).
- Fixes `persistent-agent-memory`'s end-of-life embedding model.
- Steadies both recipes' output on a small model.
- Changeset config: stop major-bumping in-range peer dependents (keeps `@alineo-labs/flue` at
  `1.0.1` instead of `2.0.0`).

## Why

- Credential injection (#204) had an `examples/` entry but no cookbook. This recipe shows the
  agent angle: a Pi agent doing real work against `api.github.com` with a token it can never
  read — an `AgentSpec.env` credential binding, injected at the egress layer, revocable
  mid-session with one `sb.credentials.remove()`.
- `cookbooks/README.md` claims every recipe is on the docs site; `persistent-agent-memory`
  wasn't. Both are now wired into `apps/docs`.
- `persistent-agent-memory` has crashed on every run since **2026-08-25**: embedding model
  `nvidia/nv-embedqa-e5-v5` reached end-of-life, NIM now returns `410 Gone`. Swapped to
  `nvidia/nemotron-3-embed-1b`.
- `@alineo-labs/flue` peer-depends on `@alineo-labs/sandbox` (`">=0.2.0"`). Changesets'
  default major-bumps any peer dependent whenever the peer moves at all, so the pending
  `@alineo-labs/sandbox` `0.2.0 → 0.3.0` was dragging flue to `2.0.0` despite `0.3.0` being in
  range and flue only carrying a patch changeset. `onlyUpdatePeerDependentsWhenOutOfRange`
  fixes that; flue is the only workspace peer dependent, so nothing else changes.

## Testing

Ran both cookbooks end-to-end against a live OpenSandbox server (`opensandbox/server:latest` +
`opensandbox/egress:v1.1.7`). Both exit 0:

- **credential-scoped-agent** — credential bound to `api.github.com` only; the agent's own
  `curl` returns authenticated data with no token in its env; a bare unauthenticated `curl`
  still gets `HTTP 200` (egress injection); after `credentials.remove()`, `HTTP 401`.
- **persistent-agent-memory** — session 2, fresh sandbox, recalls the working-memory profile
  and a `verified: true` fact; the agent's reply is grounded in that recalled memory.

`bunx changeset status --verbose` after the config change: flue `1.0.1`, "NO packages as a
major", everything else unchanged.

### A note on the model

Both specs stay on `nvidia/nemotron-3-nano-30b-a3b`. The larger NIM models
(`nemotron-3-super-120b-a12b`, `nemotron-3-ultra-550b-a55b`, `openai/gpt-oss-120b`) each
either stall Pi's stream (`PromptTimeoutError` after 180s) or return the whole answer in
`reasoning_content` with an empty text channel. `nano` is the only one that streams reliably
through the Pi bridge here (looks like a real Pi bug — out of scope). Instead, the recipes
were made robust to a small model: directive single-command prompts, and `runAgentTurn()`
streams the agent's `bash` calls + output so the authenticated request is always visible.

## Checklist

- [x] `bun run typecheck` passes
- [x] Recipes verified end-to-end against a live server
- [x] Changeset present — empty (`.changeset/gentle-llamas-slide.md`): no publishable package
      touched (cookbooks are `private`, `apps/docs` isn't published)
- [x] Docs updated — new `apps/docs/content/docs/cookbooks/*.mdx` + `meta.json` + index cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
