### PR TITLE
feat(agent): human-in-the-loop permission gate

### DIFF
--- a/.changeset/human-in-the-loop-permissions.md
+++ b/.changeset/human-in-the-loop-permissions.md
@@ -1,0 +1,26 @@
+---
+"alineo": minor
+---
+
+Add a human-in-the-loop permission gate for sandboxed agents.
+
+`AgentSpec.permissions` — a mode shorthand (`"auto"` (default), `"ask"`, `"readonly"`) or
+a full `PermissionPolicy` with ordered per-tool / per-pattern rules (last match wins;
+actions `allow` / `ask` / `deny` / `rate_limit`, plus `disabledTools`) — is enforced by a
+bundled Pi extension (`pi-permission-gate.js`, loaded via `-e` only when a policy is set).
+
+- Gated tool calls emit a `permission_request` `AgentEvent`; resolve each with
+  `agent.resolvePermission(requestId, { kind: "once" | "always" | "reject" })`. A `reject`
+  can carry `feedback` that becomes the reason the model reads. `always` / `reject`
+  auto-clear other still-pending requests for the same tool.
+- `abort()` auto-rejects any pending approvals; `steer()` leaves them open.
+- Denied calls surface to the model as a normal `isError` tool result, so it adjusts
+  rather than retrying blindly.
+- Enforcement is in-process (Pi's `tool_call` hook) — it stops a misbehaving model, not a
+  compromised sandbox. Ambient user extensions (`settings.json`, `.pi/extensions/`) still
+  load and cannot bypass the gate (Pi's first-block-wins hook semantics).
+- Default behavior is unchanged: no `permissions` (or `"auto"`) loads no gate.
+
+See `examples/human-in-the-loop` and `plans/human-in-the-loop.md`. Durable pauses across
+resume (Phase 3), the credential-proxy enforcement tier (Phase 4), and the RLM-extension
+move are tracked as follow-ups in that plan.

--- a/.changeset/human-in-the-loop-permissions.md
+++ b/.changeset/human-in-the-loop-permissions.md
@@ -1,26 +1,40 @@
 ---
 "alineo": minor
+"@alineo-labs/core": minor
 ---
 
 Add a human-in-the-loop permission gate for sandboxed agents.
 
 `AgentSpec.permissions` — a mode shorthand (`"auto"` (default), `"ask"`, `"readonly"`) or
 a full `PermissionPolicy` with ordered per-tool / per-pattern rules (last match wins;
-actions `allow` / `ask` / `deny` / `rate_limit`, plus `disabledTools`) — is enforced by a
-bundled Pi extension (`pi-permission-gate.js`, loaded via `-e` only when a policy is set).
+actions `allow` / `ask` / `deny` / `rate_limit` / `classify`, plus `disabledTools` and
+`restrictToTools`) — is enforced by a bundled Pi extension (`pi-permission-gate.js`, loaded
+via `-e` only when a policy is set).
 
 - Gated tool calls emit a `permission_request` `AgentEvent`; resolve each with
   `agent.resolvePermission(requestId, { kind: "once" | "always" | "reject" })`. A `reject`
   can carry `feedback` that becomes the reason the model reads. `always` / `reject`
   auto-clear other still-pending requests for the same tool.
+- `prompt(msg, { onPermission })` auto-resolves each request with the handler's decision —
+  no hand-wired `resolvePermission` loop.
+- `agent.listPendingPermissions()` reports tool calls currently paused; a reconnecting
+  operator (`/permission-stream`) is replayed the outstanding requests and the auto-deny
+  timeout is suspended while attached.
+- `restrictToTools` / `disabledTools` are applied via Pi's `setActiveTools` at session
+  start, so the model never sees a tool it may not use. `"readonly"` restricts the toolset
+  to the read tools and `classify`-triages any `bash` call left reachable.
+- `classify` does a conservative read-vs-write triage of a `bash` command (split on
+  `&&`/`||`/`;`/`|`, checked against a safe-reader list) — read-only → allow, else ask.
+- Every request/resolution is written to the ledger (`permission_requested` /
+  `permission_resolved`, metadata only — never raw tool args). `Alineo.resume()` closes out
+  approvals dropped when the old Pi process ended.
 - `abort()` auto-rejects any pending approvals; `steer()` leaves them open.
-- Denied calls surface to the model as a normal `isError` tool result, so it adjusts
-  rather than retrying blindly.
 - Enforcement is in-process (Pi's `tool_call` hook) — it stops a misbehaving model, not a
-  compromised sandbox. Ambient user extensions (`settings.json`, `.pi/extensions/`) still
+  process with shell access inside the sandbox actively defeating the gate (that's the
+  deferred proxy tier). Ambient user extensions (`settings.json`, `.pi/extensions/`) still
   load and cannot bypass the gate (Pi's first-block-wins hook semantics).
 - Default behavior is unchanged: no `permissions` (or `"auto"`) loads no gate.
 
-See `examples/human-in-the-loop` and `plans/human-in-the-loop.md`. Durable pauses across
-resume (Phase 3), the credential-proxy enforcement tier (Phase 4), and the RLM-extension
-move are tracked as follow-ups in that plan.
+See `examples/human-in-the-loop` and `plans/human-in-the-loop.md`. Fully durable pauses
+across `sb.pause()` / checkpoint (Phase 3c, needs an upstream Pi change) and the
+credential-proxy enforcement tier (Phase 4) are tracked as follow-ups in that plan.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -86,7 +86,7 @@
       }
     },
     {
-      "files": ["**/pi-bridge.js"],
+      "files": ["**/pi-bridge.js", "**/pi-permission-gate.js"],
       "rules": {
         "typescript/no-unsafe-assignment": "off",
         "typescript/no-unsafe-call": "off",

--- a/apps/sandbox/server/ws/chat.ts
+++ b/apps/sandbox/server/ws/chat.ts
@@ -1,4 +1,4 @@
-import type { Alineo, AgentStream, ThinkingLevel } from "alineo";
+import type { Alineo, AgentStream, PermissionDecision, ThinkingLevel } from "alineo";
 import type { Server, ServerWebSocket } from "bun";
 import * as registry from "../registry";
 import type { WSData } from "./types";
@@ -8,6 +8,7 @@ type ChatCommand =
   | { type: "steer"; text: string }
   | { type: "followUp"; text: string }
   | { type: "abort" }
+  | { type: "resolvePermission"; requestId: string; decision: PermissionDecision }
   | { type: "newSession" }
   | { type: "setSessionName"; name: string }
   | { type: "clone" }
@@ -23,7 +24,10 @@ type ChatCommand =
   | { type: "setAutoRetry"; enabled: boolean }
   | { type: "abortRetry" };
 
-type DataCommand = Exclude<ChatCommand, { type: "prompt" | "steer" | "followUp" | "abort" }>;
+type DataCommand = Exclude<
+  ChatCommand,
+  { type: "prompt" | "steer" | "followUp" | "abort" | "resolvePermission" }
+>;
 
 /**
  * Dispatch a one-shot agent command that isn't part of the prompt stream. Commands whose
@@ -145,6 +149,8 @@ export function onMessage(
     void agent.followUp(cmd.text);
   } else if (cmd.type === "abort") {
     void agent.abort();
+  } else if (cmd.type === "resolvePermission") {
+    void agent.resolvePermission(cmd.requestId, cmd.decision);
   } else {
     void runCommand(ws, agent, cmd);
   }

--- a/apps/sandbox/src/scripts/agentChat.ts
+++ b/apps/sandbox/src/scripts/agentChat.ts
@@ -74,6 +74,7 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
   let assistantRawText = "";
   let renderScheduled = false;
   const toolCalls = new Map<string, ToolCallEntry>();
+  const permissionCards = new Map<string, HTMLElement>();
 
   function send(cmd: Record<string, unknown> & { type: string }) {
     ws.send(JSON.stringify(cmd));
@@ -198,6 +199,62 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
     entry = { details, summary, argsEl, resultEl, toolName };
     toolCalls.set(toolCallId, entry);
     return entry;
+  }
+
+  function renderPermissionCard(requestId: string, tool: string, target: string, title: string) {
+    if (permissionCards.has(requestId)) return;
+    const wasNearBottom = isNearBottom(messages);
+
+    const card = document.createElement("div");
+    card.className =
+      "rounded-lg border border-[var(--color-accent)] bg-[var(--color-bg)] px-3 py-2 text-xs";
+
+    const heading = document.createElement("p");
+    heading.className = "mb-1 font-semibold text-[var(--color-fg)]";
+    heading.textContent = `Approval needed — ${tool}`;
+
+    const cmd = document.createElement("pre");
+    cmd.className =
+      "mono mt-1 mb-2 max-h-40 overflow-auto whitespace-pre-wrap break-all text-[var(--color-muted)]";
+    cmd.textContent = target || title;
+
+    const actions = document.createElement("div");
+    actions.className = "flex flex-wrap gap-1";
+
+    const resolve = (decision: Record<string, unknown>) => {
+      send({ type: "resolvePermission", requestId, decision });
+    };
+    const mkBtn = (label: string, onClick: () => void, primary = false) => {
+      const b = document.createElement("button");
+      b.type = "button";
+      b.className = primary ? "btn btn-primary" : "btn";
+      b.textContent = label;
+      b.addEventListener("click", onClick);
+      return b;
+    };
+
+    actions.append(
+      mkBtn("Allow once", () => resolve({ kind: "once" }), true),
+      mkBtn("Always allow", () => resolve({ kind: "always" })),
+      mkBtn("Deny", () => resolve({ kind: "reject" })),
+      mkBtn("Deny with feedback…", () => {
+        const feedback = window.prompt("Tell the agent what to do instead:") ?? "";
+        resolve({ kind: "reject", feedback });
+      }),
+    );
+
+    card.append(heading, cmd, actions);
+    messages.appendChild(card);
+    permissionCards.set(requestId, card);
+    scrollToBottomIfNear(wasNearBottom);
+  }
+
+  function settlePermissionCard(requestId: string, label: string) {
+    const card = permissionCards.get(requestId);
+    if (!card) return;
+    permissionCards.delete(requestId);
+    card.className = "mono pl-1 text-xs text-[var(--color-muted)] italic";
+    card.textContent = label;
   }
 
   function setQueueBadge(steering: number, followUp: number) {
@@ -417,6 +474,18 @@ export function mountAgentChat(agentId: string): { dispose(): void } {
         if (event.isDialog) {
           addBubble("system", `Alineo requested UI (${event.method}), auto-dismissed`);
         }
+        break;
+      }
+      case "permission_request": {
+        renderPermissionCard(event.requestId, event.tool, event.target, event.title);
+        break;
+      }
+      case "permission_resolved": {
+        const kind = event.decision.kind;
+        settlePermissionCard(
+          event.requestId,
+          kind === "reject" ? "Tool call denied" : "Tool call approved",
+        );
         break;
       }
       case "queue_update": {

--- a/examples/human-in-the-loop/README.md
+++ b/examples/human-in-the-loop/README.md
@@ -1,0 +1,49 @@
+# human-in-the-loop
+
+A Pi agent whose tool calls pause for operator approval, driven by `AgentSpec.permissions`
+and resolved with `agent.resolvePermission()`.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+export NVIDIA_API_KEY=...
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+`agents/hitl-agent.json` declares a permission policy:
+
+```jsonc
+"permissions": {
+  "default": "ask",                                       // pause before anything else
+  "rules": [
+    { "tool": "read",  "action": "allow" },               // reads run freely
+    { "tool": "grep",  "action": "allow" },
+    { "tool": "find",  "action": "allow" },
+    { "tool": "ls",    "action": "allow" },
+    { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" }  // hard-blocked
+  ]
+}
+```
+
+`index.ts` prompts the agent to write and run a script, then attempt an `rm -rf`. Each
+gated call arrives as a `permission_request` event; the script asks you in the terminal
+whether to allow it (once / always), deny it, or deny with feedback the model then reads.
+The `rm -rf` never even prompts — the policy denies it outright.
+
+## Notes
+
+- `permissions: "auto"` (or omitting the field) keeps the pre-approval behavior — nothing
+  pauses. `"ask"` pauses before every tool call; `"readonly"` auto-allows reads and pauses
+  on writes/exec.
+- Tier-1 enforcement runs inside the Pi process (the `tool_call` hook) — it stops a
+  misbehaving model, not a compromised sandbox. Network calls go through `bash`, so they're
+  gated by `bash` rules, best-effort.

--- a/examples/human-in-the-loop/README.md
+++ b/examples/human-in-the-loop/README.md
@@ -1,12 +1,12 @@
 # human-in-the-loop
 
-A Pi agent whose tool calls pause for operator approval, driven by `AgentSpec.permissions`
-and resolved with `agent.resolvePermission()`.
+A scripted, unattended walkthrough of `AgentSpec.permissions` — the "pause and ask before
+this tool runs" gate for sandboxed Pi agents.
 
 ## Setup
 
 ```bash
-bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time)
 export NVIDIA_API_KEY=...
 ```
 
@@ -17,33 +17,50 @@ bun install
 bun start
 ```
 
-## What it does
+## What it shows
 
-`agents/hitl-agent.json` declares a permission policy:
+**1 — `permissions: "readonly"`** (`agents/readonly-agent.json`)
+The gate removes `write` / `edit` / `bash` from the model's toolset at session start (via
+Pi's `setActiveTools`), so the agent can read a repo but _cannot_ change it — it reports
+that it has no way to create the file.
+
+**2 — the full gate** (`agents/hitl-agent.json`)
 
 ```jsonc
 "permissions": {
-  "default": "ask",                                       // pause before anything else
+  "default": "ask",
   "rules": [
-    { "tool": "read",  "action": "allow" },               // reads run freely
-    { "tool": "grep",  "action": "allow" },
-    { "tool": "find",  "action": "allow" },
-    { "tool": "ls",    "action": "allow" },
-    { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" }  // hard-blocked
+    { "tool": "read", "action": "allow" },
+    { "tool": "grep", "action": "allow" },
+    { "tool": "find", "action": "allow" },
+    { "tool": "ls",   "action": "allow" },
+    { "tool": "bash", "action": "classify" },              // read-only bash runs free
+    { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" }  // hard-blocked, no prompt
   ]
 }
 ```
 
-`index.ts` prompts the agent to write and run a script, then attempt an `rm -rf`. Each
-gated call arrives as a `permission_request` event; the script asks you in the terminal
-whether to allow it (once / always), deny it, or deny with feedback the model then reads.
-The `rm -rf` never even prompts — the policy denies it outright.
+The script prompts the agent through a fixed sequence and, via `prompt(msg, { onPermission })`:
+
+| step                                 | what the gate does                                                                |
+| ------------------------------------ | --------------------------------------------------------------------------------- |
+| `ls -la`, `cat … && uname -sr`       | `classify` → read-only → **runs, no prompt**                                      |
+| write `hello.py`, `python3 hello.py` | `ask` → handler **allows once**                                                   |
+| `pip install requests`               | `ask` → handler **denies with feedback**; the model reads the reason and moves on |
+| `rm -rf /tmp/demo-scratch`           | `deny` rule → **blocked outright**, nobody is asked                               |
+
+Then it prints `agent.listPendingPermissions()` (empty — all resolved) and reads the
+**ledger audit trail** back from the storage adapter: a `permission_requested` /
+`permission_resolved` pair for every gated call.
 
 ## Notes
 
-- `permissions: "auto"` (or omitting the field) keeps the pre-approval behavior — nothing
-  pauses. `"ask"` pauses before every tool call; `"readonly"` auto-allows reads and pauses
-  on writes/exec.
-- Tier-1 enforcement runs inside the Pi process (the `tool_call` hook) — it stops a
-  misbehaving model, not a compromised sandbox. Network calls go through `bash`, so they're
-  gated by `bash` rules, best-effort.
+- Omitting `permissions` (or `"auto"`) keeps the pre-approval behavior — nothing pauses.
+  `"ask"` pauses before every tool call.
+- `classify` is best-effort: it splits a command on `&&` / `;` / `|` and allows it only if
+  every part is a recognised pure reader (`ls`, `cat`, `grep`, `git status`, …). Anything
+  else → `ask`.
+- Enforcement runs inside the Pi process (`tool_call` hook) — it stops a misbehaving model,
+  not a process with shell access inside the sandbox actively working around it.
+- Every request/resolution is on the ledger, so `alineo logs <session>` (or any adapter
+  read) is a full record of what was gated and how it was decided.

--- a/examples/human-in-the-loop/agents/hitl-agent.json
+++ b/examples/human-in-the-loop/agents/hitl-agent.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://registry.alineo.tech/spec/agent.json",
+  "name": "hitl-agent",
+  "title": "Human-in-the-loop Agent",
+  "description": "A Pi agent whose write/exec tool calls pause for operator approval. Demonstrates AgentSpec.permissions + agent.resolvePermission().",
+  "author": "alineo",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "packages": ["git", "python3"],
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}"
+  },
+  "permissions": {
+    "default": "ask",
+    "rules": [
+      { "tool": "read", "action": "allow" },
+      { "tool": "grep", "action": "allow" },
+      { "tool": "find", "action": "allow" },
+      { "tool": "ls", "action": "allow" },
+      { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" }
+    ]
+  },
+  "resources": { "cpu": "1000m", "memory": "2Gi" }
+}

--- a/examples/human-in-the-loop/agents/hitl-agent.json
+++ b/examples/human-in-the-loop/agents/hitl-agent.json
@@ -2,7 +2,7 @@
   "$schema": "https://registry.alineo.tech/spec/agent.json",
   "name": "hitl-agent",
   "title": "Human-in-the-loop Agent",
-  "description": "A Pi agent whose write/exec tool calls pause for operator approval. Demonstrates AgentSpec.permissions + agent.resolvePermission().",
+  "description": "A Pi agent whose write/exec tool calls pause for operator approval. Demonstrates AgentSpec.permissions, the classify action, prompt({ onPermission }), listPendingPermissions(), and the ledger audit trail.",
   "author": "alineo",
   "cli": "pi",
   "provider": "nvidia",
@@ -18,6 +18,7 @@
       { "tool": "grep", "action": "allow" },
       { "tool": "find", "action": "allow" },
       { "tool": "ls", "action": "allow" },
+      { "tool": "bash", "action": "classify" },
       { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" }
     ]
   },

--- a/examples/human-in-the-loop/agents/readonly-agent.json
+++ b/examples/human-in-the-loop/agents/readonly-agent.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://registry.alineo.tech/spec/agent.json",
+  "name": "readonly-agent",
+  "title": "Read-only Agent",
+  "description": "permissions: \"readonly\" — the gate strips write/edit/bash from the model's toolset entirely (via Pi setActiveTools), so it can inspect a repo but cannot change it.",
+  "author": "alineo",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "packages": ["git"],
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}"
+  },
+  "permissions": "readonly",
+  "resources": { "cpu": "1000m", "memory": "2Gi" }
+}

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -1,59 +1,152 @@
 /**
- * Human-in-the-loop — `AgentSpec.permissions` + `agent.resolvePermission()`.
+ * Human-in-the-loop — a scripted walkthrough of `AgentSpec.permissions`.
  *
- * The spec (agents/hitl-agent.json) sets a permission policy: read-only tools run freely,
- * `rm -rf` is hard-denied, and everything else pauses for approval. Each paused call
- * surfaces as a `permission_request` event on the stream; this script plays the operator,
- * approving or rejecting from the terminal.
+ * Runs unattended (no terminal prompts). Shows, in order:
+ *   1. `permissions: "readonly"` — the gate strips write/edit/bash from the model's
+ *      toolset (via Pi `setActiveTools`), so it physically cannot change the sandbox.
+ *   2. `classify` — a `bash` rule that lets read-only commands run without asking, and
+ *      pauses anything that writes (compound commands are split on `&&`/`;`/`|` and
+ *      flagged if any part writes).
+ *   3. `prompt(msg, { onPermission })` — a handler that approves / denies each gated call.
+ *   4. deny-with-feedback + a hard `deny` rule — the model reads the reason and adjusts.
+ *   5. `agent.listPendingPermissions()` — what's paused right now.
+ *   6. the ledger audit trail — every request + resolution, from the storage adapter.
  *
- * Run:  cd examples/human-in-the-loop && bun index.ts
- * Needs: OpenSandbox running (alineo init) and NVIDIA_API_KEY in your environment.
+ * Run:  cd examples/human-in-the-loop && bun start
+ * Needs: OpenSandbox running (`bunx alineo-cli init`) and NVIDIA_API_KEY in your environment.
  */
-import { Alineo } from "alineo";
+import { Alineo, type PermissionDecision, type PermissionRequest } from "alineo";
 import { SQLiteAdapter } from "@alineo-labs/sqlite";
-import { createInterface } from "node:readline/promises";
 
 const adapter = new SQLiteAdapter("./.alineo/ledger.db");
-const spec = await Bun.file("./agents/hitl-agent.json").json();
-const agent = await Alineo.load(spec, { adapter });
-console.log(`\nSandbox: ${agent.sandboxId}\n${"─".repeat(60)}`);
+const rule = (s: string) => console.log(`\n${"─".repeat(72)}\n${s}\n${"─".repeat(72)}`);
 
-const rl = createInterface({ input: process.stdin, output: process.stdout });
+// ── 1. read-only agent: the toolset itself is restricted ───────────────────────
+rule('1 · permissions: "readonly" — write/edit/bash are not in the model\'s toolset');
 
-/** Ask the human what to do about one gated tool call. */
-async function decide(tool: string, target: string) {
-  console.log(`\n⏸  Approval needed — ${tool}\n    ${target}`);
-  const answer = (await rl.question("    [a]llow once · [A]lways · [d]eny · [f]eedback? ")).trim();
-  if (answer === "a") return { kind: "once" } as const;
-  if (answer === "A") return { kind: "always" } as const;
-  if (answer === "f") {
-    const feedback = await rl.question("    what should it do instead? ");
-    return { kind: "reject", feedback } as const;
+const ro = await Alineo.load(await Bun.file("./agents/readonly-agent.json").json(), { adapter });
+try {
+  console.log('prompt: "Create a file notes.txt containing the word hello."\n');
+  process.stdout.write("> ");
+  for await (const ev of ro.prompt(
+    "Create a file called notes.txt in the current directory containing the word hello. " +
+      "If you cannot, say so in one sentence and explain why.",
+  )) {
+    if (ev.type === "text") process.stdout.write(ev.text);
+    else if (ev.type === "tool_start") process.stdout.write(`\n[tool: ${ev.toolName}]\n`);
+    else if (ev.type === "permission_request")
+      await ro.resolvePermission(ev.requestId, { kind: "reject" });
   }
-  return { kind: "reject" } as const;
+  const { stdout } = await ro.sandbox.exec(
+    "cat notes.txt 2>/dev/null || echo '(no file — read-only held)'",
+  );
+  console.log(`\n\ncheck: ${stdout.trim()}`);
+} finally {
+  await ro.close();
+}
+
+// ── 2–6. the full gate: classify, onPermission, deny-with-feedback, audit ──────
+rule("2 · classify + onPermission — reads run free, writes pause, rm -rf is hard-denied");
+
+const agent = await Alineo.load(await Bun.file("./agents/hitl-agent.json").json(), { adapter });
+
+const toolCalls = new Map<string, { label: string; asked: boolean; blocked: boolean }>();
+
+/** The operator: approve edits, but refuse anything that installs packages. */
+async function onPermission(req: PermissionRequest): Promise<PermissionDecision> {
+  const pending = await agent.listPendingPermissions();
+  const install = /\b(pip|npm|apt|apt-get|yarn|pnpm)\b.*\binstall\b/.test(req.target);
+  console.log(
+    `\n  ⏸  approval needed — ${req.tool}: ${req.target}` +
+      `\n     listPendingPermissions() → ${pending.length}` +
+      `\n     → ${install ? "DENY with feedback" : "allow once"}`,
+  );
+  return install
+    ? {
+        kind: "reject",
+        feedback: "No package installs in this demo — use the Python standard library.",
+      }
+    : { kind: "once" };
 }
 
 try {
-  const stream = agent.prompt(
-    "Create a Python script hello.py that prints the current date, then run it. " +
-      "Then try to clean up by running: rm -rf /tmp/nonexistent-dir",
-  );
+  const prompt =
+    "Do these steps in order, one tool call at a time. If a step is blocked, note it and continue.\n" +
+    "1. Run `ls -la`.\n" +
+    "2. Run `cat /etc/os-release && uname -sr`.\n" +
+    "3. Create hello.py containing: from datetime import date; print(date.today())\n" +
+    "4. Run `python3 hello.py`.\n" +
+    "5. Run `pip install requests`.\n" +
+    "6. Run `rm -rf /tmp/demo-scratch`.";
 
-  for await (const ev of stream) {
-    if (ev.type === "text") {
-      process.stdout.write(ev.text);
-    } else if (ev.type === "tool_start") {
-      console.log(`\n  ▶ ${ev.toolName}`);
+  console.log(`${prompt}\n`);
+  process.stdout.write("> ");
+  for await (const ev of agent.prompt(prompt, { onPermission })) {
+    if (ev.type === "text") process.stdout.write(ev.text);
+    else if (ev.type === "tool_start") {
+      const t = (ev.args as { command?: string; path?: string }) ?? {};
+      const label = `${ev.toolName} ${t.command ?? t.path ?? ""}`.trim();
+      toolCalls.set(ev.toolCallId, { label, asked: false, blocked: false });
+      process.stdout.write(`\n[tool: ${label}]`);
     } else if (ev.type === "permission_request") {
-      const decision = await decide(ev.tool, ev.target);
-      await agent.resolvePermission(ev.requestId, decision);
+      for (const c of toolCalls.values())
+        if (c.label === `${ev.tool} ${ev.target}`.trim()) c.asked = true;
     } else if (ev.type === "permission_resolved") {
-      console.log(`    → ${ev.decision.kind === "reject" ? "denied" : "approved"}`);
+      process.stdout.write(`  → ${ev.decision.kind}`);
+    } else if (ev.type === "tool_end" && ev.isError) {
+      const c = toolCalls.get(ev.toolCallId);
+      if (c) c.blocked = true;
+      process.stdout.write(`\n[blocked: ${JSON.stringify(ev.result).slice(0, 140)}]`);
     }
   }
-  console.log("\n");
+
+  const calls = [...toolCalls.values()];
+  rule("3 · classify let these run with NO prompt");
+  console.log(
+    calls
+      .filter((c) => !c.asked && !c.blocked)
+      .map((c) => `  • ${c.label}`)
+      .join("\n") || "  (none)",
+  );
+
+  rule("4 · these paused for the operator");
+  console.log(
+    calls
+      .filter((c) => c.asked)
+      .map((c) => `  • ${c.label}`)
+      .join("\n") || "  (none)",
+  );
+
+  rule("4b · blocked outright by a deny rule (no prompt — nobody was asked)");
+  console.log(
+    calls
+      .filter((c) => c.blocked && !c.asked)
+      .map((c) => `  • ${c.label}`)
+      .join("\n") || "  (none)",
+  );
+
+  rule("5 · agent.listPendingPermissions() after the run");
+  console.log(`  ${JSON.stringify(await agent.listPendingPermissions())}`);
+
+  rule("6 · ledger audit trail (read back from the storage adapter)");
+  for (const e of await adapter.readAll(agent.name, agent.sandboxId)) {
+    if (e.event !== "permission_requested" && e.event !== "permission_resolved") continue;
+    const p = e.payload as {
+      requestId: string;
+      tool?: string;
+      target?: string;
+      decision?: { kind: string };
+    };
+    const tag = e.event === "permission_requested" ? "REQUESTED" : "RESOLVED ";
+    const detail = e.event === "permission_requested" ? `${p.tool}: ${p.target}` : p.decision?.kind;
+    console.log(`  ${new Date(e.ts).toISOString()}  ${tag}  ${p.requestId.slice(0, 8)}  ${detail}`);
+  }
+
+  const { stdout } = await agent.sandbox.exec(
+    "cat hello.py 2>/dev/null || echo '(hello.py not created)'",
+  );
+  console.log(`\nhello.py in the sandbox:\n${stdout.trim()}`);
 } finally {
-  rl.close();
   await agent.close();
-  console.log("Alineo closed.");
+  console.log("\nAlineo closed.");
 }

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Human-in-the-loop — `AgentSpec.permissions` + `agent.resolvePermission()`.
+ *
+ * The spec (agents/hitl-agent.json) sets a permission policy: read-only tools run freely,
+ * `rm -rf` is hard-denied, and everything else pauses for approval. Each paused call
+ * surfaces as a `permission_request` event on the stream; this script plays the operator,
+ * approving or rejecting from the terminal.
+ *
+ * Run:  cd examples/human-in-the-loop && bun index.ts
+ * Needs: OpenSandbox running (alineo init) and NVIDIA_API_KEY in your environment.
+ */
+import { Alineo } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+import { createInterface } from "node:readline/promises";
+
+const adapter = new SQLiteAdapter("./.alineo/ledger.db");
+const spec = await Bun.file("./agents/hitl-agent.json").json();
+const agent = await Alineo.load(spec, { adapter });
+console.log(`\nSandbox: ${agent.sandboxId}\n${"─".repeat(60)}`);
+
+const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+/** Ask the human what to do about one gated tool call. */
+async function decide(tool: string, target: string) {
+  console.log(`\n⏸  Approval needed — ${tool}\n    ${target}`);
+  const answer = (await rl.question("    [a]llow once · [A]lways · [d]eny · [f]eedback? ")).trim();
+  if (answer === "a") return { kind: "once" } as const;
+  if (answer === "A") return { kind: "always" } as const;
+  if (answer === "f") {
+    const feedback = await rl.question("    what should it do instead? ");
+    return { kind: "reject", feedback } as const;
+  }
+  return { kind: "reject" } as const;
+}
+
+try {
+  const stream = agent.prompt(
+    "Create a Python script hello.py that prints the current date, then run it. " +
+      "Then try to clean up by running: rm -rf /tmp/nonexistent-dir",
+  );
+
+  for await (const ev of stream) {
+    if (ev.type === "text") {
+      process.stdout.write(ev.text);
+    } else if (ev.type === "tool_start") {
+      console.log(`\n  ▶ ${ev.toolName}`);
+    } else if (ev.type === "permission_request") {
+      const decision = await decide(ev.tool, ev.target);
+      await agent.resolvePermission(ev.requestId, decision);
+    } else if (ev.type === "permission_resolved") {
+      console.log(`    → ${ev.decision.kind === "reject" ? "denied" : "approved"}`);
+    }
+  }
+  console.log("\n");
+} finally {
+  rl.close();
+  await agent.close();
+  console.log("Alineo closed.");
+}

--- a/examples/human-in-the-loop/package.json
+++ b/examples/human-in-the-loop/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-example-human-in-the-loop",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/packages/agent/src/adapters/pi-bridge.js
+++ b/packages/agent/src/adapters/pi-bridge.js
@@ -19,7 +19,12 @@ function loadEnv() {
 }
 
 // Build the pi CLI args from /etc/alineo-pi.json (model/provider config, written by the host).
-// Supports: provider, model, resume (--continue to resume the most recent session).
+// Supports: provider, model, resume (--continue to resume the most recent session),
+// permissions (loads the alineo permission-gate extension by explicit path).
+// `POLICY_ACTIVE` gates the permission-request routing below and is set here, before Pi
+// is ever spawned, so there is no window where Pi could emit a gate dialog first.
+var POLICY_ACTIVE = false;
+var PERMISSION_GATE_PATH = "/alineo-permission-gate.js";
 function buildPiArgs() {
   var args = ["--mode", "rpc", "--approve"];
   try {
@@ -28,6 +33,10 @@ function buildPiArgs() {
       if (cfg.provider) args.push("--provider", cfg.provider);
       if (cfg.model) args.push("--model", cfg.model);
       if (cfg.resume) args.push("--continue");
+      if (cfg.permissions && fs.existsSync(PERMISSION_GATE_PATH)) {
+        POLICY_ACTIVE = true;
+        args.push("-e", PERMISSION_GATE_PATH);
+      }
     }
   } catch {}
   return args;
@@ -70,7 +79,68 @@ var state = {
   queue: [], // pending items: { message, streamingBehavior?, res, text, t0 }
   gen: 0, // incremented on every (re)start; guards against stale async callbacks
   pendingCmds: {}, // id → { res, timer, bash? } — commands waiting for Pi's response ack
+  pendingPermissions: {}, // pi extension_ui_request id → { tool, target, title, timer }
+  permissionChannel: null, // { res } — long-lived SSE sink for permission_request when no prompt is active
 };
+
+// Permission-gate dialogs whose title starts with this marker are held + routed to the host
+// instead of auto-cancelled. Must match adapters/pi-permission-gate.js's MARKER.
+var PERM_MARKER = "ALINEO_PERM ";
+var PERMISSION_TIMEOUT_MS = 300000; // 5 min, matches Cline's desktop auto-deny
+
+// Push a permission event onto whichever SSE sink is live (the active prompt, else the
+// dedicated /permission-stream channel).
+function permissionSink() {
+  return state.active || state.permissionChannel;
+}
+function emitPermission(obj) {
+  var chan = permissionSink();
+  if (chan) {
+    try {
+      chan.res.write("data: " + JSON.stringify(obj) + "\n\n");
+    } catch {}
+  }
+}
+
+// Answer a held Pi extension_ui_request. `value` is a JSON string the gate parses;
+// omit it (pass null) to send { cancelled: true } instead.
+function answerPermission(id, value) {
+  if (value === null) rpc({ type: "extension_ui_response", id: id, cancelled: true });
+  else rpc({ type: "extension_ui_response", id: id, value: value });
+}
+
+// Auto-resolve every OTHER pending permission for the same tool — opencode's "one decision
+// clears the batch" for an "always" (allow) or "reject" (deny) verdict.
+function resolveMatchingPending(exceptId, tool, verdict) {
+  Object.keys(state.pendingPermissions).forEach(function (pid) {
+    if (pid === exceptId) return;
+    var p = state.pendingPermissions[pid];
+    if (p.tool !== tool) return;
+    clearTimeout(p.timer);
+    delete state.pendingPermissions[pid];
+    answerPermission(
+      pid,
+      verdict === "allow"
+        ? JSON.stringify({ verdict: "allow", scope: "once" })
+        : JSON.stringify({ verdict: "reject" }),
+    );
+    emitPermission({
+      type: "permission_resolved",
+      requestId: pid,
+      decision: verdict === "allow" ? { kind: "once" } : { kind: "reject" },
+    });
+  });
+}
+
+// Fail every held permission request (pi restart, abort, exit).
+function cancelPendingPermissions() {
+  Object.keys(state.pendingPermissions).forEach(function (pid) {
+    var p = state.pendingPermissions[pid];
+    clearTimeout(p.timer);
+    answerPermission(pid, null);
+  });
+  state.pendingPermissions = {};
+}
 
 // Fail all in-flight pendingCmds cleanly, handling bash (SSE) vs regular (JSON) responses.
 function cleanupPendingCmds(reason) {
@@ -99,6 +169,7 @@ function startPi() {
     state.active = null;
   }
   cleanupPendingCmds("pi restarted");
+  cancelPendingPermissions();
 
   if (state.rl) {
     try {
@@ -141,6 +212,7 @@ function startPi() {
     state.proc = null;
     state.ready = false;
     cleanupPendingCmds("pi exited");
+    cancelPendingPermissions();
     if (state.active) {
       stopHeartbeat(state.active.heartbeat);
       state.active.res.write("data: " + JSON.stringify({ error: "pi exited" }) + "\n\n");
@@ -285,6 +357,46 @@ function handleLine(line) {
   // We auto-cancel them immediately so Pi never stalls — even when there is no active prompt.
   // Fire-and-forget methods need no response; we just forward them.
   if (ev.type === "extension_ui_request") {
+    // alineo permission-gate dialog: title is `ALINEO_PERM {json}`. Hold it open, route it
+    // to the host as a permission_request, and wait for POST /permission-response.
+    if (
+      POLICY_ACTIVE &&
+      ev.method === "select" &&
+      ev.id &&
+      typeof ev.title === "string" &&
+      ev.title.indexOf(PERM_MARKER) === 0
+    ) {
+      var meta = {};
+      try {
+        meta = JSON.parse(ev.title.slice(PERM_MARKER.length));
+      } catch {}
+      var entry = {
+        tool: meta.tool || "unknown",
+        target: meta.target || "",
+        title: meta.title || "Approve tool call",
+      };
+      entry.timer = setTimeout(function () {
+        if (state.pendingPermissions[ev.id]) {
+          delete state.pendingPermissions[ev.id];
+          answerPermission(ev.id, null);
+          emitPermission({
+            type: "permission_resolved",
+            requestId: ev.id,
+            decision: { kind: "reject" },
+          });
+        }
+      }, PERMISSION_TIMEOUT_MS);
+      state.pendingPermissions[ev.id] = entry;
+      emitPermission({
+        type: "permission_request",
+        requestId: ev.id,
+        tool: entry.tool,
+        target: entry.target,
+        title: entry.title,
+      });
+      return;
+    }
+
     var DIALOG_METHODS = ["select", "confirm", "input", "editor"];
     var isDialog = DIALOG_METHODS.indexOf(ev.method) !== -1;
     var uiParams = {};
@@ -534,6 +646,29 @@ http
         res.end(logBuf.join("\n"));
         return;
       }
+      if (req.url === "/permission-stream") {
+        // Long-lived SSE sink so permission_request events surface even when no prompt()
+        // stream is open. One at a time — a new subscriber replaces the old.
+        if (state.permissionChannel) {
+          try {
+            state.permissionChannel.res.end();
+          } catch {}
+        }
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+        var pHeartbeat = startHeartbeat(res);
+        state.permissionChannel = { res: res };
+        req.on("close", function () {
+          stopHeartbeat(pHeartbeat);
+          if (state.permissionChannel && state.permissionChannel.res === res) {
+            state.permissionChannel = null;
+          }
+        });
+        return;
+      }
       if (req.url === "/messages") {
         rpcWithAck({ id: "gm" + Date.now(), type: "get_messages" }, res);
         return;
@@ -617,6 +752,9 @@ http
 
         case "/abort":
           // End the active SSE stream immediately, drain the queue, then wait for Pi's ack.
+          // A held permission request would leave Pi's tool_call hook awaiting forever —
+          // reject each so the abort can actually unwind.
+          cancelPendingPermissions();
           state.queue.length = 0;
           if (state.active) {
             stopHeartbeat(state.active.heartbeat);
@@ -630,6 +768,36 @@ http
         case "/steer":
           rpcWithAck({ id: "s" + Date.now(), type: "steer", message: data.message || "" }, res);
           return;
+
+        case "/permission-response": {
+          var pp = state.pendingPermissions[data.requestId];
+          if (!pp) {
+            respond(res, 404, { ok: false, error: "no such pending permission" });
+            return;
+          }
+          clearTimeout(pp.timer);
+          delete state.pendingPermissions[data.requestId];
+          var decision = data.decision || {};
+          if (decision.kind === "once") {
+            answerPermission(data.requestId, JSON.stringify({ verdict: "allow", scope: "once" }));
+          } else if (decision.kind === "always") {
+            answerPermission(data.requestId, JSON.stringify({ verdict: "allow", scope: "always" }));
+            resolveMatchingPending(data.requestId, pp.tool, "allow");
+          } else {
+            answerPermission(
+              data.requestId,
+              JSON.stringify({ verdict: "reject", feedback: decision.feedback || "" }),
+            );
+            resolveMatchingPending(data.requestId, pp.tool, "reject");
+          }
+          emitPermission({
+            type: "permission_resolved",
+            requestId: data.requestId,
+            decision: decision,
+          });
+          respond(res, 200, { ok: true });
+          return;
+        }
 
         case "/follow-up":
           rpcWithAck(

--- a/packages/agent/src/adapters/pi-bridge.js
+++ b/packages/agent/src/adapters/pi-bridge.js
@@ -4,9 +4,12 @@ var createInterface = require("readline").createInterface;
 var http = require("http");
 var fs = require("fs");
 
-var PORT = 3001;
-var ENV_FILE = "/etc/alineo-env";
-var PI_CONFIG_FILE = "/etc/alineo-pi.json";
+// Paths/port are fixed in the sandbox; the env overrides exist only so the bridge can be
+// driven against a stub `pi` in unit tests (test/pi-bridge.test.ts).
+var PORT = Number(process.env.ALINEO_BRIDGE_PORT) || 3001;
+var ENV_FILE = process.env.ALINEO_ENV_FILE || "/etc/alineo-env";
+var PI_CONFIG_FILE = process.env.ALINEO_PI_CONFIG || "/etc/alineo-pi.json";
+var PI_BIN = process.env.ALINEO_PI_BIN || "pi";
 
 // Re-read /etc/alineo-env into process.env on each Pi (re)start so setEnv() changes take effect.
 function loadEnv() {
@@ -24,7 +27,7 @@ function loadEnv() {
 // `POLICY_ACTIVE` gates the permission-request routing below and is set here, before Pi
 // is ever spawned, so there is no window where Pi could emit a gate dialog first.
 var POLICY_ACTIVE = false;
-var PERMISSION_GATE_PATH = "/alineo-permission-gate.js";
+var PERMISSION_GATE_PATH = process.env.ALINEO_PERMISSION_GATE_PATH || "/alineo-permission-gate.js";
 function buildPiArgs() {
   var args = ["--mode", "rpc", "--approve"];
   try {
@@ -88,17 +91,18 @@ var state = {
 var PERM_MARKER = "ALINEO_PERM ";
 var PERMISSION_TIMEOUT_MS = 300000; // 5 min, matches Cline's desktop auto-deny
 
-// Push a permission event onto whichever SSE sink is live (the active prompt, else the
-// dedicated /permission-stream channel).
-function permissionSink() {
-  return state.active || state.permissionChannel;
-}
+// Push a permission event to every live SSE sink: the active prompt stream (so a caller
+// iterating prompt() sees it inline) AND the dedicated /permission-stream channel (so an
+// attached operator sees it even between / across prompts). Both may be present.
 function emitPermission(obj) {
-  var chan = permissionSink();
-  if (chan) {
-    try {
-      chan.res.write("data: " + JSON.stringify(obj) + "\n\n");
-    } catch {}
+  var line = "data: " + JSON.stringify(obj) + "\n\n";
+  var sinks = [state.active, state.permissionChannel];
+  for (var i = 0; i < sinks.length; i++) {
+    if (sinks[i] && sinks[i].res) {
+      try {
+        sinks[i].res.write(line);
+      } catch {}
+    }
   }
 }
 
@@ -129,6 +133,36 @@ function resolveMatchingPending(exceptId, tool, verdict) {
       requestId: pid,
       decision: verdict === "allow" ? { kind: "once" } : { kind: "reject" },
     });
+  });
+}
+
+// Time a held permission request out: answer the gate as cancelled + tell the host.
+function expirePermission(pid) {
+  if (!state.pendingPermissions[pid]) return;
+  delete state.pendingPermissions[pid];
+  answerPermission(pid, null);
+  emitPermission({ type: "permission_resolved", requestId: pid, decision: { kind: "reject" } });
+}
+
+// While a caller is attached to /permission-stream a human is present, so the auto-deny
+// timeout is suspended; it's re-armed (fresh full window) when they disconnect.
+function suspendPermissionTimers() {
+  Object.keys(state.pendingPermissions).forEach(function (pid) {
+    var p = state.pendingPermissions[pid];
+    if (p.timer) {
+      clearTimeout(p.timer);
+      p.timer = null;
+    }
+  });
+}
+function resumePermissionTimers() {
+  Object.keys(state.pendingPermissions).forEach(function (pid) {
+    var p = state.pendingPermissions[pid];
+    if (!p.timer) {
+      p.timer = setTimeout(function () {
+        expirePermission(pid);
+      }, PERMISSION_TIMEOUT_MS);
+    }
   });
 }
 
@@ -191,7 +225,7 @@ function startPi() {
   var gen = ++state.gen;
   log("pi start gen=" + gen + ": " + args.join(" "));
 
-  var proc = spawn("pi", args, {
+  var proc = spawn(PI_BIN, args, {
     stdio: ["pipe", "pipe", "pipe"],
     env: Object.assign({}, process.env),
   });
@@ -374,18 +408,15 @@ function handleLine(line) {
         tool: meta.tool || "unknown",
         target: meta.target || "",
         title: meta.title || "Approve tool call",
+        since: Date.now(),
+        timer: null,
       };
-      entry.timer = setTimeout(function () {
-        if (state.pendingPermissions[ev.id]) {
-          delete state.pendingPermissions[ev.id];
-          answerPermission(ev.id, null);
-          emitPermission({
-            type: "permission_resolved",
-            requestId: ev.id,
-            decision: { kind: "reject" },
-          });
-        }
-      }, PERMISSION_TIMEOUT_MS);
+      // No auto-deny clock while a human is watching the permission stream.
+      if (!state.permissionChannel) {
+        entry.timer = setTimeout(function () {
+          expirePermission(ev.id);
+        }, PERMISSION_TIMEOUT_MS);
+      }
       state.pendingPermissions[ev.id] = entry;
       emitPermission({
         type: "permission_request",
@@ -661,12 +692,46 @@ http
         });
         var pHeartbeat = startHeartbeat(res);
         state.permissionChannel = { res: res };
+        // A reconnecting operator needs to see what's still outstanding, and the auto-deny
+        // clock pauses while they're attached.
+        suspendPermissionTimers();
+        Object.keys(state.pendingPermissions).forEach(function (pid) {
+          var p = state.pendingPermissions[pid];
+          try {
+            res.write(
+              "data: " +
+                JSON.stringify({
+                  type: "permission_request",
+                  requestId: pid,
+                  tool: p.tool,
+                  target: p.target,
+                  title: p.title,
+                }) +
+                "\n\n",
+            );
+          } catch {}
+        });
         req.on("close", function () {
           stopHeartbeat(pHeartbeat);
           if (state.permissionChannel && state.permissionChannel.res === res) {
             state.permissionChannel = null;
+            resumePermissionTimers();
           }
         });
+        return;
+      }
+      if (req.url === "/pending-permissions") {
+        var pending = Object.keys(state.pendingPermissions).map(function (pid) {
+          var p = state.pendingPermissions[pid];
+          return {
+            requestId: pid,
+            tool: p.tool,
+            target: p.target,
+            title: p.title,
+            since: p.since || 0,
+          };
+        });
+        respond(res, 200, { ok: true, data: { pending: pending } });
         return;
       }
       if (req.url === "/messages") {

--- a/packages/agent/src/adapters/pi-permission-gate.js
+++ b/packages/agent/src/adapters/pi-permission-gate.js
@@ -1,0 +1,177 @@
+/**
+ * alineo permission gate — a Pi extension loaded via `-e /alineo-permission-gate.js` when
+ * `AgentSpec.permissions` is set to anything other than "auto".
+ *
+ * It reads the normalized policy from /etc/alineo-pi.json (written by
+ * `packages/agent/src/adapters/pi.ts`'s `configure()`), and on every `tool_call` decides
+ * allow / deny / rate-limit / ask. An "ask" call blocks on `ctx.ui.select()` with a
+ * marker-prefixed title that `pi-bridge.js` recognizes, holds open, and forwards to the
+ * host as a `permission_request` — resolved by a matching POST to `/permission-response`.
+ *
+ * The matcher here mirrors `packages/agent/src/permissions.ts` (kept in sync by hand — a
+ * jiti-loaded extension can't import from the published `alineo` package it sits beside;
+ * same tradeoff pi-bridge.js already makes). `test/permissions.test.ts` covers the TS copy.
+ */
+import { readFileSync } from "node:fs";
+
+const CONFIG_FILE = "/etc/alineo-pi.json";
+/** Title prefix pi-bridge.js keys on to route a select() dialog to the host instead of auto-cancelling. */
+const MARKER = "ALINEO_PERM ";
+
+/** @returns {{default: string, rules: Array, disabledTools: string[]} | null} */
+function loadPolicy() {
+  try {
+    const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
+    const p = cfg && cfg.permissions;
+    if (!p || typeof p !== "object") return null;
+    return {
+      default: p.default || "ask",
+      rules: Array.isArray(p.rules) ? p.rules : [],
+      disabledTools: Array.isArray(p.disabledTools) ? p.disabledTools : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Tool-specific target string, pulled from Pi's typed `event.input`. */
+function targetOf(toolName, input) {
+  if (!input || typeof input !== "object") return "";
+  switch (toolName) {
+    case "bash":
+    case "powershell":
+      return String(input.command ?? "");
+    case "read":
+    case "write":
+    case "edit":
+    case "ls":
+      return String(input.path ?? "");
+    case "grep":
+      return String(input.pattern ?? input.query ?? "");
+    case "find":
+      return String(input.pattern ?? input.name ?? "");
+    default:
+      try {
+        return JSON.stringify(input);
+      } catch {
+        return "";
+      }
+  }
+}
+
+function globToRegExp(glob) {
+  const body = String(glob)
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${body}$`, "s");
+}
+
+function ruleMatches(rule, toolName, target) {
+  if (!globToRegExp(rule.tool).test(toolName)) return false;
+  if (
+    rule.pattern !== undefined &&
+    rule.pattern !== null &&
+    !globToRegExp(rule.pattern).test(target)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function evaluate(policy, toolName, target) {
+  if (policy.disabledTools.indexOf(toolName) !== -1) return { action: "deny" };
+  let match;
+  for (const rule of policy.rules) {
+    if (ruleMatches(rule, toolName, target)) match = rule;
+  }
+  return match ? { action: match.action, rule: match } : { action: policy.default };
+}
+
+/** Rolling-window rate limiter, keyed per rule. */
+const rateHits = new Map();
+function underLimit(rule, key) {
+  if (!rule || !rule.limit) return true;
+  const now = Date.now();
+  const windowStart = now - rule.limit.windowMs;
+  const hits = (rateHits.get(key) || []).filter((t) => t >= windowStart);
+  if (hits.length >= rule.limit.count) {
+    rateHits.set(key, hits);
+    return false;
+  }
+  hits.push(now);
+  rateHits.set(key, hits);
+  return true;
+}
+
+export default function (pi) {
+  const policy = loadPolicy();
+  if (!policy) return; // shouldn't happen — the extension is only loaded when a policy exists
+
+  /** Session-scoped "always allow" memory, keyed tool + target. */
+  const alwaysAllow = new Set();
+
+  pi.on("tool_call", async (event, ctx) => {
+    const toolName = event.toolName;
+    const target = targetOf(toolName, event.input);
+    const key = `${toolName} ${target}`;
+
+    if (alwaysAllow.has(key)) return undefined;
+
+    const { action, rule } = evaluate(policy, toolName, target);
+
+    if (action === "allow") return undefined;
+    if (action === "deny") {
+      return {
+        block: true,
+        reason: `The operator's policy denies this tool call: ${toolName} ${target}`.trim(),
+      };
+    }
+    if (action === "rate_limit") {
+      return underLimit(rule, key)
+        ? undefined
+        : {
+            block: true,
+            reason: `Rate limit reached for ${toolName}. Wait before trying this again, or take a different approach.`,
+          };
+    }
+
+    // action === "ask"
+    if (!ctx.hasUI) {
+      return {
+        block: true,
+        reason: "This tool call needs operator approval, but no UI is attached.",
+      };
+    }
+
+    const title =
+      MARKER + JSON.stringify({ tool: toolName, target, title: `Run ${toolName}: ${target}` });
+    let raw;
+    try {
+      raw = await ctx.ui.select(title, ["decide"]);
+    } catch {
+      raw = undefined;
+    }
+    if (raw === undefined || raw === null) {
+      return { block: true, reason: "Approval request was cancelled or timed out." };
+    }
+
+    let decision;
+    try {
+      decision = JSON.parse(raw);
+    } catch {
+      decision = { verdict: "reject" };
+    }
+
+    if (decision.verdict === "allow") {
+      if (decision.scope === "always") alwaysAllow.add(key);
+      return undefined;
+    }
+    return {
+      block: true,
+      reason: decision.feedback
+        ? `The operator declined this and said: ${decision.feedback}`
+        : "The operator declined this tool call.",
+    };
+  });
+}

--- a/packages/agent/src/adapters/pi-permission-gate.js
+++ b/packages/agent/src/adapters/pi-permission-gate.js
@@ -3,22 +3,103 @@
  * `AgentSpec.permissions` is set to anything other than "auto".
  *
  * It reads the normalized policy from /etc/alineo-pi.json (written by
- * `packages/agent/src/adapters/pi.ts`'s `configure()`), and on every `tool_call` decides
- * allow / deny / rate-limit / ask. An "ask" call blocks on `ctx.ui.select()` with a
- * marker-prefixed title that `pi-bridge.js` recognizes, holds open, and forwards to the
- * host as a `permission_request` — resolved by a matching POST to `/permission-response`.
+ * `packages/agent/src/adapters/pi.ts`'s `configure()`), and:
+ *   - on `session_start`, applies `restrictToTools` / `disabledTools` via Pi's
+ *     `setActiveTools` so the model never sees a tool it may not use;
+ *   - on every `tool_call`, decides allow / deny / rate-limit / classify / ask. An "ask"
+ *     call blocks on `ctx.ui.select()` with a marker-prefixed title that `pi-bridge.js`
+ *     recognizes, holds open, and forwards to the host as a `permission_request` — resolved
+ *     by a matching POST to `/permission-response`.
  *
  * The matcher here mirrors `packages/agent/src/permissions.ts` (kept in sync by hand — a
  * jiti-loaded extension can't import from the published `alineo` package it sits beside;
- * same tradeoff pi-bridge.js already makes). `test/permissions.test.ts` covers the TS copy.
+ * same tradeoff pi-bridge.js already makes). `test/permissions.test.ts` covers the TS copy;
+ * `test/pi-permission-gate.test.ts` covers this one.
  */
 import { readFileSync } from "node:fs";
 
-const CONFIG_FILE = "/etc/alineo-pi.json";
+const CONFIG_FILE = process.env.ALINEO_PI_CONFIG || "/etc/alineo-pi.json";
 /** Title prefix pi-bridge.js keys on to route a select() dialog to the host instead of auto-cancelling. */
 const MARKER = "ALINEO_PERM ";
 
-/** @returns {{default: string, rules: Array, disabledTools: string[]} | null} */
+/** Mirror of `permissions.ts` SAFE_BASH_COMMANDS. */
+const SAFE_BASH_COMMANDS = new Set([
+  "ls",
+  "cat",
+  "head",
+  "tail",
+  "grep",
+  "rg",
+  "egrep",
+  "fgrep",
+  "zgrep",
+  "find",
+  "pwd",
+  "whoami",
+  "id",
+  "env",
+  "printenv",
+  "echo",
+  "printf",
+  "which",
+  "type",
+  "file",
+  "stat",
+  "wc",
+  "date",
+  "uname",
+  "hostname",
+  "df",
+  "du",
+  "tree",
+  "basename",
+  "dirname",
+  "realpath",
+  "readlink",
+  "true",
+  "false",
+  "cmp",
+  "diff",
+  "column",
+  "nl",
+  "less",
+  "more",
+  "tac",
+  "hexdump",
+  "xxd",
+  "od",
+  "strings",
+  "sha1sum",
+  "sha256sum",
+  "md5sum",
+  "cksum",
+]);
+const SAFE_GIT_SUBCOMMANDS = new Set([
+  "status",
+  "log",
+  "diff",
+  "show",
+  "branch",
+  "remote",
+  "rev-parse",
+  "describe",
+  "blame",
+  "tag",
+  "config",
+  "ls-files",
+  "ls-tree",
+  "shortlog",
+  "reflog",
+  "cat-file",
+  "for-each-ref",
+  "whatchanged",
+  "rev-list",
+  "name-rev",
+  "symbolic-ref",
+  "count-objects",
+]);
+
+/** @returns {{default: string, rules: Array, disabledTools: string[], restrictToTools: string[]} | null} */
 function loadPolicy() {
   try {
     const cfg = JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
@@ -28,10 +109,42 @@ function loadPolicy() {
       default: p.default || "ask",
       rules: Array.isArray(p.rules) ? p.rules : [],
       disabledTools: Array.isArray(p.disabledTools) ? p.disabledTools : [],
+      restrictToTools: Array.isArray(p.restrictToTools) ? p.restrictToTools : [],
     };
   } catch {
     return null;
   }
+}
+
+/** Mirror of `permissions.ts` isReadOnlyBashCommand. */
+function isReadOnlyBashCommand(command) {
+  const segments = String(command)
+    .split(/&&|\|\||[;\n|]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (segments.length === 0) return false;
+  return segments.every((seg) => {
+    if (/(?<![0-9&])>>?/.test(seg.replace(/\d*>&\d*/g, ""))) return false;
+    let tokens = seg.split(/\s+/).filter(Boolean);
+    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]))
+      tokens = tokens.slice(1);
+    while (
+      tokens.length > 1 &&
+      (tokens[0] === "env" ||
+        tokens[0] === "command" ||
+        tokens[0] === "nice" ||
+        tokens[0] === "stdbuf" ||
+        tokens[0] === "time")
+    ) {
+      tokens = tokens.slice(1);
+    }
+    if (tokens[0] === "timeout" && tokens.length > 2) tokens = tokens.slice(2);
+    const cmd = (tokens[0] || "").replace(/^.*\//, "");
+    if (!cmd) return false;
+    if (SAFE_BASH_COMMANDS.has(cmd)) return true;
+    if (cmd === "git" && SAFE_GIT_SUBCOMMANDS.has(tokens[1] || "")) return true;
+    return false;
+  });
 }
 
 /** Tool-specific target string, pulled from Pi's typed `event.input`. */
@@ -85,7 +198,11 @@ function evaluate(policy, toolName, target) {
   for (const rule of policy.rules) {
     if (ruleMatches(rule, toolName, target)) match = rule;
   }
-  return match ? { action: match.action, rule: match } : { action: policy.default };
+  let action = match ? match.action : policy.default;
+  if (action === "classify") {
+    action = toolName === "bash" && isReadOnlyBashCommand(target) ? "allow" : "ask";
+  }
+  return { action, rule: match };
 }
 
 /** Rolling-window rate limiter, keyed per rule. */
@@ -104,9 +221,41 @@ function underLimit(rule, key) {
   return true;
 }
 
+/**
+ * Apply `restrictToTools` (allowlist) then `disabledTools` (denylist) to the model's
+ * visible toolset. Best-effort: `setActiveTools` may not exist on older Pi — the
+ * `tool_call` deny backstop still covers `disabledTools` in that case.
+ */
+function applyToolset(pi, policy) {
+  if (typeof pi.setActiveTools !== "function" || typeof pi.getActiveTools !== "function") {
+    return;
+  }
+  let active = pi.getActiveTools();
+  if (!Array.isArray(active)) return;
+  if (policy.restrictToTools.length > 0) {
+    active = active.filter((t) => policy.restrictToTools.indexOf(t) !== -1);
+  }
+  if (policy.disabledTools.length > 0) {
+    active = active.filter((t) => policy.disabledTools.indexOf(t) === -1);
+  }
+  try {
+    pi.setActiveTools(active);
+  } catch {}
+}
+
 export default function (pi) {
   const policy = loadPolicy();
   if (!policy) return; // shouldn't happen — the extension is only loaded when a policy exists
+
+  if (policy.restrictToTools.length > 0 || policy.disabledTools.length > 0) {
+    if (typeof pi.on === "function") {
+      pi.on("session_start", () => {
+        applyToolset(pi, policy);
+      });
+    }
+    // Also try immediately, in case session_start already fired before this ran.
+    applyToolset(pi, policy);
+  }
 
   /** Session-scoped "always allow" memory, keyed tool + target. */
   const alwaysAllow = new Set();

--- a/packages/agent/src/adapters/pi-permission-gate.js
+++ b/packages/agent/src/adapters/pi-permission-gate.js
@@ -116,6 +116,21 @@ function loadPolicy() {
   }
 }
 
+const WRAPPER_COMMANDS = new Set(["env", "command", "nice", "stdbuf", "time"]);
+
+// Linear scan for a file output redirection — no regex (ReDoS-safe). A `>` next to `&`
+// (`2>&1`, `>&2`), preceded by a digit (`2>`), or preceded by `&` is an fd op, not a write.
+function hasOutputRedirect(seg) {
+  for (let i = 0; i < seg.length; i++) {
+    if (seg[i] !== ">") continue;
+    const next = seg[i + 1];
+    const prev = seg[i - 1];
+    if (next === "&" || prev === "&" || (prev >= "0" && prev <= "9")) continue;
+    return true;
+  }
+  return false;
+}
+
 /** Mirror of `permissions.ts` isReadOnlyBashCommand. */
 function isReadOnlyBashCommand(command) {
   const segments = String(command)
@@ -124,22 +139,16 @@ function isReadOnlyBashCommand(command) {
     .filter(Boolean);
   if (segments.length === 0) return false;
   return segments.every((seg) => {
-    if (/(?<![0-9&])>>?/.test(seg.replace(/\d*>&\d*/g, ""))) return false;
+    if (hasOutputRedirect(seg)) return false;
     let tokens = seg.split(/\s+/).filter(Boolean);
-    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]))
-      tokens = tokens.slice(1);
-    while (
-      tokens.length > 1 &&
-      (tokens[0] === "env" ||
-        tokens[0] === "command" ||
-        tokens[0] === "nice" ||
-        tokens[0] === "stdbuf" ||
-        tokens[0] === "time")
-    ) {
+    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) {
       tokens = tokens.slice(1);
     }
+    while (tokens.length > 1 && WRAPPER_COMMANDS.has(tokens[0])) tokens = tokens.slice(1);
     if (tokens[0] === "timeout" && tokens.length > 2) tokens = tokens.slice(2);
-    const cmd = (tokens[0] || "").replace(/^.*\//, "");
+    const first = tokens[0] || "";
+    const slash = first.lastIndexOf("/");
+    const cmd = slash === -1 ? first : first.slice(slash + 1);
     if (!cmd) return false;
     if (SAFE_BASH_COMMANDS.has(cmd)) return true;
     if (cmd === "git" && SAFE_GIT_SUBCOMMANDS.has(tokens[1] || "")) return true;

--- a/packages/agent/src/adapters/pi-permission-gate.js
+++ b/packages/agent/src/adapters/pi-permission-gate.js
@@ -256,14 +256,16 @@ export default function (pi) {
   const policy = loadPolicy();
   if (!policy) return; // shouldn't happen — the extension is only loaded when a policy exists
 
+  // Action methods (setActiveTools) can't be called during extension load — only from a
+  // lifecycle hook once the runtime is up. Re-applying is idempotent (getActiveTools()
+  // returns the already-filtered set), so run it on session start and before every turn
+  // in case Pi re-registers tools.
   if (policy.restrictToTools.length > 0 || policy.disabledTools.length > 0) {
-    if (typeof pi.on === "function") {
-      pi.on("session_start", () => {
-        applyToolset(pi, policy);
-      });
-    }
-    // Also try immediately, in case session_start already fired before this ran.
-    applyToolset(pi, policy);
+    const apply = () => {
+      applyToolset(pi, policy);
+    };
+    pi.on("session_start", apply);
+    pi.on("before_agent_start", apply);
   }
 
   /** Session-scoped "always allow" memory, keyed tool + target. */

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -4,7 +4,7 @@ import type { SandboxHandle, CredentialBinding, CredentialSource } from "@alineo
 import { PromptTimeoutError } from "../errors";
 import { normalizePermissions } from "../permissions";
 import type { AgentSpec, CredentialEnvBinding } from "../schema";
-import type { PermissionDecision } from "../types";
+import type { PendingPermission, PermissionDecision } from "../types";
 import type {
   AgentEvent,
   AgentStream,
@@ -273,6 +273,15 @@ export class PiAdapter {
   /** Resolve a pending `permission_request` (see `AgentEvent`'s `permission_request`). */
   async resolvePermission(requestId: string, decision: PermissionDecision): Promise<void> {
     await rpcPost(this.bridgeUrl, "/permission-response", { requestId, decision });
+  }
+
+  /** Tool calls currently paused awaiting a human decision. */
+  async listPendingPermissions(): Promise<PendingPermission[]> {
+    const r = await rpcGet<{ pending: PendingPermission[] }>(
+      this.bridgeUrl,
+      "/pending-permissions",
+    );
+    return r.pending;
   }
 
   async followUp(message: string): Promise<void> {

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -2,7 +2,9 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { SandboxHandle, CredentialBinding, CredentialSource } from "@alineo-labs/core";
 import { PromptTimeoutError } from "../errors";
+import { normalizePermissions } from "../permissions";
 import type { AgentSpec, CredentialEnvBinding } from "../schema";
+import type { PermissionDecision } from "../types";
 import type {
   AgentEvent,
   AgentStream,
@@ -27,6 +29,14 @@ import type {
 // rolldown, the bundler tsdown uses for this package's actual publish build.
 const BRIDGE_SCRIPT = readFileSync(
   fileURLToPath(new URL("./pi-bridge.js", import.meta.url)),
+  "utf8",
+);
+
+// The permission-gate Pi extension — same copy-alongside-dist mechanism as BRIDGE_SCRIPT
+// (see tsdown.config.ts). Written into the sandbox at /alineo-permission-gate.js and loaded
+// by Pi via `-e` only when the spec sets `permissions` (see pi-bridge.js's buildPiArgs).
+const PERMISSION_GATE_SCRIPT = readFileSync(
+  fileURLToPath(new URL("./pi-permission-gate.js", import.meta.url)),
   "utf8",
 );
 
@@ -180,9 +190,12 @@ export class PiAdapter {
     if (spec.provider) piConfig.provider = spec.provider;
     if (spec.model) piConfig.model = spec.model;
     if (opts?.resume) piConfig.resume = true;
+    const permissions = normalizePermissions(spec.permissions);
+    if (permissions) piConfig.permissions = permissions;
     await sb.writeFile("/etc/alineo-pi.json", JSON.stringify(piConfig));
     await sb.writeFile("/etc/alineo-env", toShellExports(resolvedEnv));
     await sb.writeFile("/alineo-bridge.js", BRIDGE_SCRIPT);
+    if (permissions) await sb.writeFile("/alineo-permission-gate.js", PERMISSION_GATE_SCRIPT);
   }
 
   /**
@@ -255,6 +268,11 @@ export class PiAdapter {
 
   async abort(): Promise<void> {
     await rpcPost(this.bridgeUrl, "/abort");
+  }
+
+  /** Resolve a pending `permission_request` (see `AgentEvent`'s `permission_request`). */
+  async resolvePermission(requestId: string, decision: PermissionDecision): Promise<void> {
+    await rpcPost(this.bridgeUrl, "/permission-response", { requestId, decision });
   }
 
   async followUp(message: string): Promise<void> {
@@ -457,6 +475,10 @@ async function* sseStream(
   const decoder = new TextDecoder();
   let buf = "";
   let lastEventAt = Date.now();
+  // A `permission_request` can sit unanswered for as long as a human takes to decide, with
+  // no events flowing meanwhile. While any are outstanding, the inactivity timeout is
+  // suspended — the bridge's own PERMISSION_TIMEOUT_MS is the backstop there.
+  const pendingPermissions = new Set<string>();
   // Only a genuine server-signalled EOF (`done: true`) counts as reaching the natural end --
   // both the `[DONE]` early-return below and any thrown error (timeout, malformed payload,
   // bridge-reported error) leave the connection mid-stream, same as a natural EOF's opposite.
@@ -464,18 +486,30 @@ async function* sseStream(
 
   try {
     while (true) {
+      const awaitingHuman = pendingPermissions.size > 0;
       const remainingMs = inactivityTimeoutMs - (Date.now() - lastEventAt);
-      if (remainingMs <= 0) throw new PromptTimeoutError(inactivityTimeoutMs, bridgeUrl);
+      if (!awaitingHuman && remainingMs <= 0) {
+        throw new PromptTimeoutError(inactivityTimeoutMs, bridgeUrl);
+      }
 
       const result = await Promise.race([
         reader.read(),
         new Promise<"timeout">((resolve) => {
-          setTimeout(() => {
-            resolve("timeout");
-          }, remainingMs);
+          setTimeout(
+            () => {
+              resolve("timeout");
+            },
+            awaitingHuman ? inactivityTimeoutMs : Math.max(remainingMs, 1),
+          );
         }),
       ]);
-      if (result === "timeout") throw new PromptTimeoutError(inactivityTimeoutMs, bridgeUrl);
+      if (result === "timeout") {
+        if (pendingPermissions.size > 0) {
+          lastEventAt = Date.now(); // reset the clock; a human is still deciding
+          continue;
+        }
+        throw new PromptTimeoutError(inactivityTimeoutMs, bridgeUrl);
+      }
 
       const { done, value } = result;
       if (done) {
@@ -498,6 +532,8 @@ async function* sseStream(
         }
         const raw = JSON.parse(payload) as AgentEvent & { error?: string };
         if (raw.error) throw new Error(`Bridge error: ${raw.error}`);
+        if (raw.type === "permission_request") pendingPermissions.add(raw.requestId);
+        else if (raw.type === "permission_resolved") pendingPermissions.delete(raw.requestId);
         lastEventAt = Date.now();
         yield raw;
       }

--- a/packages/agent/src/agent/agent.ts
+++ b/packages/agent/src/agent/agent.ts
@@ -6,6 +6,7 @@ import type { AgentSnapshotRecord } from "../snapshots";
 import type {
   AgentStream,
   CompactResult,
+  PendingPermission,
   PermissionDecision,
   PiMessage,
   PiModel,
@@ -320,7 +321,16 @@ export class Alineo {
   /** Send a prompt to Pi and stream the response. Pi manages its own session context. */
   prompt(
     message: string,
-    opts?: { streamingBehavior?: "steer" | "followUp"; inactivityTimeoutMs?: number },
+    opts?: {
+      streamingBehavior?: "steer" | "followUp";
+      inactivityTimeoutMs?: number;
+      /**
+       * Auto-resolve each `permission_request` on this stream with the handler's decision,
+       * instead of the caller wiring `resolvePermission()` by hand. The
+       * `permission_request` / `permission_resolved` events still flow through the stream.
+       */
+      onPermission?: sessionControl.PermissionHandler;
+    },
   ): AgentStream {
     return sessionControl.prompt(this, message, opts);
   }
@@ -361,6 +371,15 @@ export class Alineo {
    */
   async resolvePermission(requestId: string, decision: PermissionDecision): Promise<void> {
     return sessionControl.resolvePermission(this, requestId, decision);
+  }
+
+  /**
+   * Tool calls currently paused awaiting a human decision — useful after reconnecting to a
+   * session to discover approvals still outstanding. Each entry is resolvable with
+   * `resolvePermission(entry.requestId, …)`.
+   */
+  async listPendingPermissions(): Promise<PendingPermission[]> {
+    return sessionControl.listPendingPermissions(this);
   }
 
   /** Queue a message to be sent to Pi after it finishes its current task. */

--- a/packages/agent/src/agent/agent.ts
+++ b/packages/agent/src/agent/agent.ts
@@ -6,6 +6,7 @@ import type { AgentSnapshotRecord } from "../snapshots";
 import type {
   AgentStream,
   CompactResult,
+  PermissionDecision,
   PiMessage,
   PiModel,
   PiSessionState,
@@ -343,6 +344,23 @@ export class Alineo {
   /** Abort Pi's current operation. */
   async abort(): Promise<void> {
     return sessionControl.abort(this);
+  }
+
+  /**
+   * Resolve a pending `permission_request` from the agent stream — emitted for each gated
+   * tool call when `AgentSpec.permissions` is set to something other than `"auto"`.
+   *
+   * @example
+   * ```ts
+   * for await (const ev of agent.prompt("Refactor auth")) {
+   *   if (ev.type === "permission_request") {
+   *     await agent.resolvePermission(ev.requestId, { kind: "once" });
+   *   }
+   * }
+   * ```
+   */
+  async resolvePermission(requestId: string, decision: PermissionDecision): Promise<void> {
+    return sessionControl.resolvePermission(this, requestId, decision);
   }
 
   /** Queue a message to be sent to Pi after it finishes its current task. */

--- a/packages/agent/src/agent/factory.ts
+++ b/packages/agent/src/agent/factory.ts
@@ -1,6 +1,6 @@
 import { Sandbox } from "@alineo-labs/sandbox";
 import { readFileSync } from "node:fs";
-import type { IStorageAdapter, SandboxHandle } from "@alineo-labs/core";
+import { LedgerEvent, type IStorageAdapter, type SandboxHandle } from "@alineo-labs/core";
 import type { Memory, ResourceRef } from "@alineo-labs/memory";
 import { readProjectConfig } from "../config";
 import { validateAgentSpec, type AgentSpec } from "../schema";
@@ -278,9 +278,46 @@ export async function resumeAgent(
   await adapter.startBridge(sb);
   await adapter.waitReady();
   console.log(`[agent] bridge ready    ${elapsed(t2)}`);
+
+  // Resuming starts a fresh Pi process — any tool call that was parked awaiting a human
+  // decision in the old process is gone (OpenSandbox restore is rootfs-only). Close out
+  // those ledger entries so `alineo logs` doesn't show them dangling forever.
+  await reconcileDroppedPermissions(opts.adapter, sb, spec.name, sandboxId);
+
   console.log(`[agent] total           ${elapsed(t0)}`);
 
   return { sandbox: sb, spec, env: resolvedEnv, adapter, fromSnapshot: false, runId };
+}
+
+async function reconcileDroppedPermissions(
+  adapter: IStorageAdapter,
+  sb: SandboxHandle,
+  name: string,
+  sandboxId: string,
+): Promise<void> {
+  try {
+    const events = await adapter.readAll(name, sandboxId);
+    const resolved = new Set<string>();
+    for (const e of events) {
+      if (e.event === LedgerEvent.PermissionResolved) {
+        const rid = (e.payload as { requestId?: string } | undefined)?.requestId;
+        if (rid) resolved.add(rid);
+      }
+    }
+    for (const e of events) {
+      if (e.event !== LedgerEvent.PermissionRequested) continue;
+      const rid = (e.payload as { requestId?: string } | undefined)?.requestId;
+      if (rid && !resolved.has(rid)) {
+        await sb.emit(LedgerEvent.PermissionResolved, -1, {
+          requestId: rid,
+          decision: { kind: "reject" },
+          note: "session resumed — pending approval dropped",
+        });
+      }
+    }
+  } catch {
+    // Best-effort audit hygiene; never block a resume on it.
+  }
 }
 
 /**

--- a/packages/agent/src/agent/index.ts
+++ b/packages/agent/src/agent/index.ts
@@ -1,2 +1,3 @@
 export { Alineo, resolveParentSpawnDepth, resolveParentMaxAgents } from "./agent";
 export type { AgentSnapshotRecord } from "./agent";
+export type { PermissionHandler } from "./session-control";

--- a/packages/agent/src/agent/session-control.ts
+++ b/packages/agent/src/agent/session-control.ts
@@ -1,13 +1,71 @@
-import type { AgentStream, PermissionDecision } from "../types";
+import { LedgerEvent } from "@alineo-labs/core";
+import type {
+  AgentStream,
+  PendingPermission,
+  PermissionDecision,
+  PermissionRequest,
+} from "../types";
 import type { AgentInternal } from "./internal";
+
+/**
+ * Called for each `permission_request` on a `prompt()`/`bash()` stream when passed as
+ * `opts.onPermission`. Return the decision; the SDK resolves the request for you. The
+ * `permission_request` / `permission_resolved` events still flow through the stream.
+ */
+export type PermissionHandler = (
+  req: PermissionRequest,
+) => PermissionDecision | Promise<PermissionDecision>;
+
+/**
+ * Wrap a raw adapter stream so that every permission event is mirrored to the ledger
+ * (`PermissionRequested` / `PermissionResolved`) and, when `onPermission` is given, each
+ * request is auto-resolved with the handler's decision.
+ */
+async function* instrument(
+  a: AgentInternal,
+  stream: AgentStream,
+  onPermission?: PermissionHandler,
+): AgentStream {
+  for await (const ev of stream) {
+    if (ev.type === "permission_request") {
+      void a.sandbox.emit(LedgerEvent.PermissionRequested, -1, {
+        requestId: ev.requestId,
+        tool: ev.tool,
+        target: ev.target,
+      });
+      if (onPermission) {
+        const req: PermissionRequest = {
+          requestId: ev.requestId,
+          tool: ev.tool,
+          target: ev.target,
+          title: ev.title,
+        };
+        void Promise.resolve(onPermission(req))
+          .then((decision) => a.adapter.resolvePermission(ev.requestId, decision))
+          .catch(() => {});
+      }
+    } else if (ev.type === "permission_resolved") {
+      void a.sandbox.emit(LedgerEvent.PermissionResolved, -1, {
+        requestId: ev.requestId,
+        decision: ev.decision,
+      });
+    }
+    yield ev;
+  }
+}
 
 /** Send a prompt to Pi and stream the response. Pi manages its own session context. */
 export function prompt(
   a: AgentInternal,
   message: string,
-  opts?: { streamingBehavior?: "steer" | "followUp"; inactivityTimeoutMs?: number },
+  opts?: {
+    streamingBehavior?: "steer" | "followUp";
+    inactivityTimeoutMs?: number;
+    /** Auto-resolve each `permission_request` with this handler's decision. */
+    onPermission?: PermissionHandler;
+  },
 ): AgentStream {
-  return a.adapter.prompt(message, opts);
+  return instrument(a, a.adapter.prompt(message, opts), opts?.onPermission);
 }
 
 /**
@@ -16,7 +74,12 @@ export function prompt(
  * arrives as a single `text` event once the command completes.
  */
 export function bash(a: AgentInternal, command: string): AgentStream {
-  return a.adapter.bash(command);
+  return instrument(a, a.adapter.bash(command));
+}
+
+/** Snapshot of tool calls currently paused awaiting a human decision. */
+export async function listPendingPermissions(a: AgentInternal): Promise<PendingPermission[]> {
+  return a.adapter.listPendingPermissions();
 }
 
 /** Steer Pi's current response mid-flight. Waits for Pi's RPC acknowledgment. */

--- a/packages/agent/src/agent/session-control.ts
+++ b/packages/agent/src/agent/session-control.ts
@@ -1,4 +1,4 @@
-import type { AgentStream } from "../types";
+import type { AgentStream, PermissionDecision } from "../types";
 import type { AgentInternal } from "./internal";
 
 /** Send a prompt to Pi and stream the response. Pi manages its own session context. */
@@ -27,6 +27,18 @@ export async function steer(a: AgentInternal, message: string): Promise<void> {
 /** Abort Pi's current operation. */
 export async function abort(a: AgentInternal): Promise<void> {
   return a.adapter.abort();
+}
+
+/**
+ * Resolve a pending `permission_request` emitted by the permission gate. `decision` is
+ * `{ kind: "once" }`, `{ kind: "always" }`, or `{ kind: "reject", feedback? }`.
+ */
+export async function resolvePermission(
+  a: AgentInternal,
+  requestId: string,
+  decision: PermissionDecision,
+): Promise<void> {
+  return a.adapter.resolvePermission(requestId, decision);
 }
 
 /** Queue a message to be sent to Pi after it finishes its current task. */

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,8 +2,15 @@ export { Alineo } from "./agent";
 export type { AgentSpec, SetupStep } from "./schema";
 export { validateAgentSpec } from "./schema";
 export type {
+  PermissionMode,
+  PermissionAction,
+  PermissionRule,
+  PermissionPolicy,
+} from "./permissions";
+export type {
   AgentEvent,
   AgentStream,
+  PermissionDecision,
   // eslint-disable-next-line typescript/no-deprecated -- deliberately still re-exported for backward compat until PromptStream's own removal
   PromptStream,
   PiModel,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,5 @@
 export { Alineo } from "./agent";
+export type { PermissionHandler } from "./agent";
 export type { AgentSpec, SetupStep } from "./schema";
 export { validateAgentSpec } from "./schema";
 export type {
@@ -7,10 +8,13 @@ export type {
   PermissionRule,
   PermissionPolicy,
 } from "./permissions";
+export { isReadOnlyBashCommand } from "./permissions";
 export type {
   AgentEvent,
   AgentStream,
   PermissionDecision,
+  PermissionRequest,
+  PendingPermission,
   // eslint-disable-next-line typescript/no-deprecated -- deliberately still re-exported for backward compat until PromptStream's own removal
   PromptStream,
   PiModel,

--- a/packages/agent/src/permissions.ts
+++ b/packages/agent/src/permissions.ts
@@ -201,6 +201,24 @@ export function normalizePermissions(
   };
 }
 
+const WRAPPER_COMMANDS = new Set(["env", "command", "nice", "stdbuf", "time"]);
+
+/**
+ * True if `seg` contains a file output redirection (`> file`, `>> file`). A `>` immediately
+ * followed by `&` (`2>&1`, `>&2`), preceded by a digit (`2>`, stderr), or preceded by `&`
+ * is a file-descriptor op, not a file write. Linear scan — no regex (ReDoS-safe).
+ */
+function hasOutputRedirect(seg: string): boolean {
+  for (let i = 0; i < seg.length; i++) {
+    if (seg[i] !== ">") continue;
+    const next = seg[i + 1];
+    const prev = seg[i - 1];
+    if (next === "&" || prev === "&" || (prev >= "0" && prev <= "9")) continue;
+    return true;
+  }
+  return false;
+}
+
 /**
  * Best-effort read-vs-write triage of a shell command. `true` = every sub-command is a
  * recognised pure reader with no output redirection; `false` = something needs a human.
@@ -213,24 +231,17 @@ export function isReadOnlyBashCommand(command: string): boolean {
     .filter(Boolean);
   if (segments.length === 0) return false;
   return segments.every((seg) => {
-    // Any output redirection (but not `2>&1` / `>&2`) makes it a writer.
-    if (/(?<![0-9&])>>?/.test(seg.replace(/\d*>&\d*/g, ""))) return false;
+    if (hasOutputRedirect(seg)) return false;
     // Strip leading `VAR=val` assignments and benign wrappers.
     let tokens = seg.split(/\s+/).filter(Boolean);
-    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]))
-      tokens = tokens.slice(1);
-    while (
-      tokens.length > 1 &&
-      (tokens[0] === "env" ||
-        tokens[0] === "command" ||
-        tokens[0] === "nice" ||
-        tokens[0] === "stdbuf" ||
-        tokens[0] === "time")
-    ) {
+    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) {
       tokens = tokens.slice(1);
     }
+    while (tokens.length > 1 && WRAPPER_COMMANDS.has(tokens[0])) tokens = tokens.slice(1);
     if (tokens[0] === "timeout" && tokens.length > 2) tokens = tokens.slice(2);
-    const cmd = (tokens[0] ?? "").replace(/^.*\//, ""); // basename
+    const first = tokens[0] ?? "";
+    const slash = first.lastIndexOf("/");
+    const cmd = slash === -1 ? first : first.slice(slash + 1);
     if (!cmd) return false;
     if ((SAFE_BASH_COMMANDS as readonly string[]).includes(cmd)) return true;
     if (cmd === "git" && (SAFE_GIT_SUBCOMMANDS as readonly string[]).includes(tokens[1] ?? "")) {

--- a/packages/agent/src/permissions.ts
+++ b/packages/agent/src/permissions.ts
@@ -25,8 +25,13 @@ export type PermissionMode = "auto" | "ask" | "readonly";
  * - `ask` — pause, surface a `permission_request`, wait for a human decision
  * - `deny` — refuse, with a reason the model reads and can adjust to
  * - `rate_limit` — allow up to `limit.count` matching calls per `limit.windowMs`, then deny
+ * - `classify` — best-effort read-vs-write triage of the call (today: `bash`/`powershell`
+ *   only, splitting on `&&`/`||`/`;`/`|`/newline and checking each sub-command against a
+ *   built-in safe-reader list). All sub-commands look read-only → `allow`; anything
+ *   unrecognised or a redirect/`sudo`/`rm` → falls through to `ask`. For any other tool,
+ *   `classify` is treated as `ask`.
  */
-export type PermissionAction = "allow" | "ask" | "deny" | "rate_limit";
+export type PermissionAction = "allow" | "ask" | "deny" | "rate_limit" | "classify";
 
 export interface PermissionRule {
   /** Tool name or glob (`*` = any run of chars, `?` = one), e.g. `"bash"`, `"write"`, `"*"`. */
@@ -49,10 +54,18 @@ export interface PermissionPolicy {
   /** Evaluated in order; the **last** matching rule wins (opencode semantics). */
   rules?: PermissionRule[];
   /**
-   * Tools the agent may never call. Enforced today as an unconditional `deny` with a clear
-   * reason (a stricter "hidden from the model entirely" mode is a later refinement).
+   * Tools the agent may never call. The gate strips these from the model's tool list at
+   * session start (via Pi's `setActiveTools`) so the model never attempts them, and also
+   * keeps an unconditional `deny` as a backstop for any tool registered after startup
+   * (SDK / MCP tools).
    */
   disabledTools?: string[];
+  /**
+   * If set, the ONLY tools the model may see — the gate calls Pi's `setActiveTools` with
+   * this list at session start. `"readonly"` mode expands to this (the read-only tools).
+   * Distinct from `disabledTools` (a denylist); this is an allowlist for the toolset.
+   */
+  restrictToTools?: string[];
 }
 
 /** The fully-defaulted shape written to `/etc/alineo-pi.json` and read by the gate. */
@@ -60,22 +73,113 @@ export interface NormalizedPermissionPolicy {
   default: PermissionAction;
   rules: PermissionRule[];
   disabledTools: string[];
+  /** Empty = no restriction. Non-empty = the exact set of tools the model may see. */
+  restrictToTools: string[];
 }
 
-/** Read-only built-in tools — auto-allowed under `"readonly"`. */
+/** Read-only built-in tools — auto-allowed (and the entire toolset) under `"readonly"`. */
 export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"] as const;
+
+/**
+ * First tokens that make a shell command a pure reader — used by the `"classify"` action
+ * and by the `bash` rule `"readonly"` installs. Deliberately conservative: an unrecognised
+ * command falls through to `ask`, never to `allow`.
+ */
+export const SAFE_BASH_COMMANDS = [
+  "ls",
+  "cat",
+  "head",
+  "tail",
+  "grep",
+  "rg",
+  "egrep",
+  "fgrep",
+  "zgrep",
+  "find",
+  "pwd",
+  "whoami",
+  "id",
+  "env",
+  "printenv",
+  "echo",
+  "printf",
+  "which",
+  "type",
+  "file",
+  "stat",
+  "wc",
+  "date",
+  "uname",
+  "hostname",
+  "df",
+  "du",
+  "tree",
+  "basename",
+  "dirname",
+  "realpath",
+  "readlink",
+  "true",
+  "false",
+  "cmp",
+  "diff",
+  "column",
+  "nl",
+  "less",
+  "more",
+  "tac",
+  "hexdump",
+  "xxd",
+  "od",
+  "strings",
+  "sha1sum",
+  "sha256sum",
+  "md5sum",
+  "cksum",
+] as const;
+
+/** `git <sub>` combinations that only read. */
+export const SAFE_GIT_SUBCOMMANDS = [
+  "status",
+  "log",
+  "diff",
+  "show",
+  "branch",
+  "remote",
+  "rev-parse",
+  "describe",
+  "blame",
+  "tag",
+  "config",
+  "ls-files",
+  "ls-tree",
+  "shortlog",
+  "reflog",
+  "cat-file",
+  "for-each-ref",
+  "whatchanged",
+  "rev-list",
+  "name-rev",
+  "symbolic-ref",
+  "count-objects",
+] as const;
 
 function expandMode(mode: PermissionMode): NormalizedPermissionPolicy | undefined {
   switch (mode) {
     case "auto":
       return undefined; // no gate loaded at all
     case "ask":
-      return { default: "ask", rules: [], disabledTools: [] };
+      return { default: "ask", rules: [], disabledTools: [], restrictToTools: [] };
     case "readonly":
       return {
         default: "ask",
-        rules: READ_ONLY_TOOLS.map((tool) => ({ tool, action: "allow" as const })),
+        rules: [
+          ...READ_ONLY_TOOLS.map((tool) => ({ tool, action: "allow" as const })),
+          // If a caller widens restrictToTools to re-admit bash, still triage each call
+          // rather than gating every one.
+          { tool: "bash", action: "classify" as const },
+        ],
         disabledTools: [],
+        restrictToTools: [...READ_ONLY_TOOLS],
       };
   }
 }
@@ -93,7 +197,47 @@ export function normalizePermissions(
     default: input.default ?? "ask",
     rules: input.rules ?? [],
     disabledTools: input.disabledTools ?? [],
+    restrictToTools: input.restrictToTools ?? [],
   };
+}
+
+/**
+ * Best-effort read-vs-write triage of a shell command. `true` = every sub-command is a
+ * recognised pure reader with no output redirection; `false` = something needs a human.
+ * Mirrored verbatim in `adapters/pi-permission-gate.js`.
+ */
+export function isReadOnlyBashCommand(command: string): boolean {
+  const segments = command
+    .split(/&&|\|\||[;\n|]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (segments.length === 0) return false;
+  return segments.every((seg) => {
+    // Any output redirection (but not `2>&1` / `>&2`) makes it a writer.
+    if (/(?<![0-9&])>>?/.test(seg.replace(/\d*>&\d*/g, ""))) return false;
+    // Strip leading `VAR=val` assignments and benign wrappers.
+    let tokens = seg.split(/\s+/).filter(Boolean);
+    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]))
+      tokens = tokens.slice(1);
+    while (
+      tokens.length > 1 &&
+      (tokens[0] === "env" ||
+        tokens[0] === "command" ||
+        tokens[0] === "nice" ||
+        tokens[0] === "stdbuf" ||
+        tokens[0] === "time")
+    ) {
+      tokens = tokens.slice(1);
+    }
+    if (tokens[0] === "timeout" && tokens.length > 2) tokens = tokens.slice(2);
+    const cmd = (tokens[0] ?? "").replace(/^.*\//, ""); // basename
+    if (!cmd) return false;
+    if ((SAFE_BASH_COMMANDS as readonly string[]).includes(cmd)) return true;
+    if (cmd === "git" && (SAFE_GIT_SUBCOMMANDS as readonly string[]).includes(tokens[1] ?? "")) {
+      return true;
+    }
+    return false;
+  });
 }
 
 /** Compile a rule glob to an anchored RegExp. `*` → `.*`, `?` → `.`, everything else literal. */
@@ -113,7 +257,8 @@ function ruleMatches(rule: PermissionRule, tool: string, target: string): boolea
 
 /**
  * Resolve a tool call to an action: the last matching rule's, or the policy default.
- * `disabledTools` short-circuits to `"deny"`.
+ * `disabledTools` short-circuits to `"deny"`. `"classify"` is resolved here to `"allow"`
+ * or `"ask"` (bash reader-triage; any other tool → `"ask"`).
  */
 export function evaluatePolicy(
   policy: NormalizedPermissionPolicy,
@@ -124,6 +269,11 @@ export function evaluatePolicy(
   let match: PermissionRule | undefined;
   for (const rule of policy.rules) {
     if (ruleMatches(rule, tool, target)) match = rule;
+  }
+  const action = match ? match.action : policy.default;
+  if (action === "classify") {
+    const resolved = tool === "bash" && isReadOnlyBashCommand(target) ? "allow" : "ask";
+    return { action: resolved, rule: match };
   }
   return match ? { action: match.action, rule: match } : { action: policy.default };
 }

--- a/packages/agent/src/permissions.ts
+++ b/packages/agent/src/permissions.ts
@@ -1,0 +1,129 @@
+/**
+ * Human-in-the-loop tool-call policy — the host-side half.
+ *
+ * `AgentSpec.permissions` (a mode string or a full policy) is normalized here into a
+ * `NormalizedPermissionPolicy`, written into the sandbox at `/etc/alineo-pi.json`, and read
+ * by the bundled Pi gate extension (`adapters/pi-permission-gate.js`), which re-implements
+ * the tiny matcher below inline (same duplication tradeoff `pi-bridge.js` already makes —
+ * the gate can't import from a published package it runs beside via jiti). Keep the two
+ * matchers in sync; `test/permissions.test.ts` covers this one.
+ */
+
+/**
+ * Shorthand for the common cases:
+ * - `"auto"` — never ask (the default; identical to not setting `permissions` at all)
+ * - `"ask"` — ask before every tool call
+ * - `"readonly"` — auto-allow the read-only tools (`read`/`grep`/`find`/`ls`), ask before
+ *   `write`/`edit`/`bash`/`powershell`. Pi has no network tool — an agent reaches the
+ *   network through `bash`, so `"readonly"` gates that by gating `bash`, not as a category.
+ */
+export type PermissionMode = "auto" | "ask" | "readonly";
+
+/**
+ * What happens when a rule (or the policy default) matches a tool call:
+ * - `allow` — run it, no prompt
+ * - `ask` — pause, surface a `permission_request`, wait for a human decision
+ * - `deny` — refuse, with a reason the model reads and can adjust to
+ * - `rate_limit` — allow up to `limit.count` matching calls per `limit.windowMs`, then deny
+ */
+export type PermissionAction = "allow" | "ask" | "deny" | "rate_limit";
+
+export interface PermissionRule {
+  /** Tool name or glob (`*` = any run of chars, `?` = one), e.g. `"bash"`, `"write"`, `"*"`. */
+  tool: string;
+  /**
+   * Glob matched against a tool-specific target string, extracted from Pi's typed
+   * `event.input` — the command for `bash`, the path for `read`/`write`/`edit`, the query
+   * for `grep`. Anchored: `"git *"` matches `"git status"` but not `"x && git status"` —
+   * use `"*git*"` for a substring match. Omit to match any call to `tool`.
+   */
+  pattern?: string;
+  action: PermissionAction;
+  /** `rate_limit` only: the ceiling and rolling window. */
+  limit?: { count: number; windowMs: number };
+}
+
+export interface PermissionPolicy {
+  /** Action when no rule matches. Default `"ask"`. */
+  default?: PermissionAction;
+  /** Evaluated in order; the **last** matching rule wins (opencode semantics). */
+  rules?: PermissionRule[];
+  /**
+   * Tools the agent may never call. Enforced today as an unconditional `deny` with a clear
+   * reason (a stricter "hidden from the model entirely" mode is a later refinement).
+   */
+  disabledTools?: string[];
+}
+
+/** The fully-defaulted shape written to `/etc/alineo-pi.json` and read by the gate. */
+export interface NormalizedPermissionPolicy {
+  default: PermissionAction;
+  rules: PermissionRule[];
+  disabledTools: string[];
+}
+
+/** Read-only built-in tools — auto-allowed under `"readonly"`. */
+export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"] as const;
+
+function expandMode(mode: PermissionMode): NormalizedPermissionPolicy | undefined {
+  switch (mode) {
+    case "auto":
+      return undefined; // no gate loaded at all
+    case "ask":
+      return { default: "ask", rules: [], disabledTools: [] };
+    case "readonly":
+      return {
+        default: "ask",
+        rules: READ_ONLY_TOOLS.map((tool) => ({ tool, action: "allow" as const })),
+        disabledTools: [],
+      };
+  }
+}
+
+/**
+ * Turn `AgentSpec.permissions` into the normalized policy the gate consumes, or `undefined`
+ * when no gate is needed (unset, or `"auto"`).
+ */
+export function normalizePermissions(
+  input: PermissionMode | PermissionPolicy | undefined,
+): NormalizedPermissionPolicy | undefined {
+  if (input === undefined) return undefined;
+  if (typeof input === "string") return expandMode(input);
+  return {
+    default: input.default ?? "ask",
+    rules: input.rules ?? [],
+    disabledTools: input.disabledTools ?? [],
+  };
+}
+
+/** Compile a rule glob to an anchored RegExp. `*` → `.*`, `?` → `.`, everything else literal. */
+function globToRegExp(glob: string): RegExp {
+  const body = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${body}$`, "s");
+}
+
+function ruleMatches(rule: PermissionRule, tool: string, target: string): boolean {
+  if (!globToRegExp(rule.tool).test(tool)) return false;
+  if (rule.pattern !== undefined && !globToRegExp(rule.pattern).test(target)) return false;
+  return true;
+}
+
+/**
+ * Resolve a tool call to an action: the last matching rule's, or the policy default.
+ * `disabledTools` short-circuits to `"deny"`.
+ */
+export function evaluatePolicy(
+  policy: NormalizedPermissionPolicy,
+  tool: string,
+  target: string,
+): { action: PermissionAction; rule?: PermissionRule } {
+  if (policy.disabledTools.includes(tool)) return { action: "deny" };
+  let match: PermissionRule | undefined;
+  for (const rule of policy.rules) {
+    if (ruleMatches(rule, tool, target)) match = rule;
+  }
+  return match ? { action: match.action, rule: match } : { action: policy.default };
+}

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { AgentSpecValidationError } from "./errors";
+import type { PermissionMode, PermissionPolicy } from "./permissions";
 
 /** Renders an arbitrary invalid field value for an error message without risking "[object Object]". */
 function describeValue(value: unknown): string {
@@ -173,6 +174,16 @@ export interface AgentSpec {
    * regardless of what the ledger ends up calling the forked sandbox.
    */
   resourceId?: string;
+  /**
+   * Human-in-the-loop tool-call policy, enforced by a bundled Pi extension that runs on
+   * every tool call before it executes. Either a mode shorthand (`"auto"` — the default,
+   * never ask; `"ask"` — ask before every call; `"readonly"` — auto-allow reads, ask before
+   * writes/exec) or a full `PermissionPolicy` with ordered per-tool / per-pattern rules
+   * (last match wins). When set to anything other than `"auto"`, a `permission_request`
+   * event is emitted on the agent stream for each gated call; resolve it with
+   * `agent.resolvePermission(requestId, decision)`.
+   */
+  permissions?: PermissionMode | PermissionPolicy;
 }
 
 /**
@@ -203,6 +214,29 @@ const SetupStepSchema = z
     cwd: z.string().optional(),
   })
   .loose();
+
+const PermissionActionSchema = z.enum(["allow", "ask", "deny", "rate_limit"]);
+
+const PermissionRuleSchema = z
+  .object({
+    tool: z.string({ error: "Each permission rule must have a 'tool' string" }),
+    pattern: z.string().optional(),
+    action: PermissionActionSchema,
+    limit: z
+      .object({ count: z.number().int().positive(), windowMs: z.number().int().positive() })
+      .optional(),
+  })
+  .loose();
+
+const PermissionPolicySchema = z
+  .object({
+    default: PermissionActionSchema.optional(),
+    rules: z.array(PermissionRuleSchema).optional(),
+    disabledTools: z.array(z.string()).optional(),
+  })
+  .loose();
+
+const PermissionsSchema = z.union([z.enum(["auto", "ask", "readonly"]), PermissionPolicySchema]);
 
 const nonNegativeIntSpecField = (fieldName: string) =>
   z
@@ -251,6 +285,7 @@ const AgentSpecSchema = z
     maxAgents: nonNegativeIntSpecField("maxAgents"),
     teamId: z.string().optional(),
     resourceId: z.string().optional(),
+    permissions: PermissionsSchema.optional(),
   })
   // Unknown keys pass through untouched rather than being stripped or rejected — matches the
   // old hand-rolled validator's behavior (it only ever checked a few fields and cast the rest

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -215,7 +215,7 @@ const SetupStepSchema = z
   })
   .loose();
 
-const PermissionActionSchema = z.enum(["allow", "ask", "deny", "rate_limit"]);
+const PermissionActionSchema = z.enum(["allow", "ask", "deny", "rate_limit", "classify"]);
 
 const PermissionRuleSchema = z
   .object({
@@ -233,6 +233,7 @@ const PermissionPolicySchema = z
     default: PermissionActionSchema.optional(),
     rules: z.array(PermissionRuleSchema).optional(),
     disabledTools: z.array(z.string()).optional(),
+    restrictToTools: z.array(z.string()).optional(),
   })
   .loose();
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -8,6 +8,11 @@
  * - `extension_ui` — a Pi extension requested UI interaction; dialog requests are
  *   auto-cancelled by the bridge so Pi never stalls, but the event is forwarded so
  *   callers can observe what was requested
+ * - `permission_request` — the permission gate paused a tool call for human approval
+ *   (only when `AgentSpec.permissions` is set to something other than `"auto"`); resolve
+ *   it with `agent.resolvePermission(requestId, decision)`
+ * - `permission_resolved` — a `permission_request` was answered (by a caller, a batched
+ *   "always"/"reject" decision, or the timeout)
  * - `auto_retry_start` — Pi is about to retry after a transient error (429, 5xx)
  * - `auto_retry_end` — Pi's retry sequence completed (success or exhausted)
  * - `agent_start` — Pi began processing the prompt
@@ -34,6 +39,22 @@ export type AgentEvent =
       params: unknown;
       isDialog: boolean;
       requestId?: string;
+    }
+  | {
+      type: "permission_request";
+      /** Pass to `agent.resolvePermission()`. */
+      requestId: string;
+      /** The tool Pi is about to run, e.g. `"bash"`. */
+      tool: string;
+      /** Tool-specific target: the command for `bash`, the path for file tools. */
+      target: string;
+      /** Human-readable one-line summary for a prompt. */
+      title: string;
+    }
+  | {
+      type: "permission_resolved";
+      requestId: string;
+      decision: PermissionDecision;
     }
   | {
       type: "auto_retry_start";
@@ -66,6 +87,19 @@ export type AgentEvent =
       willRetry: boolean;
     }
   | { type: "extension_error"; extensionPath: string; event: string; error: string };
+
+/**
+ * A human's answer to a `permission_request`, passed to `agent.resolvePermission()`.
+ * - `once` — allow this one call
+ * - `always` — allow this call and auto-allow every other still-pending request for the
+ *   same tool (opencode's batch-clear); does not persist past the session
+ * - `reject` — block the call; `feedback` (if given) becomes the reason the model reads,
+ *   and every other still-pending request for the same tool is rejected too
+ */
+export type PermissionDecision =
+  | { kind: "once" }
+  | { kind: "always" }
+  | { kind: "reject"; feedback?: string };
 
 /**
  * Async iterable of structured agent events. Returned by `Alineo.prompt()` and `Alineo.bash()`.

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -101,6 +101,24 @@ export type PermissionDecision =
   | { kind: "always" }
   | { kind: "reject"; feedback?: string };
 
+/** The payload of a `permission_request`, as handed to a `prompt()` `onPermission` handler. */
+export interface PermissionRequest {
+  requestId: string;
+  tool: string;
+  target: string;
+  title: string;
+}
+
+/** One entry from `agent.listPendingPermissions()` — a tool call paused awaiting a decision. */
+export interface PendingPermission {
+  requestId: string;
+  tool: string;
+  target: string;
+  title: string;
+  /** Unix ms when the gate raised this request. */
+  since: number;
+}
+
 /**
  * Async iterable of structured agent events. Returned by `Alineo.prompt()` and `Alineo.bash()`.
  *

--- a/packages/agent/test/permissions.test.ts
+++ b/packages/agent/test/permissions.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { normalizePermissions, evaluatePolicy, READ_ONLY_TOOLS } from "../src/permissions";
+import {
+  normalizePermissions,
+  evaluatePolicy,
+  isReadOnlyBashCommand,
+  READ_ONLY_TOOLS,
+} from "../src/permissions";
 
 describe("normalizePermissions", () => {
   it("returns undefined for unset or 'auto' (no gate)", () => {
@@ -8,14 +13,25 @@ describe("normalizePermissions", () => {
   });
 
   it("'ask' → default ask, no rules", () => {
-    expect(normalizePermissions("ask")).toEqual({ default: "ask", rules: [], disabledTools: [] });
+    expect(normalizePermissions("ask")).toEqual({
+      default: "ask",
+      rules: [],
+      disabledTools: [],
+      restrictToTools: [],
+    });
   });
 
-  it("'readonly' → ask by default, allow the read tools", () => {
+  it("'readonly' → ask by default, allow the read tools, classify bash, restrict the toolset", () => {
     const p = normalizePermissions("readonly");
     expect(p?.default).toBe("ask");
-    expect(p?.rules.map((r) => r.tool).sort()).toEqual([...READ_ONLY_TOOLS].sort());
-    expect(p?.rules.every((r) => r.action === "allow")).toBe(true);
+    expect(p?.restrictToTools.slice().sort()).toEqual([...READ_ONLY_TOOLS].sort());
+    expect(
+      p?.rules
+        .filter((r) => r.action === "allow")
+        .map((r) => r.tool)
+        .sort(),
+    ).toEqual([...READ_ONLY_TOOLS].sort());
+    expect(p?.rules.some((r) => r.tool === "bash" && r.action === "classify")).toBe(true);
   });
 
   it("fills defaults on a partial policy object", () => {
@@ -23,12 +39,22 @@ describe("normalizePermissions", () => {
       default: "ask",
       rules: [{ tool: "bash", action: "deny" }],
       disabledTools: [],
+      restrictToTools: [],
     });
   });
 
-  it("keeps an explicit default and disabledTools", () => {
-    const p = normalizePermissions({ default: "allow", disabledTools: ["bash"] });
-    expect(p).toEqual({ default: "allow", rules: [], disabledTools: ["bash"] });
+  it("keeps an explicit default, disabledTools, and restrictToTools", () => {
+    const p = normalizePermissions({
+      default: "allow",
+      disabledTools: ["bash"],
+      restrictToTools: ["read", "grep"],
+    });
+    expect(p).toEqual({
+      default: "allow",
+      rules: [],
+      disabledTools: ["bash"],
+      restrictToTools: ["read", "grep"],
+    });
   });
 });
 
@@ -37,6 +63,7 @@ describe("evaluatePolicy", () => {
     default: "ask" as const,
     rules: [],
     disabledTools: [],
+    restrictToTools: [],
     ...over,
   });
 
@@ -90,5 +117,42 @@ describe("evaluatePolicy", () => {
       limit: { count: 3, windowMs: 1000 },
     };
     expect(evaluatePolicy(P({ rules: [rule] }), "bash", "x").rule).toEqual(rule);
+  });
+
+  it("'classify' resolves to allow for a read-only bash command, ask otherwise", () => {
+    const p = P({ rules: [{ tool: "bash", action: "classify" }] });
+    expect(evaluatePolicy(p, "bash", "ls -la && cat README.md").action).toBe("allow");
+    expect(evaluatePolicy(p, "bash", "git status").action).toBe("allow");
+    expect(evaluatePolicy(p, "bash", "rm -rf build").action).toBe("ask");
+    expect(evaluatePolicy(p, "bash", "echo hi > out.txt").action).toBe("ask");
+  });
+
+  it("'classify' on a non-bash tool just asks", () => {
+    const p = P({ rules: [{ tool: "write", action: "classify" }] });
+    expect(evaluatePolicy(p, "write", "/tmp/x").action).toBe("ask");
+  });
+});
+
+describe("isReadOnlyBashCommand", () => {
+  it("recognises pure readers and pipelines of them", () => {
+    expect(isReadOnlyBashCommand("ls")).toBe(true);
+    expect(isReadOnlyBashCommand("cat a.txt | grep foo | wc -l")).toBe(true);
+    expect(isReadOnlyBashCommand("git log --oneline -5 && git diff")).toBe(true);
+    expect(isReadOnlyBashCommand("FOO=bar env")).toBe(true);
+    expect(isReadOnlyBashCommand("timeout 5 grep -r foo .")).toBe(true);
+  });
+
+  it("flags writers, redirects, unknowns", () => {
+    expect(isReadOnlyBashCommand("rm file")).toBe(false);
+    expect(isReadOnlyBashCommand("echo hi > f")).toBe(false);
+    expect(isReadOnlyBashCommand("cat a && npm install")).toBe(false);
+    expect(isReadOnlyBashCommand("git push")).toBe(false);
+    expect(isReadOnlyBashCommand("curl https://x.test")).toBe(false);
+    expect(isReadOnlyBashCommand("")).toBe(false);
+  });
+
+  it("allows benign stderr redirects", () => {
+    expect(isReadOnlyBashCommand("grep foo bar 2>/dev/null")).toBe(true);
+    expect(isReadOnlyBashCommand("ls 2>&1")).toBe(true);
   });
 });

--- a/packages/agent/test/permissions.test.ts
+++ b/packages/agent/test/permissions.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "bun:test";
+import { normalizePermissions, evaluatePolicy, READ_ONLY_TOOLS } from "../src/permissions";
+
+describe("normalizePermissions", () => {
+  it("returns undefined for unset or 'auto' (no gate)", () => {
+    expect(normalizePermissions(undefined)).toBeUndefined();
+    expect(normalizePermissions("auto")).toBeUndefined();
+  });
+
+  it("'ask' → default ask, no rules", () => {
+    expect(normalizePermissions("ask")).toEqual({ default: "ask", rules: [], disabledTools: [] });
+  });
+
+  it("'readonly' → ask by default, allow the read tools", () => {
+    const p = normalizePermissions("readonly");
+    expect(p?.default).toBe("ask");
+    expect(p?.rules.map((r) => r.tool).sort()).toEqual([...READ_ONLY_TOOLS].sort());
+    expect(p?.rules.every((r) => r.action === "allow")).toBe(true);
+  });
+
+  it("fills defaults on a partial policy object", () => {
+    expect(normalizePermissions({ rules: [{ tool: "bash", action: "deny" }] })).toEqual({
+      default: "ask",
+      rules: [{ tool: "bash", action: "deny" }],
+      disabledTools: [],
+    });
+  });
+
+  it("keeps an explicit default and disabledTools", () => {
+    const p = normalizePermissions({ default: "allow", disabledTools: ["bash"] });
+    expect(p).toEqual({ default: "allow", rules: [], disabledTools: ["bash"] });
+  });
+});
+
+describe("evaluatePolicy", () => {
+  const P = (over: Partial<ReturnType<typeof normalizePermissions>> = {}) => ({
+    default: "ask" as const,
+    rules: [],
+    disabledTools: [],
+    ...over,
+  });
+
+  it("falls back to the policy default when nothing matches", () => {
+    expect(evaluatePolicy(P(), "bash", "ls").action).toBe("ask");
+    expect(evaluatePolicy(P({ default: "allow" }), "bash", "ls").action).toBe("allow");
+  });
+
+  it("matches a rule by tool name", () => {
+    const p = P({ rules: [{ tool: "read", action: "allow" }] });
+    expect(evaluatePolicy(p, "read", "/etc/hosts").action).toBe("allow");
+    expect(evaluatePolicy(p, "write", "/etc/hosts").action).toBe("ask");
+  });
+
+  it("last matching rule wins", () => {
+    const p = P({
+      rules: [
+        { tool: "bash", action: "deny" },
+        { tool: "bash", pattern: "git *", action: "allow" },
+      ],
+    });
+    expect(evaluatePolicy(p, "bash", "git status").action).toBe("allow");
+    expect(evaluatePolicy(p, "bash", "rm -rf /").action).toBe("deny");
+  });
+
+  it("anchors glob patterns, supports * and ?", () => {
+    const p = P({ rules: [{ tool: "bash", pattern: "rm -rf *", action: "deny" }] });
+    expect(evaluatePolicy(p, "bash", "rm -rf node_modules").action).toBe("deny");
+    expect(evaluatePolicy(p, "bash", "echo rm -rf x").action).toBe("ask"); // not anchored → no match
+  });
+
+  it("substring match via *pattern*", () => {
+    const p = P({ rules: [{ tool: "bash", pattern: "*sudo*", action: "deny" }] });
+    expect(evaluatePolicy(p, "bash", "echo x && sudo rm").action).toBe("deny");
+  });
+
+  it("tool globs work too", () => {
+    const p = P({ rules: [{ tool: "*", action: "allow" }] });
+    expect(evaluatePolicy(p, "anything", "").action).toBe("allow");
+  });
+
+  it("disabledTools short-circuits to deny regardless of rules", () => {
+    const p = P({ disabledTools: ["bash"], rules: [{ tool: "bash", action: "allow" }] });
+    expect(evaluatePolicy(p, "bash", "ls").action).toBe("deny");
+  });
+
+  it("returns the matched rule (for rate_limit bookkeeping)", () => {
+    const rule = {
+      tool: "bash",
+      action: "rate_limit" as const,
+      limit: { count: 3, windowMs: 1000 },
+    };
+    expect(evaluatePolicy(P({ rules: [rule] }), "bash", "x").rule).toEqual(rule);
+  });
+});

--- a/packages/agent/test/pi-bridge.test.ts
+++ b/packages/agent/test/pi-bridge.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { chmodSync, copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+/**
+ * Drives the real pi-bridge.js against a stub `pi` process — covers the permission
+ * hold/route/resolve protocol, batch-clear, and `/pending-permissions` without a sandbox.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), "alineo-bridge-"));
+const PORT = 3100 + Math.floor(Math.random() * 800);
+const BASE = `http://127.0.0.1:${PORT}`;
+const bridgeSrc = fileURLToPath(new URL("../src/adapters/pi-bridge.js", import.meta.url));
+const gatePath = fileURLToPath(new URL("../src/adapters/pi-permission-gate.js", import.meta.url));
+// The package is `"type": "module"` but pi-bridge.js is CJS (it runs from the sandbox root,
+// outside any package.json). Copy it to a `.cjs` so `node` treats it as CJS here too.
+const bridgePath = join(mkdtempSync(join(tmpdir(), "alineo-bridge-bin-")), "bridge.cjs");
+copyFileSync(bridgeSrc, bridgePath);
+
+// Stub Pi: speaks just enough of the RPC line protocol. On `prompt`, emits two
+// ALINEO_PERM select dialogs (same tool) so batch-clear is exercised. Echoes every
+// extension_ui_response back as `__ui_ack__` so the test can assert what was sent.
+const stubPi = `#!/usr/bin/env node
+const rl = require("readline").createInterface({ input: process.stdin });
+const send = (o) => process.stdout.write(JSON.stringify(o) + "\\n");
+rl.on("line", (line) => {
+  let m; try { m = JSON.parse(line); } catch { return; }
+  if (m.id === "__probe__") { send({ id: "__probe__", type: "response", command: "get_state", success: true, data: { model: { id: "stub", api: "stub" } } }); return; }
+  if (m.type === "prompt") {
+    for (const n of [1, 2]) {
+      send({ type: "extension_ui_request", id: "perm-" + n, method: "select",
+        title: 'ALINEO_PERM {"tool":"bash","target":"cmd-' + n + '","title":"Run bash cmd-' + n + '"}',
+        options: ["decide"] });
+    }
+    return;
+  }
+  if (m.type === "extension_ui_response") { send({ type: "__ui_ack__", id: m.id, value: m.value, cancelled: !!m.cancelled }); return; }
+  if (m.id) send({ id: m.id, type: "response", success: true, data: null });
+});
+`;
+const stubPath = join(dir, "stub-pi");
+const configPath = join(dir, "alineo-pi.json");
+
+let proc: ReturnType<typeof Bun.spawn>;
+
+async function getJson<T>(url: string): Promise<T> {
+  return (await (await fetch(url)).json()) as T;
+}
+
+async function waitForHealth() {
+  for (let i = 0; i < 100; i++) {
+    try {
+      const r = await fetch(`${BASE}/health`);
+      const body = (await r.json().catch(() => null)) as { ok?: boolean } | null;
+      if (r.ok && body?.ok) return;
+    } catch {}
+    await Bun.sleep(100);
+  }
+  throw new Error("bridge did not become healthy");
+}
+
+type SseEvent = { type?: string; requestId?: string };
+
+/** Consume the permission SSE stream in the background, recording event objects. */
+function openPermissionStream(sink: SseEvent[], signal: AbortSignal) {
+  void (async () => {
+    const res = await fetch(`${BASE}/permission-stream`, { signal });
+    if (!res.body) return;
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const l of lines) {
+          if (l.startsWith("data: ") && l.slice(6).trim() !== "[DONE]") {
+            try {
+              sink.push(JSON.parse(l.slice(6)) as SseEvent);
+            } catch {}
+          }
+        }
+      }
+    } catch {}
+  })();
+}
+
+async function until<T>(fn: () => T | undefined, ms = 5000): Promise<T> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const v = fn();
+    if (v !== undefined) return v;
+    await Bun.sleep(50);
+  }
+  throw new Error("timeout waiting for condition");
+}
+
+beforeAll(async () => {
+  writeFileSync(stubPath, stubPi);
+  chmodSync(stubPath, 0o755);
+  writeFileSync(configPath, JSON.stringify({ permissions: { default: "ask", rules: [] } }));
+  proc = Bun.spawn(["node", bridgePath], {
+    env: {
+      ...process.env,
+      ALINEO_BRIDGE_PORT: String(PORT),
+      ALINEO_PI_BIN: stubPath,
+      ALINEO_PI_CONFIG: configPath,
+      ALINEO_PERMISSION_GATE_PATH: gatePath,
+      ALINEO_ENV_FILE: join(dir, "nonexistent-env"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await waitForHealth();
+});
+
+afterAll(() => {
+  try {
+    proc.kill();
+  } catch {}
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("pi-bridge permission protocol", () => {
+  it("holds gate dialogs, routes them, resolves + batch-clears, tracks pending", async () => {
+    const ac = new AbortController();
+    const events: SseEvent[] = [];
+    openPermissionStream(events, ac.signal);
+    await Bun.sleep(200);
+
+    // Kick a prompt so the stub emits perm-1 / perm-2.
+    const promptAc = new AbortController();
+    void fetch(`${BASE}/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "go" }),
+      signal: promptAc.signal,
+    }).catch(() => {});
+
+    await until(() =>
+      events.filter((e) => e.type === "permission_request").length === 2 ? true : undefined,
+    );
+
+    // Both pending, visible via /pending-permissions.
+    type PendingBody = { data: { pending: Array<{ requestId: string; tool: string }> } };
+    const pending = (await getJson<PendingBody>(`${BASE}/pending-permissions`)).data.pending;
+    expect(pending.map((p) => p.requestId).sort((a, b) => a.localeCompare(b))).toEqual([
+      "perm-1",
+      "perm-2",
+    ]);
+    expect(pending[0].tool).toBe("bash");
+
+    // Unknown id → 404.
+    const bad = await fetch(`${BASE}/permission-response`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId: "nope", decision: { kind: "once" } }),
+    });
+    expect(bad.status).toBe(404);
+
+    // Resolve perm-1 as always → perm-2 (same tool) batch-clears.
+    const ok = await fetch(`${BASE}/permission-response`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId: "perm-1", decision: { kind: "always" } }),
+    });
+    expect(ok.status).toBe(200);
+
+    await until(() =>
+      events.filter((e) => e.type === "permission_resolved").length === 2 ? true : undefined,
+    );
+    const resolvedIds = events
+      .filter((e) => e.type === "permission_resolved")
+      .map((e) => e.requestId ?? "")
+      .sort((a, b) => a.localeCompare(b));
+    expect(resolvedIds).toEqual(["perm-1", "perm-2"]);
+
+    // Nothing left pending.
+    const after = (await getJson<PendingBody>(`${BASE}/pending-permissions`)).data.pending;
+    expect(after).toHaveLength(0);
+
+    promptAc.abort();
+    ac.abort();
+  }, 20_000);
+});

--- a/packages/agent/test/pi-permission-gate.test.ts
+++ b/packages/agent/test/pi-permission-gate.test.ts
@@ -75,30 +75,47 @@ async function call(
   return { result, selectCalls };
 }
 
+/** Fire the lifecycle hooks the gate registers to apply the toolset (it can't at load time). */
+function boot(pi: ReturnType<typeof makePi>) {
+  for (const fn of pi.handlers.session_start ?? []) fn();
+  for (const fn of pi.handlers.before_agent_start ?? []) fn();
+}
+
 describe("pi-permission-gate — toolset", () => {
-  it("restrictToTools intersects the visible toolset", () => {
+  it("does not touch the toolset during extension load", () => {
     setPolicy({ default: "ask", rules: [], restrictToTools: ["read", "grep"] });
     const pi = makePi();
     gate(pi);
+    expect(pi.active).toContain("bash"); // untouched until a lifecycle hook fires
+  });
+
+  it("restrictToTools intersects the visible toolset on session_start", () => {
+    setPolicy({ default: "ask", rules: [], restrictToTools: ["read", "grep"] });
+    const pi = makePi();
+    gate(pi);
+    boot(pi);
     expect(pi.active.sort()).toEqual(["grep", "read"]);
   });
 
-  it("disabledTools is removed from the visible toolset and denied at call time", async () => {
+  it("disabledTools is removed from the toolset and denied at call time", async () => {
     setPolicy({ default: "allow", rules: [], disabledTools: ["bash"] });
     const pi = makePi();
     gate(pi);
+    boot(pi);
     expect(pi.active).not.toContain("bash");
     const { result } = await call(pi, "bash", { command: "ls" });
     expect(result).toMatchObject({ block: true });
   });
 
-  it("re-applies the toolset on session_start", () => {
+  it("re-applies each turn (idempotent) if Pi re-registers tools", () => {
     setPolicy({ default: "ask", rules: [], restrictToTools: ["read"] });
     const pi = makePi();
     gate(pi);
-    pi.active = ["read", "write", "bash"]; // simulate Pi re-registering tools
-    for (const fn of pi.handlers.session_start) fn();
+    boot(pi);
     expect(pi.active).toEqual(["read"]);
+    pi.active = ["read", "write", "bash"]; // Pi re-registers tools mid-session
+    for (const fn of pi.handlers.before_agent_start ?? []) fn();
+    expect(pi.active).toEqual(["read"]); // re-filtered
   });
 });
 

--- a/packages/agent/test/pi-permission-gate.test.ts
+++ b/packages/agent/test/pi-permission-gate.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The gate reads its policy from process.env.ALINEO_PI_CONFIG (falling back to
+// /etc/alineo-pi.json). Point it at a temp file we rewrite per-case, then import the
+// extension once — loadPolicy() re-reads the file on every gate(pi) call.
+const dir = mkdtempSync(join(tmpdir(), "alineo-gate-"));
+const configPath = join(dir, "alineo-pi.json");
+process.env.ALINEO_PI_CONFIG = configPath;
+
+type GateResult = { block: true; reason: string } | undefined;
+
+let gate: (pi: unknown) => void;
+
+beforeAll(async () => {
+  // `: string` so TS doesn't try to resolve a declaration file for the plain-.js extension.
+  const modPath: string = "../src/adapters/pi-permission-gate.js";
+  const mod = (await import(modPath)) as { default: (pi: unknown) => void };
+  gate = mod.default;
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function setPolicy(permissions: unknown) {
+  writeFileSync(configPath, JSON.stringify({ permissions }));
+}
+
+type Fn = (...a: unknown[]) => unknown;
+type ToolCallFn = (
+  event: { toolName: string; input: unknown },
+  ctx: unknown,
+) => Promise<GateResult>;
+
+function makePi(activeTools = ["read", "write", "edit", "bash", "grep", "find", "ls"]) {
+  const handlers: Record<string, Fn[]> = {};
+  const pi = {
+    handlers,
+    active: [...activeTools] as string[],
+    on(name: string, fn: Fn) {
+      (handlers[name] ??= []).push(fn);
+    },
+    getActiveTools() {
+      return pi.active;
+    },
+    setActiveTools(tools: string[]) {
+      pi.active = tools;
+    },
+  };
+  return pi;
+}
+
+/** Drive one tool_call through the gate. `select` is what ctx.ui.select resolves to. */
+async function call(
+  pi: ReturnType<typeof makePi>,
+  toolName: string,
+  input: unknown,
+  select?: (title: string) => unknown,
+): Promise<{ result: GateResult; selectCalls: string[] }> {
+  const selectCalls: string[] = [];
+  const ctx = {
+    hasUI: true,
+    ui: {
+      // eslint-disable-next-line typescript/require-await
+      select: async (title: string) => {
+        selectCalls.push(title);
+        return select ? select(title) : undefined;
+      },
+    },
+  };
+  const handler = pi.handlers.tool_call[0] as ToolCallFn;
+  const result = await handler({ toolName, input }, ctx);
+  return { result, selectCalls };
+}
+
+describe("pi-permission-gate — toolset", () => {
+  it("restrictToTools intersects the visible toolset", () => {
+    setPolicy({ default: "ask", rules: [], restrictToTools: ["read", "grep"] });
+    const pi = makePi();
+    gate(pi);
+    expect(pi.active.sort()).toEqual(["grep", "read"]);
+  });
+
+  it("disabledTools is removed from the visible toolset and denied at call time", async () => {
+    setPolicy({ default: "allow", rules: [], disabledTools: ["bash"] });
+    const pi = makePi();
+    gate(pi);
+    expect(pi.active).not.toContain("bash");
+    const { result } = await call(pi, "bash", { command: "ls" });
+    expect(result).toMatchObject({ block: true });
+  });
+
+  it("re-applies the toolset on session_start", () => {
+    setPolicy({ default: "ask", rules: [], restrictToTools: ["read"] });
+    const pi = makePi();
+    gate(pi);
+    pi.active = ["read", "write", "bash"]; // simulate Pi re-registering tools
+    for (const fn of pi.handlers.session_start) fn();
+    expect(pi.active).toEqual(["read"]);
+  });
+});
+
+describe("pi-permission-gate — decisions", () => {
+  it("allow rule → runs (undefined)", async () => {
+    setPolicy({ default: "ask", rules: [{ tool: "read", action: "allow" }] });
+    const pi = makePi();
+    gate(pi);
+    const { result } = await call(pi, "read", { path: "/etc/hosts" });
+    expect(result).toBeUndefined();
+  });
+
+  it("deny rule → blocks with a reason", async () => {
+    setPolicy({ default: "ask", rules: [{ tool: "bash", pattern: "*rm -rf*", action: "deny" }] });
+    const pi = makePi();
+    gate(pi);
+    const { result } = await call(pi, "bash", { command: "x && rm -rf /" });
+    expect(result).toMatchObject({ block: true });
+  });
+
+  it("classify → allows a read-only bash command without asking", async () => {
+    setPolicy({ default: "ask", rules: [{ tool: "bash", action: "classify" }] });
+    const pi = makePi();
+    gate(pi);
+    const { result, selectCalls } = await call(pi, "bash", { command: "ls -la | grep foo" });
+    expect(result).toBeUndefined();
+    expect(selectCalls).toHaveLength(0);
+  });
+
+  it("classify → asks for a writing bash command", async () => {
+    setPolicy({ default: "ask", rules: [{ tool: "bash", action: "classify" }] });
+    const pi = makePi();
+    gate(pi);
+    const { result, selectCalls } = await call(pi, "bash", { command: "npm install" }, () =>
+      JSON.stringify({ verdict: "reject", feedback: "no" }),
+    );
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("no");
+    expect(selectCalls[0]).toStartWith("ALINEO_PERM ");
+  });
+
+  it("ask + allow-once → runs; ask + reject → blocks", async () => {
+    setPolicy({ default: "ask", rules: [] });
+    const pi = makePi();
+    gate(pi);
+    const ok = await call(pi, "write", { path: "/a" }, () =>
+      JSON.stringify({ verdict: "allow", scope: "once" }),
+    );
+    expect(ok.result).toBeUndefined();
+    const no = await call(pi, "write", { path: "/b" }, () => JSON.stringify({ verdict: "reject" }));
+    expect(no.result).toMatchObject({ block: true });
+  });
+
+  it("ask + allow-always → subsequent identical calls skip the prompt", async () => {
+    setPolicy({ default: "ask", rules: [] });
+    const pi = makePi();
+    gate(pi);
+    const first = await call(pi, "bash", { command: "make" }, () =>
+      JSON.stringify({ verdict: "allow", scope: "always" }),
+    );
+    expect(first.result).toBeUndefined();
+    const second = await call(pi, "bash", { command: "make" });
+    expect(second.result).toBeUndefined();
+    expect(second.selectCalls).toHaveLength(0);
+  });
+
+  it("cancelled/timed-out prompt (undefined) → blocks", async () => {
+    setPolicy({ default: "ask", rules: [] });
+    const pi = makePi();
+    gate(pi);
+    const { result } = await call(pi, "bash", { command: "make" }, () => undefined);
+    expect(result).toMatchObject({ block: true });
+  });
+
+  it("rate_limit → allows up to the ceiling, then blocks", async () => {
+    setPolicy({
+      default: "ask",
+      rules: [{ tool: "bash", action: "rate_limit", limit: { count: 2, windowMs: 10_000 } }],
+    });
+    const pi = makePi();
+    gate(pi);
+    expect((await call(pi, "bash", { command: "a" })).result).toBeUndefined();
+    expect((await call(pi, "bash", { command: "a" })).result).toBeUndefined();
+    expect((await call(pi, "bash", { command: "a" })).result).toMatchObject({ block: true });
+  });
+});

--- a/packages/agent/test/schema.test.ts
+++ b/packages/agent/test/schema.test.ts
@@ -167,6 +167,47 @@ describe("validateAgentSpec", () => {
     expect(() => validateAgentSpec({ name: "x", cli: "pi", env: { PORT: 3000 } })).toThrow(/env/);
   });
 
+  it("accepts a permissions mode shorthand", () => {
+    expect(validateAgentSpec({ name: "x", cli: "pi", permissions: "readonly" }).permissions).toBe(
+      "readonly",
+    );
+    expect(validateAgentSpec({ name: "x", cli: "pi", permissions: "ask" }).permissions).toBe("ask");
+  });
+
+  it("accepts a full permissions policy", () => {
+    const spec = validateAgentSpec({
+      name: "x",
+      cli: "pi",
+      permissions: {
+        default: "deny",
+        rules: [
+          { tool: "read", action: "allow" },
+          { tool: "bash", pattern: "git *", action: "ask" },
+          { tool: "bash", action: "rate_limit", limit: { count: 5, windowMs: 60000 } },
+        ],
+        disabledTools: ["powershell"],
+      },
+    });
+    expect(spec.permissions).toMatchObject({ default: "deny", disabledTools: ["powershell"] });
+  });
+
+  it("rejects an unknown permissions mode / action", () => {
+    expect(() => validateAgentSpec({ name: "x", cli: "pi", permissions: "yolo" })).toThrow(
+      /permissions/,
+    );
+    expect(() =>
+      validateAgentSpec({
+        name: "x",
+        cli: "pi",
+        permissions: { rules: [{ tool: "bash", action: "maybe" }] },
+      }),
+    ).toThrow(/permissions/);
+  });
+
+  it("leaves permissions undefined when omitted", () => {
+    expect(validateAgentSpec({ name: "x", cli: "pi" }).permissions).toBeUndefined();
+  });
+
   it("passes unknown top-level fields through untouched (forward-compat)", () => {
     const spec = validateAgentSpec({
       name: "x",

--- a/packages/agent/test/schema.test.ts
+++ b/packages/agent/test/schema.test.ts
@@ -183,12 +183,18 @@ describe("validateAgentSpec", () => {
         rules: [
           { tool: "read", action: "allow" },
           { tool: "bash", pattern: "git *", action: "ask" },
+          { tool: "bash", action: "classify" },
           { tool: "bash", action: "rate_limit", limit: { count: 5, windowMs: 60000 } },
         ],
         disabledTools: ["powershell"],
+        restrictToTools: ["read", "grep", "bash"],
       },
     });
-    expect(spec.permissions).toMatchObject({ default: "deny", disabledTools: ["powershell"] });
+    expect(spec.permissions).toMatchObject({
+      default: "deny",
+      disabledTools: ["powershell"],
+      restrictToTools: ["read", "grep", "bash"],
+    });
   });
 
   it("rejects an unknown permissions mode / action", () => {

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -12,5 +12,5 @@ export default defineConfig({
   // adapters/pi.ts) rather than bundled as a string — copy it alongside index.mjs
   // so that resolution works identically in dev (src/adapters/) and in the
   // published package (dist/).
-  copy: ["src/adapters/pi-bridge.js"],
+  copy: ["src/adapters/pi-bridge.js", "src/adapters/pi-permission-gate.js"],
 });

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -95,6 +95,20 @@ export enum LedgerEvent {
   /** Emitted by `sb.credentials.remove()`. */
   CredentialRevoked = "credential_revoked",
 
+  // ── Agent human-in-the-loop events (used by the `alineo` agent SDK) ──────────────
+  /**
+   * Emitted when the permission gate pauses a tool call for human approval. Payload is
+   * `{ requestId, tool, target }` — metadata only; the raw tool arguments (which can carry
+   * secrets in a bash command or a file write) are never written to the ledger.
+   */
+  PermissionRequested = "permission_requested",
+  /**
+   * Emitted when a `PermissionRequested` is answered — by a caller, a batched
+   * always/reject decision, a timeout, or a session resume dropping it. Payload is
+   * `{ requestId, decision }`.
+   */
+  PermissionResolved = "permission_resolved",
+
   // ── Workflow layer events (used by @alineo-labs/workflow) ────────────────────────
   /** Emitted once when a workflow run starts, before any steps execute. */
   RunStarted = "run_started",

--- a/tests/integration/human-in-the-loop.test.ts
+++ b/tests/integration/human-in-the-loop.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration test for the human-in-the-loop permission gate.
+ *
+ * Requires OpenSandbox running (alineo init or uvx opensandbox-server) and GEMINI_API_KEY
+ * (free tier — https://aistudio.google.com/apikey).
+ *
+ * Run: GEMINI_API_KEY=... bun test tests/integration/human-in-the-loop.test.ts --timeout 600000
+ */
+import { Alineo, type AgentEvent } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+import { afterAll, expect, test } from "bun:test";
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_API_KEY) {
+  throw new Error("GEMINI_API_KEY env var is required to run this test");
+}
+
+const BASE = {
+  $schema: "https://registry.alineo.tech/spec/agent.json",
+  cli: "pi" as const,
+  packages: [],
+  model: "gemini-flash-latest",
+  env: { GEMINI_API_KEY: "${GEMINI_API_KEY}" },
+  resources: { cpu: "1000m", memory: "2Gi" },
+};
+
+const agents: Alineo[] = [];
+afterAll(async () => {
+  for (const a of agents) await a.close();
+});
+
+async function load(spec: Record<string, unknown>): Promise<Alineo> {
+  const a = await Alineo.load(spec, { adapter: new SQLiteAdapter(":memory:") });
+  agents.push(a);
+  return a;
+}
+
+test(
+  "gated tool call emits permission_request and a reject blocks it",
+  async () => {
+    const agent = await load({
+      ...BASE,
+      name: "hitl-ask",
+      permissions: { default: "ask", rules: [{ tool: "read", action: "allow" }] },
+    });
+
+    const seen: AgentEvent["type"][] = [];
+    let denied = false;
+    for await (const ev of agent.prompt(
+      "Run this exact shell command and nothing else: echo permission-test > /tmp/hitl.txt",
+    )) {
+      seen.push(ev.type);
+      if (ev.type === "permission_request") {
+        expect(ev.tool).toBe("bash");
+        expect(ev.requestId).toBeTruthy();
+        await agent.resolvePermission(ev.requestId, {
+          kind: "reject",
+          feedback: "Do not write that file.",
+        });
+        denied = true;
+      }
+    }
+
+    expect(seen).toContain("permission_request");
+    expect(seen).toContain("permission_resolved");
+    expect(denied).toBe(true);
+
+    // The reject actually blocked the write.
+    const { stdout } = await agent.sandbox.exec("cat /tmp/hitl.txt 2>/dev/null || echo MISSING");
+    expect(stdout.trim()).toBe("MISSING");
+  },
+  600_000,
+);
+
+test(
+  "allow-once lets the call through",
+  async () => {
+    const agent = await load({ ...BASE, name: "hitl-allow", permissions: "ask" });
+
+    for await (const ev of agent.prompt(
+      "Run this exact shell command and nothing else: echo approved > /tmp/hitl-ok.txt",
+    )) {
+      if (ev.type === "permission_request") {
+        await agent.resolvePermission(ev.requestId, { kind: "once" });
+      }
+    }
+
+    const { stdout } = await agent.sandbox.exec("cat /tmp/hitl-ok.txt");
+    expect(stdout.trim()).toBe("approved");
+  },
+  600_000,
+);
+
+test(
+  "no permissions field → never emits permission_request (back-compat)",
+  async () => {
+    const agent = await load({ ...BASE, name: "hitl-auto" });
+
+    const seen: AgentEvent["type"][] = [];
+    for await (const ev of agent.prompt(
+      "Run this exact shell command and nothing else: echo auto > /tmp/hitl-auto.txt",
+    )) {
+      seen.push(ev.type);
+    }
+
+    expect(seen).not.toContain("permission_request");
+    const { stdout } = await agent.sandbox.exec("cat /tmp/hitl-auto.txt");
+    expect(stdout.trim()).toBe("auto");
+  },
+  600_000,
+);

--- a/tests/integration/human-in-the-loop.test.ts
+++ b/tests/integration/human-in-the-loop.test.ts
@@ -1,26 +1,28 @@
 /**
  * Integration test for the human-in-the-loop permission gate.
  *
- * Requires OpenSandbox running (alineo init or uvx opensandbox-server) and GEMINI_API_KEY
- * (free tier — https://aistudio.google.com/apikey).
+ * Requires OpenSandbox running (`bunx alineo-cli init` or `uvx opensandbox-server`) and
+ * NVIDIA_API_KEY (https://build.nvidia.com). Model: nvidia/nemotron-3-nano-30b-a3b —
+ * fast, reliable tool calls, and it adjusts after a deny-with-feedback.
  *
- * Run: GEMINI_API_KEY=... bun test tests/integration/human-in-the-loop.test.ts --timeout 600000
+ * Run: NVIDIA_API_KEY=... bun test tests/integration/human-in-the-loop.test.ts --timeout 600000
  */
-import { Alineo, type AgentEvent } from "alineo";
+import { Alineo, type AgentEvent, type PermissionRequest } from "alineo";
 import { SQLiteAdapter } from "@alineo-labs/sqlite";
 import { afterAll, expect, test } from "bun:test";
 
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
-if (!GEMINI_API_KEY) {
-  throw new Error("GEMINI_API_KEY env var is required to run this test");
+const NVIDIA_API_KEY = process.env.NVIDIA_API_KEY;
+if (!NVIDIA_API_KEY) {
+  throw new Error("NVIDIA_API_KEY env var is required to run this test");
 }
 
 const BASE = {
   $schema: "https://registry.alineo.tech/spec/agent.json",
   cli: "pi" as const,
-  packages: [],
-  model: "gemini-flash-latest",
-  env: { GEMINI_API_KEY: "${GEMINI_API_KEY}" },
+  packages: ["python3"],
+  provider: "nvidia",
+  model: "nvidia/nemotron-3-nano-30b-a3b",
+  env: { NVIDIA_API_KEY: "${NVIDIA_API_KEY}" },
   resources: { cpu: "1000m", memory: "2Gi" },
 };
 
@@ -29,26 +31,26 @@ afterAll(async () => {
   for (const a of agents) await a.close();
 });
 
-async function load(spec: Record<string, unknown>): Promise<Alineo> {
-  const a = await Alineo.load(spec, { adapter: new SQLiteAdapter(":memory:") });
-  agents.push(a);
-  return a;
+async function load(spec: Record<string, unknown>): Promise<{ agent: Alineo; adapter: SQLiteAdapter }> {
+  const adapter = new SQLiteAdapter(":memory:");
+  const agent = await Alineo.load(spec, { adapter });
+  agents.push(agent);
+  return { agent, adapter };
 }
 
+const runExact = (cmd: string) => `Run this exact shell command and nothing else: ${cmd}`;
+
 test(
-  "gated tool call emits permission_request and a reject blocks it",
+  "gated tool call emits permission_request; reject with feedback blocks the write",
   async () => {
-    const agent = await load({
+    const { agent } = await load({
       ...BASE,
       name: "hitl-ask",
       permissions: { default: "ask", rules: [{ tool: "read", action: "allow" }] },
     });
 
     const seen: AgentEvent["type"][] = [];
-    let denied = false;
-    for await (const ev of agent.prompt(
-      "Run this exact shell command and nothing else: echo permission-test > /tmp/hitl.txt",
-    )) {
+    for await (const ev of agent.prompt(runExact("echo permission-test > /tmp/hitl.txt"))) {
       seen.push(ev.type);
       if (ev.type === "permission_request") {
         expect(ev.tool).toBe("bash");
@@ -57,15 +59,12 @@ test(
           kind: "reject",
           feedback: "Do not write that file.",
         });
-        denied = true;
       }
     }
 
     expect(seen).toContain("permission_request");
     expect(seen).toContain("permission_resolved");
-    expect(denied).toBe(true);
 
-    // The reject actually blocked the write.
     const { stdout } = await agent.sandbox.exec("cat /tmp/hitl.txt 2>/dev/null || echo MISSING");
     expect(stdout.trim()).toBe("MISSING");
   },
@@ -75,11 +74,9 @@ test(
 test(
   "allow-once lets the call through",
   async () => {
-    const agent = await load({ ...BASE, name: "hitl-allow", permissions: "ask" });
+    const { agent } = await load({ ...BASE, name: "hitl-allow", permissions: "ask" });
 
-    for await (const ev of agent.prompt(
-      "Run this exact shell command and nothing else: echo approved > /tmp/hitl-ok.txt",
-    )) {
+    for await (const ev of agent.prompt(runExact("echo approved > /tmp/hitl-ok.txt"))) {
       if (ev.type === "permission_request") {
         await agent.resolvePermission(ev.requestId, { kind: "once" });
       }
@@ -92,14 +89,83 @@ test(
 );
 
 test(
-  "no permissions field → never emits permission_request (back-compat)",
+  "classify: a read-only bash command runs without a prompt",
   async () => {
-    const agent = await load({ ...BASE, name: "hitl-auto" });
+    const { agent } = await load({
+      ...BASE,
+      name: "hitl-classify",
+      permissions: { default: "ask", rules: [{ tool: "bash", action: "classify" }] },
+    });
+
+    const seen: AgentEvent["type"][] = [];
+    for await (const ev of agent.prompt(runExact("cat /etc/os-release"))) {
+      seen.push(ev.type);
+      if (ev.type === "permission_request") {
+        await agent.resolvePermission(ev.requestId, { kind: "reject" });
+      }
+    }
+    expect(seen).not.toContain("permission_request");
+  },
+  600_000,
+);
+
+test(
+  "onPermission handler auto-resolves, and the ledger records every decision",
+  async () => {
+    const { agent, adapter } = await load({ ...BASE, name: "hitl-onperm", permissions: "ask" });
+
+    const requests: PermissionRequest[] = [];
+    for await (const _ of agent.prompt(runExact("echo via-handler > /tmp/hitl-h.txt"), {
+      onPermission: (req) => {
+        requests.push(req);
+        return { kind: "once" };
+      },
+    })) {
+      void _;
+    }
+
+    expect(requests.length).toBeGreaterThan(0);
+    const { stdout } = await agent.sandbox.exec("cat /tmp/hitl-h.txt");
+    expect(stdout.trim()).toBe("via-handler");
+    expect(await agent.listPendingPermissions()).toHaveLength(0);
+
+    const events = await adapter.readAll(agent.name, agent.sandboxId);
+    const kinds = events.map((e) => e.event);
+    expect(kinds).toContain("permission_requested");
+    expect(kinds).toContain("permission_resolved");
+  },
+  600_000,
+);
+
+test(
+  'permissions: "readonly" removes write/bash from the toolset',
+  async () => {
+    const { agent } = await load({ ...BASE, name: "hitl-readonly", permissions: "readonly" });
 
     const seen: AgentEvent["type"][] = [];
     for await (const ev of agent.prompt(
-      "Run this exact shell command and nothing else: echo auto > /tmp/hitl-auto.txt",
+      "Create a file /tmp/ro.txt containing the word hello. If you cannot, say CANNOT.",
     )) {
+      seen.push(ev.type);
+      if (ev.type === "permission_request") {
+        await agent.resolvePermission(ev.requestId, { kind: "reject" });
+      }
+    }
+
+    const { stdout } = await agent.sandbox.exec("cat /tmp/ro.txt 2>/dev/null || echo MISSING");
+    expect(stdout.trim()).toBe("MISSING");
+    expect(seen).not.toContain("permission_request");
+  },
+  600_000,
+);
+
+test(
+  "no permissions field → never emits permission_request (back-compat)",
+  async () => {
+    const { agent } = await load({ ...BASE, name: "hitl-auto" });
+
+    const seen: AgentEvent["type"][] = [];
+    for await (const ev of agent.prompt(runExact("echo auto > /tmp/hitl-auto.txt"))) {
       seen.push(ev.type);
     }
 


### PR DESCRIPTION
## What

Adds a human-in-the-loop **permission gate** for sandboxed agents — the "pause and ask before this tool runs" primitive alineo didn't have (its HITL was live-attach only, never enforcement).

`AgentSpec.permissions` — a mode shorthand or a full policy:

```jsonc
// shorthand
"permissions": "readonly"   // "auto" (default) | "ask" | "readonly"

// or a full policy — ordered rules, last match wins
"permissions": {
  "default": "ask",
  "rules": [
    { "tool": "read", "action": "allow" },
    { "tool": "bash", "pattern": "git *", "action": "allow" },
    { "tool": "bash", "action": "classify" },
    { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" },
    { "tool": "bash", "action": "rate_limit", "limit": { "count": 20, "windowMs": 60000 } }
  ],
  "disabledTools": ["powershell"],
  "restrictToTools": ["read", "grep", "find", "ls", "bash"]
}
```

Gated calls surface as a `permission_request` event; resolve each with:

```ts
for await (const ev of agent.prompt("Refactor auth")) {
  if (ev.type === "permission_request") {
    await agent.resolvePermission(ev.requestId, { kind: "once" });
    // or { kind: "always" } | { kind: "reject", feedback: "use the migration script" }
  }
}

// …or let a handler do it:
agent.prompt("Refactor auth", { onPermission: (req) => decide(req) });
```

## How

- **Enforcement** is a bundled Pi extension (`pi-permission-gate.js`), loaded via `-e` **only when a policy is set**. It runs on Pi's `tool_call` hook, evaluates the policy, and for an `ask` call blocks on `ctx.ui.select()` with a marker-prefixed title. On `session_start` it applies `restrictToTools` / `disabledTools` through Pi's `setActiveTools`, so the model never sees a tool it may not use (deny-rule backstop kept for tools registered later).
- **`pi-bridge.js`** recognises that marker, holds the dialog open, forwards it to the host as `permission_request`, and answers it on `POST /permission-response`. `always`/`reject` batch-clear other pending requests for the same tool (opencode semantics); `/abort` auto-rejects all pending. `GET /pending-permissions` lists what's outstanding; `/permission-stream` replays those on connect and suspends the auto-deny timeout while an operator is attached.
- **`classify`** does a conservative read-vs-write triage of a `bash` command (split on `&&`/`||`/`;`/`|`, checked against a safe-reader list) — read-only → allow, else ask. `"readonly"` restricts the toolset to the read tools and classifies any `bash` left reachable.
- **Ledger audit** — every request/resolution is written as `permission_requested` / `permission_resolved` (`@alineo-labs/core`, metadata only, never raw tool args). `Alineo.resume()` closes out approvals dropped when the old Pi process ended.
- **Denied calls** come back to the model as a normal `isError` tool result with the reason — so it adjusts instead of retrying blindly (opencode's `CorrectedError`, for free — verified against Pi source).
- `permissions.ts` holds the host-side matcher (unit-tested); the gate `.js` mirrors it inline because a jiti-loaded extension can't import the published package (same tradeoff `pi-bridge.js` already makes).
- **No `--no-extensions`** — a user's own `settings.json` / `.pi/extensions/` extensions still load and *cannot* bypass the gate (Pi runs `tool_call` hooks first-block-wins; there is no "force allow" return).

## Commits

1. **`b48664b`** — the core gate (Phase 1) + dashboard wiring (Phase 2) + example + integration test.
2. **`6ff0758`** — follow-up, from a survey of Mastra / eve / LangGraph / OpenAI Agents SDK / CrewAI HITL and OpenSandbox/Pi source:
   - ledger audit (`@alineo-labs/core` `LedgerEvent` additions) + `resume()` reconcile
   - `classify` action + `isReadOnlyBashCommand`; `restrictToTools`; `setActiveTools`-backed toolset control
   - `/pending-permissions`, `/permission-stream` replay + timeout suspension, `agent.listPendingPermissions()`
   - `prompt(msg, { onPermission })`
   - `test/pi-permission-gate.test.ts` + `test/pi-bridge.test.ts` (real bridge driven against a stub `pi`)

## Scope

| | |
|---|---|
| **Phase 1 — core gate** | ✅ |
| **Phase 2 — dashboard** | ✅ approval card + `resolvePermission` in `apps/sandbox` chat. Live "permissions mode" dropdown deferred |
| **Phase 3 — durable pauses** | partial — ledger audit + host-restart resilience ✅ (`emit` turned out to be public). Full durability across `sb.pause()` / checkpoint is blocked on OpenSandbox being rootfs-only (no CRIU) + Pi's `tool_call` hook not being resumable — needs an upstream Pi change |
| **Phase 4 — proxy enforcement tier** | deferred — no native request-hold, but buildable on `OPENSANDBOX_EGRESS_DENY_WEBHOOK` + dynamic `NetworkPolicy` + Credential Vault for the credential-bound egress subset |
| **`@alineo-labs/workflow` `.approvalGate()`, bridge-trust bearer token, docs page** | deferred — tracked in `plans/human-in-the-loop.md` |

Enforcement is in-process (Pi's hook) — it stops a misbehaving model, not a process with shell access inside the sandbox actively defeating the gate. That's Phase 4's job.

## Behaviour change

None by default. No `permissions` field (or `"auto"`) → no gate loaded, identical to today.

## Test plan

- `bun run lint` / `typecheck` / `build` — all pass. `apps/sandbox` `astro check` + server `tsc` pass. `bunx changeset status` — `alineo` + `@alineo-labs/core` at minor. Docs epoch check green. CodeQL green.
- `packages/agent` unit tests: 106 pass (10 files) — the matcher (`permissions.test.ts`, +`classify` / `isReadOnlyBashCommand` / `restrictToTools`), `schema.test.ts`, `pi-permission-gate.test.ts` (toolset control + every decision branch), `pi-bridge.test.ts` (bridge protocol against a stub `pi`).
- **Verified live** against a local OpenSandbox (`bunx alineo-cli init`) + `nvidia/nemotron-3-nano-30b-a3b`:
  - `examples/human-in-the-loop/` — the scripted walkthrough runs end to end (readonly toolset restriction, classify auto-allow, `onPermission`, deny-with-feedback, hard deny, `listPendingPermissions()`, ledger audit).
  - `tests/integration/human-in-the-loop.test.ts` — 6/6 pass (~108s). Switched from Gemini to NVIDIA; not run in CI (no workflow runs integration tests).

Design write-up + research findings: `plans/human-in-the-loop.md` (local, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RRFCYN29pb1krnK2Wzb3h

