### PR TITLE
feat(egress): CIDR targets, runtime egress policy, substitution injection, approve-on-egress hold

### DIFF
--- a/.changeset/credential-substitution-injection.md
+++ b/.changeset/credential-substitution-injection.md
@@ -1,0 +1,28 @@
+---
+"@alineo-labs/core": minor
+"@alineo-labs/vault": minor
+"alineo": minor
+---
+
+Credential injection: replace the placeholder `query` / `path` shapes with a working
+`substitution` type.
+
+`CredentialBinding.injection` (and `AgentSpec.env`'s `CredentialEnvBinding.injection`) is now:
+
+```ts
+| { type: "header"; name: string }
+| { type: "substitution"; placeholder: string; in: Array<"path" | "query" | "header" | "body"> }
+```
+
+`substitution` maps onto the egress sidecar's real `passthrough` + `substitutions` auth model:
+the sidecar replaces every literal occurrence of `placeholder` in the listed request surfaces
+with the credential value. **The outbound request must already contain `placeholder` verbatim**
+— put it in a base URL, e.g. `https://api.example.com/v1?key=__API_KEY__`. `header` injection
+is unchanged and stays the recommended default.
+
+**Migration** — the old `{ type: "query"; param }` / `{ type: "path"; segment }` shapes are
+removed (they only ever threw `UnsupportedInjectionError`). Replace
+`{ type: "query"; param: "k" }` with `{ type: "substitution"; placeholder: "__CRED__"; in: ["query"] }`
+and add `?k=__CRED__` to the request. `sb.credentials.listBindings()` is lossy for
+substitution bindings (the vault does not echo `substitutions` back) — `resume()` / `fork()`
+recover the full shape from the ledger instead.

--- a/.changeset/egress-approval-hold.md
+++ b/.changeset/egress-approval-hold.md
@@ -6,16 +6,20 @@
 Approve-on-egress hold for agents: `approval: "hold"` on a credential env binding.
 
 A `CredentialEnvBinding` in `AgentSpec.env` can now carry `approval: "hold"`. The agent's
-sandbox starts with that host **denied** at the egress sidecar (everything else, including the
-agent's own model traffic, keeps working); the first outbound request to it pauses and calls
-the `onEgressRequest` handler you pass to `Alineo.load()`, which returns `"allow-once"`
-(reverted when the turn ends), `"allow-always"` (permanent for the agent's life), or
-`"deny"`. Enforcement is entirely out-of-process at the sidecar — a compromised in-sandbox
-agent cannot skip it.
+sandbox starts with that host **denied** at the egress sidecar and the credential **not
+registered in the vault at all** (the vault refuses a binding whose host isn't allowed);
+everything else, including the agent's own model traffic, keeps working. The first outbound
+request to the held host pauses and calls the `onEgressRequest` handler you pass to
+`Alineo.load()`, which returns `"allow-once"` (reversed when the turn ends), `"allow-always"`
+(permanent for the agent's life), or `"deny"`. Only on approval does the gate open the egress
+rule and *then* register the credential — so the secret literally does not exist inside the
+sandbox until a human approves. Enforcement is entirely out-of-process at the sidecar — a
+compromised in-sandbox agent cannot skip it.
 
 - New `EgressApprovalGate` (exported from `alineo`): a small host-side listener for the
-  sidecar's deny webhook that flips the rule via `sb.egress.patch()` on approval. `Alineo`
-  starts one automatically for `hold` bindings and stops it on `close()`;
+  sidecar's deny webhook that, on approval, calls `sb.egress.patch()` then
+  `sb.credentials.set()` (and reverses both on an `allow-once` at turn end). `Alineo` starts
+  one automatically for `hold` bindings and stops it on `close()`;
   `agent.pendingEgressRequests()` lists what is waiting. `agent.egressGate` is exposed for
   direct control. Ledger: `PermissionRequested` / `PermissionResolved` with `tool: "network"`.
 - The webhook host defaults to the Docker bridge gateway (`172.17.0.1`); override via

--- a/.changeset/egress-approval-hold.md
+++ b/.changeset/egress-approval-hold.md
@@ -1,0 +1,29 @@
+---
+"alineo": minor
+"@alineo-labs/sandbox": minor
+---
+
+Approve-on-egress hold for agents: `approval: "hold"` on a credential env binding.
+
+A `CredentialEnvBinding` in `AgentSpec.env` can now carry `approval: "hold"`. The agent's
+sandbox starts with that host **denied** at the egress sidecar (everything else, including the
+agent's own model traffic, keeps working); the first outbound request to it pauses and calls
+the `onEgressRequest` handler you pass to `Alineo.load()`, which returns `"allow-once"`
+(reverted when the turn ends), `"allow-always"` (permanent for the agent's life), or
+`"deny"`. Enforcement is entirely out-of-process at the sidecar — a compromised in-sandbox
+agent cannot skip it.
+
+- New `EgressApprovalGate` (exported from `alineo`): a small host-side listener for the
+  sidecar's deny webhook that flips the rule via `sb.egress.patch()` on approval. `Alineo`
+  starts one automatically for `hold` bindings and stops it on `close()`;
+  `agent.pendingEgressRequests()` lists what is waiting. `agent.egressGate` is exposed for
+  direct control. Ledger: `PermissionRequested` / `PermissionResolved` with `tool: "network"`.
+- The webhook host defaults to the Docker bridge gateway (`172.17.0.1`); override via
+  `ALINEO_EGRESS_APPROVAL_HOST` for other topologies.
+- `@alineo-labs/sandbox`: `restoreSnapshot()` gains an `env` option (for re-supplying
+  `OPENSANDBOX_EGRESS_*` sidecar vars on a restore — the sidecar is not snapshotted).
+
+Deferred: the deny-webhook signal is not yet unified into the Pi tool-permission stream (so
+network approvals do not appear in `listPendingPermissions()` alongside tool permissions or
+in the chat UI), and there is no automatic re-run of the request that hit the denial — the
+model retries on its own (the retry window is effectively instant). Both are follow-ups.

--- a/.changeset/egress-policy.md
+++ b/.changeset/egress-policy.md
@@ -1,0 +1,21 @@
+---
+"@alineo-labs/opensandbox": minor
+"@alineo-labs/core": minor
+"@alineo-labs/sandbox": minor
+---
+
+Egress network policy: CIDR/IP targets, and runtime policy changes on a live sandbox.
+
+- **`NetworkRule.target` now documents (and the SDK validates) IP and CIDR targets** —
+  `"10.0.0.5"`, `"10.0.0.0/8"`, plus IPv6 — alongside FQDNs and `*.` wildcards. IP/CIDR rules
+  are enforced at the nftables layer (so they need `egress.mode = "dns+nft"`) and gate raw-IP
+  egress only, not name resolution. A malformed `networkPolicy` target now throws
+  `SandboxClientError` locally instead of failing on a server round-trip
+  (`isValidEgressTarget` is exported from `@alineo-labs/opensandbox`).
+- **`sb.egress.patch(rules)` / `sb.egress.delete(targets)` / `sb.egress.get()`** adjust a
+  running sandbox's egress policy through its sidecar — merge in allow/deny rules (an incoming
+  rule replaces any rule with the same `target`) or remove them by target. Changes apply
+  immediately and are recorded to the ledger (`EgressRuleAdded` / `EgressRuleRemoved`), so
+  `Sandbox.resume()` re-applies a still-wanted allowance — egress policy is sidecar-local and
+  does not survive a resume on its own. New `EgressClient` in `@alineo-labs/opensandbox` and
+  `reconstructEgressRules` in `@alineo-labs/core`.

--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
     },
     "cookbooks/ai-agent-bugfix": {
       "name": "alineo-cookbook-ai-agent-bugfix",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@alineo-labs/opensandbox": "workspace:*",
         "@alineo-labs/sandbox": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "cookbooks/ci-test-runner": {
       "name": "alineo-cookbook-ci-test-runner",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -101,7 +101,7 @@
     },
     "cookbooks/credential-scoped-agent": {
       "name": "alineo-cookbook-credential-scoped-agent",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -110,7 +110,7 @@
     },
     "cookbooks/parallel-test-shards": {
       "name": "alineo-cookbook-parallel-test-shards",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -118,7 +118,7 @@
     },
     "cookbooks/persistent-agent-memory": {
       "name": "alineo-cookbook-persistent-agent-memory",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/memory": "workspace:*",
@@ -130,7 +130,7 @@
     },
     "cookbooks/resumable-etl-pipeline": {
       "name": "alineo-cookbook-resumable-etl-pipeline",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -138,15 +138,23 @@
     },
     "cookbooks/untrusted-code-execution": {
       "name": "alineo-cookbook-untrusted-code-execution",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
       },
     },
+    "examples/agent-egress-approval": {
+      "name": "alineo-example-agent-egress-approval",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
     "examples/benchmark": {
       "name": "alineo-example-benchmark",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -154,7 +162,7 @@
     },
     "examples/cancellation": {
       "name": "alineo-example-cancellation",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -162,7 +170,7 @@
     },
     "examples/capture": {
       "name": "alineo-example-capture",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -170,7 +178,7 @@
     },
     "examples/control-flow": {
       "name": "alineo-example-control-flow",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -179,7 +187,7 @@
     },
     "examples/credential-injection": {
       "name": "alineo-example-credential-injection",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -187,7 +195,7 @@
     },
     "examples/environments": {
       "name": "alineo-example-environments",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -195,7 +203,7 @@
     },
     "examples/error-handling": {
       "name": "alineo-example-error-handling",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -203,7 +211,7 @@
     },
     "examples/exec-code": {
       "name": "alineo-example-exec-code",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -211,7 +219,7 @@
     },
     "examples/file-ops": {
       "name": "alineo-example-file-ops",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -219,15 +227,23 @@
     },
     "examples/hello-world": {
       "name": "alineo-example-hello-world",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
       },
     },
+    "examples/human-in-the-loop": {
+      "name": "alineo-example-human-in-the-loop",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sqlite": "workspace:*",
+        "alineo": "workspace:*",
+      },
+    },
     "examples/interactive-exec": {
       "name": "alineo-example-interactive-exec",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -235,16 +251,24 @@
     },
     "examples/memory-basics": {
       "name": "alineo-example-memory-basics",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/memory": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
       },
     },
+    "examples/network-egress": {
+      "name": "alineo-example-network-egress",
+      "version": "0.0.1",
+      "dependencies": {
+        "@alineo-labs/sandbox": "workspace:*",
+        "@alineo-labs/sqlite": "workspace:*",
+      },
+    },
     "examples/pi-agent": {
       "name": "alineo-example-pi-agent",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/opensandbox": "workspace:*",
         "@alineo-labs/sandbox": "workspace:*",
@@ -254,7 +278,7 @@
     },
     "examples/ports": {
       "name": "alineo-example-ports",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -262,7 +286,7 @@
     },
     "examples/read-file": {
       "name": "alineo-example-read-file",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -270,7 +294,7 @@
     },
     "examples/rlm-repo-fanout": {
       "name": "alineo-example-rlm-repo-fanout",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -279,7 +303,7 @@
     },
     "examples/run-bash-script": {
       "name": "alineo-example-run-bash-script",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -287,7 +311,7 @@
     },
     "examples/sandbox-extensions": {
       "name": "alineo-example-sandbox-extensions",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -296,7 +320,7 @@
     },
     "examples/sandbox-fork": {
       "name": "alineo-example-sandbox-fork",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -304,7 +328,7 @@
     },
     "examples/snapshot-replay": {
       "name": "alineo-example-snapshot-replay",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -312,7 +336,7 @@
     },
     "packages/adapters/flue": {
       "name": "@alineo-labs/flue",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@flue/runtime": "1.0.0-beta.9",
@@ -327,7 +351,7 @@
     },
     "packages/adapters/otel": {
       "name": "@alineo-labs/otel",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -343,7 +367,7 @@
     },
     "packages/adapters/postgres": {
       "name": "@alineo-labs/postgres",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "postgres": "3.4.9",
@@ -356,7 +380,7 @@
     },
     "packages/adapters/postgres-memory": {
       "name": "@alineo-labs/postgres-memory",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@alineo-labs/memory": "workspace:*",
         "postgres": "3.4.9",
@@ -369,7 +393,7 @@
     },
     "packages/adapters/sqlite": {
       "name": "@alineo-labs/sqlite",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -381,7 +405,7 @@
     },
     "packages/adapters/sqlite-memory": {
       "name": "@alineo-labs/sqlite-memory",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@alineo-labs/memory": "workspace:*",
         "sqlite-vec": "^0.1.9",
@@ -394,7 +418,7 @@
     },
     "packages/adapters/vault": {
       "name": "@alineo-labs/vault",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/opensandbox": "workspace:*",
@@ -407,7 +431,7 @@
     },
     "packages/agent": {
       "name": "alineo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/memory": "workspace:*",
@@ -422,7 +446,7 @@
     },
     "packages/agent-browser": {
       "name": "@alineo-labs/agent-browser",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -435,7 +459,7 @@
     },
     "packages/cli": {
       "name": "alineo-cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "alineo": "./dist/index.mjs",
       },
@@ -455,7 +479,7 @@
     },
     "packages/core": {
       "name": "@alineo-labs/core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@alineo-labs/opensandbox": "workspace:*",
       },
@@ -468,7 +492,7 @@
     },
     "packages/harness": {
       "name": "@alineo-labs/harness",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "bun-types": "1.3.14",
         "typescript": "6.0.3",
@@ -476,7 +500,7 @@
     },
     "packages/memory": {
       "name": "@alineo-labs/memory",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -489,7 +513,7 @@
     },
     "packages/model-providers": {
       "name": "@alineo-labs/model-providers",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ai-sdk/google": "^4.0.50",
         "@ai-sdk/groq": "^4.0.30",
@@ -503,7 +527,7 @@
     },
     "packages/opensandbox": {
       "name": "@alineo-labs/opensandbox",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "bun-types": "1.3.14",
         "tsdown": "0.22.3",
@@ -513,7 +537,7 @@
     },
     "packages/sdks/typescript": {
       "name": "@alineo-labs/sandbox",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/opensandbox": "workspace:*",
@@ -528,7 +552,7 @@
     },
     "packages/workflow": {
       "name": "@alineo-labs/workflow",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
       },
@@ -541,7 +565,7 @@
     },
     "tests/integration": {
       "name": "@alineo-labs/integration-tests",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -1581,6 +1605,8 @@
 
     "alineo-cookbook-untrusted-code-execution": ["alineo-cookbook-untrusted-code-execution@workspace:cookbooks/untrusted-code-execution"],
 
+    "alineo-example-agent-egress-approval": ["alineo-example-agent-egress-approval@workspace:examples/agent-egress-approval"],
+
     "alineo-example-benchmark": ["alineo-example-benchmark@workspace:examples/benchmark"],
 
     "alineo-example-cancellation": ["alineo-example-cancellation@workspace:examples/cancellation"],
@@ -1601,9 +1627,13 @@
 
     "alineo-example-hello-world": ["alineo-example-hello-world@workspace:examples/hello-world"],
 
+    "alineo-example-human-in-the-loop": ["alineo-example-human-in-the-loop@workspace:examples/human-in-the-loop"],
+
     "alineo-example-interactive-exec": ["alineo-example-interactive-exec@workspace:examples/interactive-exec"],
 
     "alineo-example-memory-basics": ["alineo-example-memory-basics@workspace:examples/memory-basics"],
+
+    "alineo-example-network-egress": ["alineo-example-network-egress@workspace:examples/network-egress"],
 
     "alineo-example-pi-agent": ["alineo-example-pi-agent@workspace:examples/pi-agent"],
 

--- a/cookbooks/credential-scoped-agent/README.md
+++ b/cookbooks/credential-scoped-agent/README.md
@@ -83,5 +83,7 @@ That only matters for `resume()` / `fork()` (which would then need an explicit
 comes up. Use a bare `${GH_TOKEN}` (and a token that already includes its scheme) if you want
 env-based auto-resolution.
 
-Header injection is currently the only supported `injection` type — `query` and `path` bindings
-are defined in the types but not yet wired to the sidecar's auth model.
+Two `injection` types are supported: `{ type: "header", name }` (the common case, shown above)
+and `{ type: "substitution", placeholder, in }`, which replaces a literal placeholder string
+in the request's path/query/header/body with the value — use it for APIs that take the key in
+the URL. The request must already contain the placeholder verbatim (e.g. put it in a base URL).

--- a/examples/agent-egress-approval/README.md
+++ b/examples/agent-egress-approval/README.md
@@ -8,7 +8,8 @@ an operator approves it — `AgentSpec.env` `approval: "hold"` + `Alineo.load({ 
 ```bash
 bunx alineo-cli init   # starts OpenSandbox in Docker (one-time), with egress.mode = "dns+nft"
 export NVIDIA_API_KEY=...
-export GITHUB_TOKEN=...   # optional — the demo works without one (the request just 401s)
+export GITHUB_TOKEN=...   # optional — without it, approval still opens the host but no
+                         # credential is injected, so the request goes out unauthenticated (401)
 ```
 
 ## Run

--- a/examples/agent-egress-approval/README.md
+++ b/examples/agent-egress-approval/README.md
@@ -1,0 +1,46 @@
+# agent-egress-approval
+
+A Pi agent whose outbound access to `api.github.com` is **held at the egress sidecar** until
+an operator approves it — `AgentSpec.env` `approval: "hold"` + `Alineo.load({ onEgressRequest })`.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time), with egress.mode = "dns+nft"
+export NVIDIA_API_KEY=...
+export GITHUB_TOKEN=...   # optional — the demo works without one (the request just 401s)
+```
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it shows
+
+`agents/egress-agent.json` binds `GITHUB_TOKEN` to `api.github.com` with header injection **and**
+`"approval": "hold"`. On `Alineo.load()`:
+
+1. The sandbox is created `defaultAction: "allow"` with a single `deny` rule for
+   `api.github.com` — everything else (npm, the model API, …) works normally.
+2. A small host-side listener is started for the sidecar's deny webhook. `Alineo` stops it on
+   `close()`.
+3. The agent runs a `curl` to `api.github.com`. The sidecar denies the DNS query, POSTs the
+   webhook, and `onEgressRequest({ host: "api.github.com" })` is called — this example returns
+   `"allow-once"` (also available: `"allow-always"`, `"deny"`).
+4. The listener flips the rule to `allow` via `sb.egress.patch()`. The retried request now
+   resolves, and the sidecar injects the real `GITHUB_TOKEN` into it — the sandbox process
+   never held the token.
+5. `"allow-once"` is reverted to `deny` when the turn ends.
+6. The ledger has `permission_requested` / `permission_resolved` rows (`tool: "network"`) for
+   the audit trail. `agent.pendingEgressRequests()` reports anything still waiting.
+
+The webhook host defaults to the Docker bridge gateway (`172.17.0.1`); set
+`ALINEO_EGRESS_APPROVAL_HOST` for other topologies.
+
+## Notes
+
+Enforcement is entirely out-of-process at the egress sidecar — a compromised in-sandbox agent
+cannot reach a held host until a human approves, regardless of what it does inside the sandbox.

--- a/examples/agent-egress-approval/agents/egress-agent.json
+++ b/examples/agent-egress-approval/agents/egress-agent.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://registry.alineo.tech/spec/agent.json",
+  "name": "egress-approval-agent",
+  "title": "Egress-approval Agent",
+  "description": "A Pi agent whose outbound access to api.github.com is held at the egress sidecar until an operator approves it. Demonstrates AgentSpec.env approval: \"hold\", Alineo.load({ onEgressRequest }), and pendingEgressRequests().",
+  "author": "alineo",
+  "cli": "pi",
+  "provider": "nvidia",
+  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "packages": ["curl"],
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}",
+    "GITHUB_TOKEN": {
+      "credential": "${GITHUB_TOKEN}",
+      "host": "api.github.com",
+      "injection": { "type": "header", "name": "Authorization" },
+      "approval": "hold"
+    }
+  },
+  "resources": { "cpu": "1000m", "memory": "2Gi" }
+}

--- a/examples/agent-egress-approval/index.ts
+++ b/examples/agent-egress-approval/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Approve-on-egress hold — a Pi agent whose reach to `api.github.com` is gated behind an
+ * operator decision.
+ *
+ * The `GITHUB_TOKEN` binding in `agents/egress-agent.json` has `approval: "hold"`, so:
+ *   - the agent's sandbox starts with `api.github.com` denied at the egress sidecar (every
+ *     other host — including the model API — still works);
+ *   - the first time the agent tries to reach it, the request pauses and `onEgressRequest`
+ *     is called on the host;
+ *   - only on `"allow-once"` / `"allow-always"` does the sidecar's rule flip to allow, and
+ *     the (also transparently injected) `GITHUB_TOKEN` credential goes out with the request.
+ *
+ * Enforcement is entirely out-of-process at the sidecar — a compromised in-sandbox agent
+ * cannot skip it.
+ *
+ * Run: `cd examples/agent-egress-approval && bun install && bun start`
+ * Needs: OpenSandbox running (`bunx alineo-cli init`, with `egress.mode = "dns+nft"`), a
+ * `NVIDIA_API_KEY`, and optionally a real `GITHUB_TOKEN` (the demo works without one — the
+ * request just comes back 401).
+ */
+import { Alineo, type EgressRequest, type EgressDecision } from "alineo";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const adapter = new SQLiteAdapter("./.alineo/ledger.db");
+const rule = (s: string) => console.log(`\n${"─".repeat(72)}\n${s}\n${"─".repeat(72)}`);
+
+/** The operator: allow GitHub once, refuse everything else. */
+async function onEgressRequest(req: EgressRequest): Promise<EgressDecision> {
+  const decision: EgressDecision = req.host === "api.github.com" ? "allow-once" : "deny";
+  console.log(`\n  ⏸  egress approval needed — ${req.host}  →  ${decision}`);
+  return decision;
+}
+
+rule('1 · load the agent — api.github.com starts denied (approval: "hold")');
+const agent = await Alineo.load(await Bun.file("./agents/egress-agent.json").json(), {
+  adapter,
+  onEgressRequest,
+});
+
+try {
+  rule("2 · ask it to call the GitHub API — the request pauses for approval, then succeeds");
+  console.log('prompt: "curl -s -o /dev/null -w \'%{http_code}\' https://api.github.com/user"\n');
+  process.stdout.write("> ");
+  for await (const ev of agent.prompt(
+    "Run exactly this shell command and report only its output: " +
+      "curl -s -o /dev/null -w '%{http_code}' https://api.github.com/user",
+  )) {
+    if (ev.type === "text") process.stdout.write(ev.text);
+    else if (ev.type === "tool_start") process.stdout.write(`\n[tool: ${ev.toolName}]\n`);
+  }
+
+  rule("3 · the ledger audit trail — every egress request + resolution");
+  const entries = await adapter.readAll(agent.name, agent.sandboxId);
+  for (const e of entries) {
+    if (e.event === "permission_requested" || e.event === "permission_resolved") {
+      console.log(`  ${e.event.padEnd(22)} ${JSON.stringify(e.payload)}`);
+    }
+  }
+} finally {
+  await agent.close(); // also stops the egress-approval listener
+}

--- a/examples/agent-egress-approval/index.ts
+++ b/examples/agent-egress-approval/index.ts
@@ -39,7 +39,7 @@ const agent = await Alineo.load(await Bun.file("./agents/egress-agent.json").jso
 
 try {
   rule("2 · ask it to call the GitHub API — the request pauses for approval, then succeeds");
-  console.log('prompt: "curl -s -o /dev/null -w \'%{http_code}\' https://api.github.com/user"\n');
+  console.log("prompt: \"curl -s -o /dev/null -w '%{http_code}' https://api.github.com/user\"\n");
   process.stdout.write("> ");
   for await (const ev of agent.prompt(
     "Run exactly this shell command and report only its output: " +

--- a/examples/agent-egress-approval/package.json
+++ b/examples/agent-egress-approval/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-example-agent-egress-approval",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sqlite": "workspace:*",
+    "alineo": "workspace:*"
+  }
+}

--- a/examples/credential-injection/README.md
+++ b/examples/credential-injection/README.md
@@ -48,6 +48,9 @@ GH_TOKEN=ghp_xxx bun start
 4. Forks the sandbox and repeats the same request from the child — the bound credential carries
    over automatically, no re-registration needed.
 5. Calls `sb.credentials.remove()` and repeats the request once more, now unauthenticated.
+6. Registers a second credential with `injection: { type: "substitution", placeholder, in }` and
+   shows a placeholder in the request URL (`?api_key=__TOKEN__`) get swapped for the real value
+   at the sidecar — for APIs that take a key in the query string rather than a header.
 
 ## Notes
 
@@ -61,8 +64,13 @@ carrying all work as described above. `@alineo-labs/vault`'s wire protocol was c
 OpenSandbox's actual Go source (`components/egress/pkg/credentialvault`) during that
 verification — see plans/credential-injection.md's addendum for what changed and why.
 
-Two known limitations, both from the real Credential Vault API rather than this package:
-only `{ type: "header" }` credential bindings are supported (`query`/`path` injection has no
-direct equivalent in the sidecar's `Auth` model — see `UnsupportedInjectionError`), and
-`OpenSandboxCredentialBroker.patch()` requires both `value` and `binding` together (the vault
-never echoes a credential's value back, so a partial update can't preserve the unspecified half).
+Two `injection` types are supported: `{ type: "header", name }` and
+`{ type: "substitution", placeholder, in }` (the sidecar swaps a literal placeholder the
+request already contains — in the path, query, a header, or the body — for the value; use it
+for APIs that take a key in the URL). `sb.credentials.listBindings()` is lossy for substitution
+bindings (the vault doesn't echo the placeholder back) — `resume()`/`fork()` recover the full
+shape from the ledger.
+
+One known limitation from the real Credential Vault API: `OpenSandboxCredentialBroker.patch()`
+requires both `value` and `binding` together — the vault never echoes a credential's value
+back, so a partial update can't preserve the unspecified half.

--- a/examples/credential-injection/index.ts
+++ b/examples/credential-injection/index.ts
@@ -85,7 +85,7 @@ try {
   // just less visible there).
   await new Promise((r) => setTimeout(r, 1500));
   await sb
-    .exec("curl -s 'https://httpbin.org/get?api_key=__TOKEN__' | grep -o '\"api_key\": \"[^\"]*\"'")
+    .exec('curl -s \'https://httpbin.org/get?api_key=__TOKEN__\' | grep -o \'"api_key": "[^"]*"\'')
     .pipe(process.stdout);
 
   // ── Part 3: fork() carries bound credentials to the child automatically ────

--- a/examples/credential-injection/index.ts
+++ b/examples/credential-injection/index.ts
@@ -69,9 +69,38 @@ try {
     .exec('curl -s -o /dev/null -w "HTTP %{http_code}\\n" https://api.github.com/user')
     .pipe(process.stdout);
 
-  // ── Part 2: fork() carries bound credentials to the child automatically ────
+  // ── Part 2: substitution injection (a key in the URL, not a header) ───────
+  //
+  // Some APIs only take a key in the query string. `{ type: "substitution" }` replaces a
+  // literal placeholder — which the request must already contain — with the real value at
+  // the sidecar. Here the placeholder rides in the URL; httpbin.org/get echoes the args back,
+  // so `"api_key": "s3cr3t-substituted-value"` proves the swap happened on the wire.
+  console.log("\n--- substitution injection: __TOKEN__ in the URL is swapped for the value ---");
+  await sb.credentials.set("echo-key", "s3cr3t-substituted-value", {
+    host: "httpbin.org",
+    injection: { type: "substitution", placeholder: "__TOKEN__", in: ["query"] },
+  });
+  // The sidecar's mitm addon caches the credential vault for ~0.5s — give a just-registered
+  // binding a beat to go live before relying on it (applies to header injection too; it's
+  // just less visible there).
+  await new Promise((r) => setTimeout(r, 1500));
+  await sb
+    .exec("curl -s 'https://httpbin.org/get?api_key=__TOKEN__' | grep -o '\"api_key\": \"[^\"]*\"'")
+    .pipe(process.stdout);
+
+  // ── Part 3: fork() carries bound credentials to the child automatically ────
   console.log("\n--- forking: the child inherits the 'github' credential too ---");
-  const child = await sb.fork("before-fork");
+  // `resolveCredential` re-supplies each bound credential's value on the child. A real
+  // GH_TOKEN in the environment makes the `github` binding's `{ type: "env" }` source
+  // auto-resolve; the `echo-key` binding has no source, so the callback is what carries it.
+  const child = await sb.fork("before-fork", undefined, {
+    resolveCredential: (name) =>
+      name === "github"
+        ? githubToken
+        : name === "echo-key"
+          ? "s3cr3t-substituted-value"
+          : undefined,
+  });
   try {
     await child
       .exec('curl -s -o /dev/null -w "HTTP %{http_code}\\n" https://api.github.com/user')
@@ -80,7 +109,7 @@ try {
     await child.close();
   }
 
-  // ── Part 3: revoke ───────────────────────────────────────────────────────
+  // ── Part 4: revoke ───────────────────────────────────────────────────────
   console.log("\n--- revoking, then repeating the same request ---");
   await sb.credentials.remove("github");
   await sb

--- a/examples/network-egress/README.md
+++ b/examples/network-egress/README.md
@@ -1,0 +1,52 @@
+# network-egress
+
+A deny-by-default sandbox whose outbound allow-list is changed at runtime with `sb.egress.*`.
+
+## Setup
+
+```bash
+bunx alineo-cli init   # starts OpenSandbox in Docker (one-time setup)
+```
+
+Requires a server with `egress.image` configured and `egress.mode = "dns+nft"` — the default for
+`alineo init`. On an older config or the `uvx opensandbox-server` setup, add:
+
+```toml
+[egress]
+image = "opensandbox/egress:v1.1.7"
+mode = "dns+nft"
+```
+
+to `~/.config/alineo/server.toml` (Docker) or `~/.sandbox.toml` (uvx), then restart the server.
+
+## Run
+
+```bash
+bun install
+bun start
+```
+
+## What it does
+
+1. Creates a sandbox with `networkPolicy: { defaultAction: "deny", egress: [] }` — an egress
+   sidecar that lets nothing out.
+2. `sb.egress.patch([{ action: "allow", target: "example.com" }])` — allows one host on the
+   already-running sandbox; the change hits the sidecar immediately.
+3. Shows a CIDR target being accepted. IP/CIDR rules are enforced at the nftables layer (so
+   they need `dns+nft` mode) and gate raw-IP egress — they do **not** authorize resolving a
+   *domain* into that range, so for reach-by-name you still want a domain rule.
+4. `sb.egress.delete(["example.com"])` — revokes it; the host is blocked again.
+5. `sb.egress.get()` — reads back the live policy from the sidecar.
+
+Reachability is probed with `getent hosts <name>` — it exits 0 only when the egress policy
+lets the DNS query through.
+
+Every `patch` / `delete` is recorded to the ledger (`EgressRuleAdded` / `EgressRuleRemoved`),
+so `Sandbox.resume()` folds whatever is still live back into the resumed sandbox's boot policy
+— egress policy is sidecar-local and does not survive a resume on its own.
+
+## Notes
+
+All examples default to `useServerProxy: true` — traffic routes through the OpenSandbox server so
+Docker bridge IPs don't need to be reachable directly. Set `USE_SERVER_PROXY=false` to disable
+(e.g. when using `uvx opensandbox-server` on the host).

--- a/examples/network-egress/README.md
+++ b/examples/network-egress/README.md
@@ -34,7 +34,7 @@ bun start
    already-running sandbox; the change hits the sidecar immediately.
 3. Shows a CIDR target being accepted. IP/CIDR rules are enforced at the nftables layer (so
    they need `dns+nft` mode) and gate raw-IP egress — they do **not** authorize resolving a
-   *domain* into that range, so for reach-by-name you still want a domain rule.
+   _domain_ into that range, so for reach-by-name you still want a domain rule.
 4. `sb.egress.delete(["example.com"])` — revokes it; the host is blocked again.
 5. `sb.egress.get()` — reads back the live policy from the sidecar.
 

--- a/examples/network-egress/index.ts
+++ b/examples/network-egress/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Network egress control — a deny-by-default sandbox whose allow-list is changed at runtime.
+ *
+ * Shows, in order:
+ *   1. `networkPolicy: { defaultAction: "deny" }` — the sandbox can reach nothing.
+ *   2. `sb.egress.patch()` — allow a host on the *running* sandbox; it becomes reachable.
+ *   3. CIDR / IP targets are accepted too (nftables layer; needs `egress.mode = "dns+nft"`).
+ *   4. `sb.egress.delete()` — revoke the host; it's blocked again.
+ *   5. `sb.egress.get()` — read back the live policy.
+ *
+ * Every change is also recorded to the ledger (`EgressRuleAdded` / `EgressRuleRemoved`), so
+ * `Sandbox.resume()` re-applies whatever is still live — egress policy is sidecar-local and
+ * does not survive a resume on its own.
+ *
+ * Requires the OpenSandbox server to have `egress.image` configured with `egress.mode = "dns+nft"`
+ * (the default for `alineo init`). Run: `cd examples/network-egress && bun install && bun start`.
+ */
+import { Sandbox, type SandboxHandle } from "@alineo-labs/sandbox";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+
+const client = new Sandbox({
+  baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+  apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+  adapter: new SQLiteAdapter("./ledger.db"),
+  useServerProxy: process.env.USE_SERVER_PROXY !== "false",
+});
+
+/** `getent hosts` exits 0 iff the name resolves — i.e. the egress policy let the DNS query through. */
+async function canReach(sb: SandboxHandle, host: string): Promise<boolean> {
+  const { exitCode } = await sb.exec(`getent hosts ${host}`, { strict: false });
+  return exitCode === 0;
+}
+
+const report = async (sb: SandboxHandle, host: string) =>
+  console.log(`  ${host.padEnd(20)} ${(await canReach(sb, host)) ? "reachable" : "blocked"}`);
+
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+  name: "network-egress",
+  // Nothing is allowed out until we say so. (Omit `networkPolicy` entirely for the usual
+  // unrestricted behaviour — no egress sidecar is attached at all.)
+  networkPolicy: { defaultAction: "deny", egress: [] },
+});
+console.log(`sandbox ${sb.sandboxId}\n`);
+
+try {
+  console.log("1 · deny-by-default — nothing is reachable");
+  await report(sb, "example.com");
+  await report(sb, "example.org");
+
+  console.log("\n2 · sb.egress.patch() — allow example.com on the running sandbox");
+  await sb.egress.patch([{ action: "allow", target: "example.com" }]);
+  await report(sb, "example.com");
+  await report(sb, "example.org"); // still blocked
+
+  console.log("\n3 · CIDR / IP targets are accepted too (enforced at the nftables layer —");
+  console.log("    they gate raw-IP egress, not name resolution; use a domain rule for that)");
+  await sb.egress.patch([{ action: "allow", target: "10.0.0.0/8" }]);
+
+  console.log("\n4 · sb.egress.delete() — revoke example.com");
+  await sb.egress.delete(["example.com"]);
+  await report(sb, "example.com"); // blocked again
+
+  console.log("\n5 · sb.egress.get() — the live policy");
+  const status = await sb.egress.get();
+  console.log(`   ${JSON.stringify(status.policy)}`);
+} finally {
+  await sb.close();
+}

--- a/examples/network-egress/package.json
+++ b/examples/network-egress/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "alineo-example-network-egress",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "@alineo-labs/sandbox": "workspace:*",
+    "@alineo-labs/sqlite": "workspace:*"
+  }
+}

--- a/packages/adapters/vault/package.json
+++ b/packages/adapters/vault/package.json
@@ -24,7 +24,8 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "test": "bun test"
   },
   "dependencies": {
     "@alineo-labs/core": "workspace:*",

--- a/packages/adapters/vault/src/broker.ts
+++ b/packages/adapters/vault/src/broker.ts
@@ -9,31 +9,34 @@ import {
 } from "./vault-client";
 
 /**
- * Thrown when a `CredentialBinding.injection` has no equivalent in the sidecar's real `Auth`
- * model. Only header injection (`{ type: "header" }`) maps onto it today — it supports
- * `bearer`/`basic`/`apiKey`/`customHeaders` header injection and placeholder `substitutions`
- * (for path/query/body), but not an arbitrary named query param or path segment the way this
- * package's `{ type: "query" }`/`{ type: "path" }` binding shapes imply. Wire those up to
- * `substitutions` (which needs a literal placeholder string in the request, a different model
- * from "inject a named param") before lifting this restriction.
+ * Thrown when a wire `auth.type` read back from the vault has no `CredentialInjection` this
+ * package understands. Both injection shapes it *writes* — `{ type: "header" }` → `apiKey`,
+ * `{ type: "substitution" }` → `passthrough` — round-trip; anything else is a binding some
+ * other client created.
  */
 export class UnsupportedInjectionError extends Error {
   constructor(injectionType: string) {
     super(
-      `Credential injection type "${injectionType}" is not yet supported by ` +
-        `@alineo-labs/vault — only { type: "header" } maps onto the egress sidecar's real ` +
-        `Credential Vault API today.`,
+      `Credential vault auth type "${injectionType}" has no @alineo-labs/vault ` +
+        `CredentialInjection equivalent — it was likely created by another client.`,
     );
     this.name = "UnsupportedInjectionError";
   }
 }
 
-function toWireAuth(name: string, injection: CredentialBinding["injection"]): WireAuth {
-  if (injection.type !== "header") throw new UnsupportedInjectionError(injection.type);
-  return { type: "apiKey", name: injection.name, credential: name };
+export function toWireAuth(name: string, injection: CredentialBinding["injection"]): WireAuth {
+  if (injection.type === "header") {
+    return { type: "apiKey", name: injection.name, credential: name };
+  }
+  // `substitution` → passthrough (no injected auth header) + one substitution entry. The
+  // sidecar replaces every literal `placeholder` in the listed surfaces with the value.
+  return {
+    type: "passthrough",
+    substitutions: [{ credential: name, placeholder: injection.placeholder, in: injection.in }],
+  };
 }
 
-function toWireBinding(name: string, binding: CredentialBinding): WireBinding {
+export function toWireBinding(name: string, binding: CredentialBinding): WireBinding {
   return {
     name,
     match: {
@@ -44,20 +47,26 @@ function toWireBinding(name: string, binding: CredentialBinding): WireBinding {
   };
 }
 
-function fromWireBindingMetadata(meta: {
+export function fromWireBindingMetadata(meta: {
   match: { hosts: string[]; paths?: string[] };
   auth: { type: string; name?: string };
 }): CredentialBinding {
-  if (meta.auth.type !== "apiKey" || !meta.auth.name) {
-    // Only bindings this package itself created (always `apiKey`) round-trip cleanly.
-    throw new UnsupportedInjectionError(meta.auth.type);
-  }
   const path = meta.match.paths?.[0];
-  return {
+  const base = {
     host: meta.match.hosts[0] ?? "",
     ...(path && path !== "/*" ? { pathPrefix: path.replace(/\*$/, "") } : {}),
-    injection: { type: "header", name: meta.auth.name },
   };
+  if (meta.auth.type === "apiKey" && meta.auth.name) {
+    return { ...base, injection: { type: "header", name: meta.auth.name } };
+  }
+  if (meta.auth.type === "passthrough") {
+    // `GET /credential-vault` returns only `auth.type` for a passthrough binding — the
+    // sidecar never echoes `substitutions` (placeholder / surfaces). `listBindings()` is
+    // therefore lossy here; `Sandbox.resume()`/`sb.fork()` recover the full injection shape
+    // from the ledger `CredentialBound` payload instead.
+    return { ...base, injection: { type: "substitution", placeholder: "", in: [] } };
+  }
+  throw new UnsupportedInjectionError(meta.auth.type);
 }
 
 /**

--- a/packages/adapters/vault/test/broker.test.ts
+++ b/packages/adapters/vault/test/broker.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import type { CredentialBinding } from "@alineo-labs/core";
+import { toWireAuth, toWireBinding, fromWireBindingMetadata } from "../src/broker.ts";
+
+describe("toWireAuth", () => {
+  it("maps { type: 'header' } to an apiKey wire auth carrying the credential name", () => {
+    expect(toWireAuth("gh", { type: "header", name: "Authorization" })).toEqual({
+      type: "apiKey",
+      name: "Authorization",
+      credential: "gh",
+    });
+  });
+
+  it("maps { type: 'substitution' } to passthrough + one substitution entry", () => {
+    expect(
+      toWireAuth("oai", { type: "substitution", placeholder: "__OAI__", in: ["query", "path"] }),
+    ).toEqual({
+      type: "passthrough",
+      substitutions: [{ credential: "oai", placeholder: "__OAI__", in: ["query", "path"] }],
+    });
+  });
+});
+
+describe("toWireBinding", () => {
+  it("carries host + a trailing-glob path from pathPrefix", () => {
+    const binding: CredentialBinding = {
+      host: "api.github.com",
+      pathPrefix: "/repos/",
+      injection: { type: "header", name: "Authorization" },
+    };
+    expect(toWireBinding("gh", binding)).toEqual({
+      name: "gh",
+      match: { hosts: ["api.github.com"], paths: ["/repos/*"] },
+      auth: { type: "apiKey", name: "Authorization", credential: "gh" },
+    });
+  });
+});
+
+describe("fromWireBindingMetadata", () => {
+  it("round-trips a header binding this package created", () => {
+    const binding: CredentialBinding = {
+      host: "api.github.com",
+      injection: { type: "header", name: "Authorization" },
+    };
+    const meta = { match: toWireBinding("gh", binding).match, auth: { type: "apiKey", name: "Authorization" } };
+    expect(fromWireBindingMetadata(meta)).toEqual(binding);
+  });
+
+  it("recovers host + a substitution shape for a passthrough binding (placeholder/in are lossy)", () => {
+    expect(
+      fromWireBindingMetadata({ match: { hosts: ["api.example.com"] }, auth: { type: "passthrough" } }),
+    ).toEqual({
+      host: "api.example.com",
+      injection: { type: "substitution", placeholder: "", in: [] },
+    });
+  });
+
+  it("throws UnsupportedInjectionError for an auth type another client created", () => {
+    expect(() =>
+      fromWireBindingMetadata({ match: { hosts: ["x"] }, auth: { type: "bearer" } }),
+    ).toThrow("bearer");
+  });
+});

--- a/packages/adapters/vault/test/broker.test.ts
+++ b/packages/adapters/vault/test/broker.test.ts
@@ -42,13 +42,19 @@ describe("fromWireBindingMetadata", () => {
       host: "api.github.com",
       injection: { type: "header", name: "Authorization" },
     };
-    const meta = { match: toWireBinding("gh", binding).match, auth: { type: "apiKey", name: "Authorization" } };
+    const meta = {
+      match: toWireBinding("gh", binding).match,
+      auth: { type: "apiKey", name: "Authorization" },
+    };
     expect(fromWireBindingMetadata(meta)).toEqual(binding);
   });
 
   it("recovers host + a substitution shape for a passthrough binding (placeholder/in are lossy)", () => {
     expect(
-      fromWireBindingMetadata({ match: { hosts: ["api.example.com"] }, auth: { type: "passthrough" } }),
+      fromWireBindingMetadata({
+        match: { hosts: ["api.example.com"] },
+        auth: { type: "passthrough" },
+      }),
     ).toEqual({
       host: "api.example.com",
       injection: { type: "substitution", placeholder: "", in: [] },

--- a/packages/adapters/vault/tsconfig.json
+++ b/packages/adapters/vault/tsconfig.json
@@ -9,5 +9,5 @@
     "allowImportingTsExtensions": true,
     "types": ["bun-types"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -81,12 +81,20 @@ const SOLE_ENV_REF = /^\$\{([^}]+)\}$/;
  */
 export function extractCredentialBindings(
   env: Record<string, string | CredentialEnvBinding>,
-): Array<{ name: string; value: string; binding: CredentialBinding; source: CredentialSource }> {
+): Array<{
+  name: string;
+  value: string;
+  binding: CredentialBinding;
+  source: CredentialSource;
+  /** `"hold"` when the spec gated egress to this binding's host behind human approval. */
+  approval?: "hold";
+}> {
   const out: Array<{
     name: string;
     value: string;
     binding: CredentialBinding;
     source: CredentialSource;
+    approval?: "hold";
   }> = [];
   for (const [key, value] of Object.entries(env)) {
     if (typeof value === "string") continue;
@@ -99,6 +107,7 @@ export function extractCredentialBindings(
       ),
       binding: { host: value.host, pathPrefix: value.pathPrefix, injection: value.injection },
       source: soleRef ? { type: "env", varName: soleRef[1] } : { type: "external" },
+      ...(value.approval ? { approval: value.approval } : {}),
     });
   }
   return out;

--- a/packages/agent/src/agent/agent.ts
+++ b/packages/agent/src/agent/agent.ts
@@ -20,6 +20,7 @@ import * as sessionControl from "./session-control";
 import * as model from "./model";
 import * as introspection from "./introspection";
 import * as lifecycle from "./lifecycle";
+import type { EgressApprovalGate, EgressRequest, EgressRequestHandler } from "./egress-approval";
 
 export { resolveParentSpawnDepth, resolveParentMaxAgents } from "./validation";
 
@@ -113,6 +114,13 @@ export class Alineo {
     return { resourceId: this.resourceId, teamId: this.teamId };
   }
 
+  /**
+   * Present when the spec has `approval: "hold"` credential bindings — the out-of-process
+   * gate that holds the sandbox's egress to those hosts until `onEgressRequest` approves.
+   * Stopped by `close()`.
+   */
+  readonly egressGate?: EgressApprovalGate;
+
   private constructor(
     sandbox: SandboxHandle,
     spec: AgentSpec,
@@ -120,6 +128,7 @@ export class Alineo {
     adapter: PiAdapter,
     fromSnapshot: boolean,
     runId: string,
+    egressGate?: EgressApprovalGate,
   ) {
     this.sandbox = sandbox;
     this.sandboxId = sandbox.sandboxId;
@@ -130,6 +139,12 @@ export class Alineo {
     this.env = env;
     this.fromSnapshot = fromSnapshot;
     this.runId = runId;
+    this.egressGate = egressGate;
+  }
+
+  /** Egress requests currently awaiting a decision (see `AgentSpec.env` `approval: "hold"`). */
+  pendingEgressRequests(): EgressRequest[] {
+    return this.egressGate?.pending() ?? [];
   }
 
   /**
@@ -167,10 +182,25 @@ export class Alineo {
       runId?: string;
       /** Wire a `Memory` instance onto the returned agent — see `Alineo.memory`. */
       memory?: Memory;
+      /**
+       * Required when the spec has `approval: "hold"` credential bindings — decides each
+       * first outbound request to a held host: return `"allow-once"` (reverts at turn end),
+       * `"allow-always"` (permanent for this agent's life), or `"deny"`. Enforcement is
+       * out-of-process at the egress sidecar; a compromised agent cannot skip it.
+       */
+      onEgressRequest?: EgressRequestHandler;
     },
   ): Promise<Alineo> {
     const r = await factory.loadAgent(spec, opts);
-    const agent = new Alineo(r.sandbox, r.spec, r.env, r.adapter, r.fromSnapshot, r.runId);
+    const agent = new Alineo(
+      r.sandbox,
+      r.spec,
+      r.env,
+      r.adapter,
+      r.fromSnapshot,
+      r.runId,
+      r.egressGate,
+    );
     agent.memory = opts.memory;
     return agent;
   }

--- a/packages/agent/src/agent/egress-approval.ts
+++ b/packages/agent/src/agent/egress-approval.ts
@@ -1,16 +1,28 @@
 import { createServer, type Server } from "node:http";
-import { LedgerEvent, type SandboxHandle } from "@alineo-labs/core";
+import {
+  LedgerEvent,
+  type CredentialBinding,
+  type CredentialSource,
+  type SandboxHandle,
+} from "@alineo-labs/core";
 
 /**
  * Human-in-the-loop gate for a sandboxed agent's outbound network access.
  *
- * Hosts marked `approval: "hold"` in `AgentSpec.env` start *denied* at the egress sidecar
- * (the sandbox is `defaultAction: "allow"` with an explicit `deny` rule per held host, so
- * everything else — including the agent's own model/tooling traffic — keeps working). The
- * sidecar POSTs a fire-and-forget webhook when the agent's sandbox is denied a DNS query;
- * this gate listens for that, calls the caller's handler, and — on approval — flips the rule
- * to `allow` on the running sidecar via `sb.egress.patch()`. Enforcement is entirely
- * out-of-process: a compromised in-sandbox agent cannot skip it.
+ * Credential env bindings marked `approval: "hold"` in `AgentSpec.env` start with their host
+ * *denied* at the egress sidecar (the sandbox is `defaultAction: "allow"` with an explicit
+ * `deny` rule per held host, so everything else — including the agent's own model traffic —
+ * keeps working) and their credential **not registered in the vault at all** (the vault
+ * refuses a binding whose host isn't allowed).
+ *
+ * The sidecar POSTs a fire-and-forget webhook when the sandbox is denied a DNS query. This
+ * gate listens for that, calls the caller's handler, and on approval:
+ *   1. flips the sidecar rule to `allow` for that host (`sb.egress.patch`), then
+ *   2. registers the held credential(s) for it (`sb.credentials.set`) — so the credential
+ *      literally does not exist inside the sandbox until a human approves.
+ *
+ * `allow-once` reverses both at the end of the turn; `allow-always` leaves them in place.
+ * Enforcement is entirely out-of-process — a compromised in-sandbox agent cannot skip it.
  *
  * The listener binds `0.0.0.0` on an ephemeral port and is torn down with the agent.
  */
@@ -29,6 +41,14 @@ export type EgressRequestHandler = (
   req: EgressRequest,
 ) => EgressDecision | Promise<EgressDecision>;
 
+/** A credential whose registration is gated behind egress approval for its host. */
+export interface HeldCredential {
+  name: string;
+  value: string;
+  binding: CredentialBinding;
+  source?: CredentialSource;
+}
+
 /** The sidecar's deny-webhook body (`components/egress/pkg/events/webhook.go`). */
 interface DenyWebhookBody {
   hostname?: string;
@@ -38,8 +58,12 @@ interface DenyWebhookBody {
 const DEDUP_TTL_MS = 30_000;
 
 export interface EgressApprovalGateOptions {
-  /** Hosts that start denied — the gate flips these to `allow` on approval. */
-  heldHosts: string[];
+  /**
+   * Credentials whose host starts denied. The gate allows the host and registers these on
+   * approval. (Non-credential held hosts can be passed as `{ name, value: "", binding }` with
+   * an empty value — the gate then only manages the egress rule.)
+   */
+  heldCredentials: HeldCredential[];
   handler: EgressRequestHandler;
   /**
    * Address the sandbox's egress sidecar can reach this host process at. Defaults to the
@@ -55,20 +79,28 @@ export class EgressApprovalGate {
   private sandbox: SandboxHandle | undefined;
   private readonly handler: EgressRequestHandler;
   private readonly webhookHost: string;
-  /** Hosts still denied — dropped from here once permanently opened by `allow-always`. */
-  private readonly held: Set<string>;
+  /** host → the held credentials bound to it. */
+  private readonly byHost = new Map<string, HeldCredential[]>();
+  /** Hosts still gated — dropped once permanently opened by `allow-always`. */
+  private readonly held = new Set<string>();
   /** host → last time we raised a request for it (dedup; the webhook fires per DNS query). */
   private readonly seen = new Map<string, number>();
   /** Hosts with a decision currently in flight. */
   private readonly inFlight = new Set<string>();
-  /** Hosts approved `allow-once` — reverted to `deny` on `endTurn()`. */
+  /** Hosts approved `allow-once` — reversed on `endTurn()`. */
   private readonly onceApproved = new Set<string>();
 
   constructor(opts: EgressApprovalGateOptions) {
     this.handler = opts.handler;
     this.webhookHost =
       opts.webhookHost ?? process.env.ALINEO_EGRESS_APPROVAL_HOST ?? "172.17.0.1";
-    this.held = new Set(opts.heldHosts.map(normalizeHost));
+    for (const held of opts.heldCredentials) {
+      const host = normalizeHost(held.binding.host);
+      this.held.add(host);
+      const list = this.byHost.get(host);
+      if (list) list.push(held);
+      else this.byHost.set(host, [held]);
+    }
   }
 
   /** Attach the sandbox whose egress this gate manages. Called once its handle exists. */
@@ -139,14 +171,18 @@ export class EgressApprovalGate {
   }
 
   /**
-   * Revert every `allow-once` approval to `deny`. Call when an agent turn ends so a
-   * one-shot grant does not silently persist.
+   * Reverse every `allow-once` approval — remove its credential(s) and re-deny the host.
+   * Call when an agent turn ends so a one-shot grant does not silently persist.
    */
   async endTurn(): Promise<void> {
     const toRevert = [...this.onceApproved].filter((h) => this.held.has(h));
     this.onceApproved.clear();
-    if (toRevert.length > 0) {
-      await this.sb().egress.patch(toRevert.map((target) => ({ action: "deny", target })));
+    for (const host of toRevert) {
+      // Credential first (while the host is still allowed), then re-deny.
+      for (const held of this.byHost.get(host) ?? []) {
+        if (held.value !== "") await this.sb().credentials.remove(held.name).catch(() => {});
+      }
+      await this.sb().egress.patch([{ action: "deny", target: host }]);
     }
   }
 
@@ -174,7 +210,14 @@ export class EgressApprovalGate {
 
     try {
       if (decision === "allow-once" || decision === "allow-always") {
+        // Order matters: the vault refuses a binding whose host isn't allowed, so open the
+        // egress rule first, then register the credential(s).
         await this.sb().egress.patch([{ action: "allow", target: host }]);
+        for (const held of this.byHost.get(host) ?? []) {
+          if (held.value !== "") {
+            await this.sb().credentials.set(held.name, held.value, held.binding, held.source);
+          }
+        }
         if (decision === "allow-once") this.onceApproved.add(host);
         else this.held.delete(host);
       }

--- a/packages/agent/src/agent/egress-approval.ts
+++ b/packages/agent/src/agent/egress-approval.ts
@@ -37,9 +37,7 @@ export interface EgressRequest {
   since: number;
 }
 
-export type EgressRequestHandler = (
-  req: EgressRequest,
-) => EgressDecision | Promise<EgressDecision>;
+export type EgressRequestHandler = (req: EgressRequest) => EgressDecision | Promise<EgressDecision>;
 
 /** A credential whose registration is gated behind egress approval for its host. */
 export interface HeldCredential {
@@ -92,8 +90,7 @@ export class EgressApprovalGate {
 
   constructor(opts: EgressApprovalGateOptions) {
     this.handler = opts.handler;
-    this.webhookHost =
-      opts.webhookHost ?? process.env.ALINEO_EGRESS_APPROVAL_HOST ?? "172.17.0.1";
+    this.webhookHost = opts.webhookHost ?? process.env.ALINEO_EGRESS_APPROVAL_HOST ?? "172.17.0.1";
     for (const held of opts.heldCredentials) {
       const host = normalizeHost(held.binding.host);
       this.held.add(host);
@@ -180,7 +177,10 @@ export class EgressApprovalGate {
     for (const host of toRevert) {
       // Credential first (while the host is still allowed), then re-deny.
       for (const held of this.byHost.get(host) ?? []) {
-        if (held.value !== "") await this.sb().credentials.remove(held.name).catch(() => {});
+        if (held.value !== "")
+          await this.sb()
+            .credentials.remove(held.name)
+            .catch(() => {});
       }
       await this.sb().egress.patch([{ action: "deny", target: host }]);
     }

--- a/packages/agent/src/agent/egress-approval.ts
+++ b/packages/agent/src/agent/egress-approval.ts
@@ -1,0 +1,193 @@
+import { createServer, type Server } from "node:http";
+import { LedgerEvent, type SandboxHandle } from "@alineo-labs/core";
+
+/**
+ * Human-in-the-loop gate for a sandboxed agent's outbound network access.
+ *
+ * Hosts marked `approval: "hold"` in `AgentSpec.env` start *denied* at the egress sidecar
+ * (the sandbox is `defaultAction: "allow"` with an explicit `deny` rule per held host, so
+ * everything else — including the agent's own model/tooling traffic — keeps working). The
+ * sidecar POSTs a fire-and-forget webhook when the agent's sandbox is denied a DNS query;
+ * this gate listens for that, calls the caller's handler, and — on approval — flips the rule
+ * to `allow` on the running sidecar via `sb.egress.patch()`. Enforcement is entirely
+ * out-of-process: a compromised in-sandbox agent cannot skip it.
+ *
+ * The listener binds `0.0.0.0` on an ephemeral port and is torn down with the agent.
+ */
+
+export type EgressDecision = "allow-once" | "allow-always" | "deny";
+
+/** One egress attempt awaiting a decision. */
+export interface EgressRequest {
+  /** The hostname the agent's sandbox tried to reach. */
+  host: string;
+  /** Unix ms when the sidecar reported the denial. */
+  since: number;
+}
+
+export type EgressRequestHandler = (
+  req: EgressRequest,
+) => EgressDecision | Promise<EgressDecision>;
+
+/** The sidecar's deny-webhook body (`components/egress/pkg/events/webhook.go`). */
+interface DenyWebhookBody {
+  hostname?: string;
+  sandboxId?: string;
+}
+
+const DEDUP_TTL_MS = 30_000;
+
+export interface EgressApprovalGateOptions {
+  /** Hosts that start denied — the gate flips these to `allow` on approval. */
+  heldHosts: string[];
+  handler: EgressRequestHandler;
+  /**
+   * Address the sandbox's egress sidecar can reach this host process at. Defaults to the
+   * Docker default-bridge gateway (`172.17.0.1`), which an `alineo init` server's sidecars
+   * can reach. Override for other topologies via `ALINEO_EGRESS_APPROVAL_HOST`.
+   */
+  webhookHost?: string;
+}
+
+export class EgressApprovalGate {
+  private server: Server | undefined;
+  private port = 0;
+  private sandbox: SandboxHandle | undefined;
+  private readonly handler: EgressRequestHandler;
+  private readonly webhookHost: string;
+  /** Hosts still denied — dropped from here once permanently opened by `allow-always`. */
+  private readonly held: Set<string>;
+  /** host → last time we raised a request for it (dedup; the webhook fires per DNS query). */
+  private readonly seen = new Map<string, number>();
+  /** Hosts with a decision currently in flight. */
+  private readonly inFlight = new Set<string>();
+  /** Hosts approved `allow-once` — reverted to `deny` on `endTurn()`. */
+  private readonly onceApproved = new Set<string>();
+
+  constructor(opts: EgressApprovalGateOptions) {
+    this.handler = opts.handler;
+    this.webhookHost =
+      opts.webhookHost ?? process.env.ALINEO_EGRESS_APPROVAL_HOST ?? "172.17.0.1";
+    this.held = new Set(opts.heldHosts.map(normalizeHost));
+  }
+
+  /** Attach the sandbox whose egress this gate manages. Called once its handle exists. */
+  bind(sandbox: SandboxHandle): void {
+    this.sandbox = sandbox;
+  }
+
+  private sb(): SandboxHandle {
+    if (!this.sandbox) throw new Error("EgressApprovalGate.bind() has not been called");
+    return this.sandbox;
+  }
+
+  /** Start the listener. Idempotent. */
+  async start(): Promise<void> {
+    if (this.server) return;
+    const server = createServer((req, res) => {
+      if (req.method !== "POST" || (req.url ?? "").split("?")[0] !== "/egress-deny") {
+        res.writeHead(404).end();
+        return;
+      }
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        // Answer 200 immediately — the sidecar retries on non-2xx and fires per DNS query.
+        res.writeHead(200).end("ok");
+        let body: DenyWebhookBody | null = null;
+        try {
+          body = JSON.parse(raw) as DenyWebhookBody;
+        } catch {
+          return;
+        }
+        const host = body?.hostname ? normalizeHost(body.hostname) : undefined;
+        if (host) void this.onDenied(host);
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "0.0.0.0", () => {
+        const addr = server.address();
+        this.port = typeof addr === "object" && addr ? addr.port : 0;
+        resolve();
+      });
+    });
+    // Don't hold the event loop open on our own account — `close()`/`stop()` is the explicit
+    // teardown; `unref` just means a leaked gate (e.g. `Alineo.load()` throwing after this
+    // point) can't hang the process.
+    server.unref();
+    this.server = server;
+  }
+
+  /** Stop the listener. */
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = undefined;
+    if (!server) return;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  /** The `OPENSANDBOX_EGRESS_DENY_WEBHOOK` value to put in the sandbox's env. */
+  get webhookUrl(): string {
+    if (!this.server) throw new Error("EgressApprovalGate.start() has not been called");
+    return `http://${this.webhookHost}:${this.port}/egress-deny`;
+  }
+
+  /** Egress requests currently awaiting a decision. */
+  pending(): EgressRequest[] {
+    return [...this.inFlight].map((host) => ({ host, since: this.seen.get(host) ?? Date.now() }));
+  }
+
+  /**
+   * Revert every `allow-once` approval to `deny`. Call when an agent turn ends so a
+   * one-shot grant does not silently persist.
+   */
+  async endTurn(): Promise<void> {
+    const toRevert = [...this.onceApproved].filter((h) => this.held.has(h));
+    this.onceApproved.clear();
+    if (toRevert.length > 0) {
+      await this.sb().egress.patch(toRevert.map((target) => ({ action: "deny", target })));
+    }
+  }
+
+  private async onDenied(host: string): Promise<void> {
+    if (!this.held.has(host)) return; // not a gated host
+    const now = Date.now();
+    const last = this.seen.get(host);
+    if (last !== undefined && now - last < DEDUP_TTL_MS) return;
+    if (this.inFlight.has(host)) return;
+    this.seen.set(host, now);
+    this.inFlight.add(host);
+
+    void this.sb().emit(LedgerEvent.PermissionRequested, -1, {
+      requestId: `egress:${host}`,
+      tool: "network",
+      target: host,
+    });
+
+    let decision: EgressDecision = "deny";
+    try {
+      decision = await this.handler({ host, since: now });
+    } catch {
+      decision = "deny";
+    }
+
+    try {
+      if (decision === "allow-once" || decision === "allow-always") {
+        await this.sb().egress.patch([{ action: "allow", target: host }]);
+        if (decision === "allow-once") this.onceApproved.add(host);
+        else this.held.delete(host);
+      }
+    } finally {
+      this.inFlight.delete(host);
+      void this.sb().emit(LedgerEvent.PermissionResolved, -1, {
+        requestId: `egress:${host}`,
+        decision: { kind: decision },
+      });
+    }
+  }
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().replace(/\.$/, "").toLowerCase();
+}

--- a/packages/agent/src/agent/egress-approval.ts
+++ b/packages/agent/src/agent/egress-approval.ts
@@ -183,6 +183,9 @@ export class EgressApprovalGate {
             .catch(() => {});
       }
       await this.sb().egress.patch([{ action: "deny", target: host }]);
+      // Clear the dedup timestamp so the next turn's request re-prompts instead of being
+      // swallowed for the rest of DEDUP_TTL_MS.
+      this.seen.delete(host);
     }
   }
 

--- a/packages/agent/src/agent/factory.ts
+++ b/packages/agent/src/agent/factory.ts
@@ -85,7 +85,11 @@ export async function loadAgent(
   // denied at the sidecar and the credential is NOT registered — the gate does both on
   // approval (the vault refuses a binding whose host isn't allowed).
   const heldCredentials = credentialBindings.filter((b) => b.approval === "hold");
-  const heldHosts = [...new Set(heldCredentials.map((b) => b.binding.host))];
+  // Normalize the same way `EgressApprovalGate` does, so the `deny` rule created here and the
+  // `allow` rule the gate patches on approval name the exact same target.
+  const heldHosts = [
+    ...new Set(heldCredentials.map((b) => b.binding.host.trim().replace(/\.$/, "").toLowerCase())),
+  ];
   if (heldCredentials.length > 0 && !opts.onEgressRequest) {
     throw new Error(
       `AgentSpec.env has ${heldCredentials.length} credential binding(s) with approval: "hold" ` +

--- a/packages/agent/src/agent/factory.ts
+++ b/packages/agent/src/agent/factory.ts
@@ -19,6 +19,7 @@ import {
   resolveChildResourceId,
 } from "./validation";
 import type { AgentInternal } from "./internal";
+import { EgressApprovalGate, type EgressRequestHandler } from "./egress-approval";
 
 function elapsed(t: number) {
   return `${Date.now() - t}ms`;
@@ -35,6 +36,8 @@ export interface AgentConstructorArgs {
   fromSnapshot: boolean;
   /** Run-correlation ID for this agent's sandbox — see `SandboxDetails.runId`. */
   runId: string;
+  /** Started when the spec has `approval: "hold"` bindings; stopped by `agent.close()`. */
+  egressGate?: EgressApprovalGate;
 }
 
 /**
@@ -49,6 +52,9 @@ export async function loadAgent(
     spawnDepth?: number;
     maxAgents?: number;
     runId?: string;
+    /** Required when the spec has `approval: "hold"` credential bindings — decides each
+     *  first outbound request to a held host. See `EgressApprovalGate`. */
+    onEgressRequest?: EgressRequestHandler;
   },
 ): Promise<AgentConstructorArgs> {
   const t0 = Date.now();
@@ -74,12 +80,42 @@ export async function loadAgent(
 
   const credentialBindings = extractCredentialBindings(spec.env ?? {});
   const needsCredentialProxy = credentialBindings.length > 0;
-  // `credentialProxy` requires `networkPolicy` to also be set (see SandboxOptions docs). There's
-  // no spec-level network-restriction feature yet, so this stays wide open by default — the
-  // point here is purely "make injection available for the bound host(s)", not lockdown.
-  const networkPolicy = needsCredentialProxy
-    ? { defaultAction: "allow" as const, egress: [] }
-    : undefined;
+
+  // Hosts the spec gated behind human approval (`approval: "hold"`). They start denied at
+  // the sidecar; the gate flips each to `allow` when its handler approves.
+  const heldHosts = [
+    ...new Set(credentialBindings.filter((b) => b.approval === "hold").map((b) => b.binding.host)),
+  ];
+  if (heldHosts.length > 0 && !opts.onEgressRequest) {
+    throw new Error(
+      `AgentSpec.env has ${heldHosts.length} credential binding(s) with approval: "hold" ` +
+        `(${heldHosts.join(", ")}) but Alineo.load() was called without an onEgressRequest handler.`,
+    );
+  }
+
+  // `credentialProxy` requires `networkPolicy` to also be set (see SandboxOptions docs).
+  // `defaultAction: "allow"` — the point is to make injection available, not lockdown; held
+  // hosts get an explicit `deny` rule (and `defaultAction: "allow"` is also what keeps the
+  // sidecar's own deny-webhook POST able to leave the network).
+  const networkPolicy =
+    needsCredentialProxy || heldHosts.length > 0
+      ? {
+          defaultAction: "allow" as const,
+          egress: heldHosts.map((target) => ({ action: "deny" as const, target })),
+        }
+      : undefined;
+
+  // Start the listener before creating the sandbox — its URL goes into the sidecar env.
+  // `gate.bind(sb)` attaches the handle once it exists.
+  const egressGate =
+    heldHosts.length > 0 && opts.onEgressRequest
+      ? new EgressApprovalGate({ heldHosts, handler: opts.onEgressRequest })
+      : undefined;
+  const egressEnv: Record<string, string> = {};
+  if (egressGate) {
+    await egressGate.start();
+    egressEnv.OPENSANDBOX_EGRESS_DENY_WEBHOOK = egressGate.webhookUrl;
+  }
 
   const client = new Sandbox({
     baseUrl: config.serverUrl,
@@ -104,6 +140,9 @@ export async function loadAgent(
         const t1 = Date.now();
         sb = await client.restoreSnapshot(record.snapshotId, spec.name, resources, runId, {
           networkPolicy,
+          // Sidecar-scoped, process-specific — the sidecar is fresh on every restore, so the
+          // deny-webhook URL must be re-supplied (never stored in the container).
+          ...(egressEnv.OPENSANDBOX_EGRESS_DENY_WEBHOOK ? { env: egressEnv } : {}),
           credentialProxy: needsCredentialProxy,
           // Kept consistent with `Alineo.resourceRef` — see `AgentSpec.teamId`'s doc comment
           // for why this matters (episodicRecall() enforces teamId strictly).
@@ -132,7 +171,7 @@ export async function loadAgent(
       image: "node:22",
       resources,
       name: spec.name,
-      env: resolvedEnv,
+      env: { ...resolvedEnv, ...egressEnv },
       runId,
       networkPolicy,
       credentialProxy: needsCredentialProxy,
@@ -172,6 +211,7 @@ export async function loadAgent(
   // install path just above) assign sb before getting here — this only trips if
   // that invariant is ever broken.
   if (!sb) throw new Error("internal error: sandbox was neither restored nor created");
+  egressGate?.bind(sb);
 
   // Applied on every load() (fresh or from-snapshot) — the vault is sidecar-runtime-only, so
   // whichever path just created `sb` needs these re-registered against its own sandboxId.
@@ -190,7 +230,7 @@ export async function loadAgent(
   console.log(`[agent] bridge ready    ${elapsed(t4)}`);
   console.log(`[agent] total           ${elapsed(t0)}${fromSnapshot ? " (from snapshot)" : ""}`);
 
-  return { sandbox: sb, spec, env: resolvedEnv, adapter, fromSnapshot, runId };
+  return { sandbox: sb, spec, env: resolvedEnv, adapter, fromSnapshot, runId, egressGate };
 }
 
 /**
@@ -398,6 +438,13 @@ export async function spawnChild(
   // parent's own bound credentials over on its own; this is for bindings that only exist in
   // the *child's* spec, which `fork()` has no way to know about on its own.
   const childCredentialBindings = extractCredentialBindings(childSpec.env ?? {});
+  if (childCredentialBindings.some((b) => b.approval === "hold")) {
+    throw new Error(
+      `Spawned agent "${childSpec.name}" has a credential binding with approval: "hold" — ` +
+        `egress approval gating is not supported for spawned agents yet (no handler is wired ` +
+        `on the spawn path). Remove approval: "hold" from the child spec.`,
+    );
+  }
 
   const childResourceId = resolveChildResourceId(childSpec);
 

--- a/packages/agent/src/agent/factory.ts
+++ b/packages/agent/src/agent/factory.ts
@@ -81,14 +81,14 @@ export async function loadAgent(
   const credentialBindings = extractCredentialBindings(spec.env ?? {});
   const needsCredentialProxy = credentialBindings.length > 0;
 
-  // Hosts the spec gated behind human approval (`approval: "hold"`). They start denied at
-  // the sidecar; the gate flips each to `allow` when its handler approves.
-  const heldHosts = [
-    ...new Set(credentialBindings.filter((b) => b.approval === "hold").map((b) => b.binding.host)),
-  ];
-  if (heldHosts.length > 0 && !opts.onEgressRequest) {
+  // Credential bindings gated behind human approval (`approval: "hold"`). Their host starts
+  // denied at the sidecar and the credential is NOT registered — the gate does both on
+  // approval (the vault refuses a binding whose host isn't allowed).
+  const heldCredentials = credentialBindings.filter((b) => b.approval === "hold");
+  const heldHosts = [...new Set(heldCredentials.map((b) => b.binding.host))];
+  if (heldCredentials.length > 0 && !opts.onEgressRequest) {
     throw new Error(
-      `AgentSpec.env has ${heldHosts.length} credential binding(s) with approval: "hold" ` +
+      `AgentSpec.env has ${heldCredentials.length} credential binding(s) with approval: "hold" ` +
         `(${heldHosts.join(", ")}) but Alineo.load() was called without an onEgressRequest handler.`,
     );
   }
@@ -108,8 +108,16 @@ export async function loadAgent(
   // Start the listener before creating the sandbox — its URL goes into the sidecar env.
   // `gate.bind(sb)` attaches the handle once it exists.
   const egressGate =
-    heldHosts.length > 0 && opts.onEgressRequest
-      ? new EgressApprovalGate({ heldHosts, handler: opts.onEgressRequest })
+    heldCredentials.length > 0 && opts.onEgressRequest
+      ? new EgressApprovalGate({
+          heldCredentials: heldCredentials.map((b) => ({
+            name: b.name,
+            value: b.value,
+            binding: b.binding,
+            source: b.source,
+          })),
+          handler: opts.onEgressRequest,
+        })
       : undefined;
   const egressEnv: Record<string, string> = {};
   if (egressGate) {
@@ -215,8 +223,11 @@ export async function loadAgent(
 
   // Applied on every load() (fresh or from-snapshot) — the vault is sidecar-runtime-only, so
   // whichever path just created `sb` needs these re-registered against its own sandboxId.
-  for (const { name, value, binding, source } of credentialBindings) {
-    await sb.credentials.set(name, value, binding, source);
+  // `approval: "hold"` bindings are skipped here — their host is denied, so the vault would
+  // reject them; the gate registers them on approval instead.
+  for (const cb of credentialBindings) {
+    if (cb.approval === "hold") continue;
+    await sb.credentials.set(cb.name, cb.value, cb.binding, cb.source);
   }
 
   // ── Always: write fresh config + start bridge ─────────────────────────────

--- a/packages/agent/src/agent/index.ts
+++ b/packages/agent/src/agent/index.ts
@@ -7,4 +7,5 @@ export type {
   EgressRequest,
   EgressRequestHandler,
   EgressApprovalGateOptions,
+  HeldCredential,
 } from "./egress-approval";

--- a/packages/agent/src/agent/index.ts
+++ b/packages/agent/src/agent/index.ts
@@ -1,3 +1,10 @@
 export { Alineo, resolveParentSpawnDepth, resolveParentMaxAgents } from "./agent";
 export type { AgentSnapshotRecord } from "./agent";
 export type { PermissionHandler } from "./session-control";
+export { EgressApprovalGate } from "./egress-approval";
+export type {
+  EgressDecision,
+  EgressRequest,
+  EgressRequestHandler,
+  EgressApprovalGateOptions,
+} from "./egress-approval";

--- a/packages/agent/src/agent/internal.ts
+++ b/packages/agent/src/agent/internal.ts
@@ -1,5 +1,6 @@
 import type { SandboxHandle } from "@alineo-labs/core";
 import type { PiAdapter } from "../adapters/pi";
+import type { EgressApprovalGate } from "./egress-approval";
 
 /**
  * Narrow surface that `session-control.ts`/`model.ts`/`introspection.ts`/
@@ -11,4 +12,6 @@ export interface AgentInternal {
   readonly adapter: PiAdapter;
   readonly sandbox: SandboxHandle;
   env: Record<string, string>;
+  /** Present when the spec has `approval: "hold"` credential bindings. */
+  readonly egressGate?: EgressApprovalGate;
 }

--- a/packages/agent/src/agent/lifecycle.ts
+++ b/packages/agent/src/agent/lifecycle.ts
@@ -59,5 +59,8 @@ export async function close(a: AgentInternal): Promise<void> {
   // `[DONE]` (see PiAdapter.disposeConnections()) -- otherwise those connections can keep
   // the process alive indefinitely even after the sandbox itself is gone.
   a.adapter.disposeConnections();
+  // Stop the egress-approval listener (if any) before the sandbox goes away — its port must
+  // not outlive the agent.
+  await a.egressGate?.stop().catch(() => {});
   await a.sandbox.close();
 }

--- a/packages/agent/src/agent/session-control.ts
+++ b/packages/agent/src/agent/session-control.ts
@@ -52,6 +52,8 @@ async function* instrument(
     }
     yield ev;
   }
+  // Turn done — revert any `allow-once` egress grant made during it.
+  await a.egressGate?.endTurn().catch(() => {});
 }
 
 /** Send a prompt to Pi and stream the response. Pi manages its own session context. */

--- a/packages/agent/src/agent/session-control.ts
+++ b/packages/agent/src/agent/session-control.ts
@@ -26,34 +26,38 @@ async function* instrument(
   stream: AgentStream,
   onPermission?: PermissionHandler,
 ): AgentStream {
-  for await (const ev of stream) {
-    if (ev.type === "permission_request") {
-      void a.sandbox.emit(LedgerEvent.PermissionRequested, -1, {
-        requestId: ev.requestId,
-        tool: ev.tool,
-        target: ev.target,
-      });
-      if (onPermission) {
-        const req: PermissionRequest = {
+  try {
+    for await (const ev of stream) {
+      if (ev.type === "permission_request") {
+        void a.sandbox.emit(LedgerEvent.PermissionRequested, -1, {
           requestId: ev.requestId,
           tool: ev.tool,
           target: ev.target,
-          title: ev.title,
-        };
-        void Promise.resolve(onPermission(req))
-          .then((decision) => a.adapter.resolvePermission(ev.requestId, decision))
-          .catch(() => {});
+        });
+        if (onPermission) {
+          const req: PermissionRequest = {
+            requestId: ev.requestId,
+            tool: ev.tool,
+            target: ev.target,
+            title: ev.title,
+          };
+          void Promise.resolve(onPermission(req))
+            .then((decision) => a.adapter.resolvePermission(ev.requestId, decision))
+            .catch(() => {});
+        }
+      } else if (ev.type === "permission_resolved") {
+        void a.sandbox.emit(LedgerEvent.PermissionResolved, -1, {
+          requestId: ev.requestId,
+          decision: ev.decision,
+        });
       }
-    } else if (ev.type === "permission_resolved") {
-      void a.sandbox.emit(LedgerEvent.PermissionResolved, -1, {
-        requestId: ev.requestId,
-        decision: ev.decision,
-      });
+      yield ev;
     }
-    yield ev;
+  } finally {
+    // Turn done (or the consumer broke out / threw) — revert any `allow-once` egress grant
+    // made during it, so a one-shot grant never silently becomes permanent.
+    await a.egressGate?.endTurn().catch(() => {});
   }
-  // Turn done — revert any `allow-once` egress grant made during it.
-  await a.egressGate?.endTurn().catch(() => {});
 }
 
 /** Send a prompt to Pi and stream the response. Pi manages its own session context. */

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,12 @@
 export { Alineo } from "./agent";
 export type { PermissionHandler } from "./agent";
+export { EgressApprovalGate } from "./agent";
+export type {
+  EgressDecision,
+  EgressRequest,
+  EgressRequestHandler,
+  EgressApprovalGateOptions,
+} from "./agent";
 export type { AgentSpec, SetupStep } from "./schema";
 export { validateAgentSpec } from "./schema";
 export type {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,7 @@ export type {
   EgressRequest,
   EgressRequestHandler,
   EgressApprovalGateOptions,
+  HeldCredential,
 } from "./agent";
 export type { AgentSpec, SetupStep } from "./schema";
 export { validateAgentSpec } from "./schema";

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -43,6 +43,14 @@ export interface CredentialEnvBinding {
   injection:
     | { type: "header"; name: string }
     | { type: "substitution"; placeholder: string; in: Array<"path" | "query" | "header" | "body"> };
+  /**
+   * `"hold"` gates outbound egress to `host` behind a human decision: the agent's sandbox
+   * starts with `host` denied at the egress sidecar, the first request to it pauses and
+   * raises an approval request, and the host is allowed only once someone approves. Requires
+   * an `onEgressRequest` handler on `Alineo.load()`. Omit for the default (the host is
+   * reachable as soon as the credential is bound).
+   */
+  approval?: "hold";
 }
 
 /**
@@ -212,6 +220,7 @@ const CredentialEnvBindingSchema = z
         in: z.array(z.enum(["path", "query", "header", "body"])).min(1),
       }),
     ]),
+    approval: z.literal("hold").optional(),
   })
   .loose();
 

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -33,11 +33,16 @@ export interface CredentialEnvBinding {
   host: string;
   /** Narrows the binding to requests whose path starts with this prefix. */
   pathPrefix?: string;
-  /** How the credential reaches the request. */
+  /**
+   * How the credential reaches the request. `header` adds `name: <value>`. `substitution`
+   * replaces every literal `placeholder` in the listed request surfaces with the value — the
+   * request must already contain `placeholder` verbatim (put it in a base URL, say). Mirrors
+   * `@alineo-labs/core`'s `CredentialInjection`; `packages/agent/test/schema.test.ts` is the
+   * drift check.
+   */
   injection:
     | { type: "header"; name: string }
-    | { type: "query"; param: string }
-    | { type: "path"; segment: string };
+    | { type: "substitution"; placeholder: string; in: Array<"path" | "query" | "header" | "body"> };
 }
 
 /**
@@ -201,8 +206,11 @@ const CredentialEnvBindingSchema = z
     pathPrefix: z.string().optional(),
     injection: z.union([
       z.object({ type: z.literal("header"), name: z.string() }),
-      z.object({ type: z.literal("query"), param: z.string() }),
-      z.object({ type: z.literal("path"), segment: z.string() }),
+      z.object({
+        type: z.literal("substitution"),
+        placeholder: z.string(),
+        in: z.array(z.enum(["path", "query", "header", "body"])).min(1),
+      }),
     ]),
   })
   .loose();

--- a/packages/agent/src/schema.ts
+++ b/packages/agent/src/schema.ts
@@ -42,7 +42,11 @@ export interface CredentialEnvBinding {
    */
   injection:
     | { type: "header"; name: string }
-    | { type: "substitution"; placeholder: string; in: Array<"path" | "query" | "header" | "body"> };
+    | {
+        type: "substitution";
+        placeholder: string;
+        in: Array<"path" | "query" | "header" | "body">;
+      };
   /**
    * `"hold"` gates outbound egress to `host` behind a human decision: the agent's sandbox
    * starts with `host` denied at the egress sidecar, the first request to it pauses and

--- a/packages/agent/test/egress-approval.test.ts
+++ b/packages/agent/test/egress-approval.test.ts
@@ -166,6 +166,32 @@ describe("EgressApprovalGate", () => {
     }
   });
 
+  it("re-prompts on the next turn after an allow-once is reverted (dedup is cleared)", async () => {
+    const sb = fakeSandbox();
+    let calls = 0;
+    const gate = new EgressApprovalGate({
+      heldCredentials: [cred("gh", "held.example.com")],
+      handler: () => {
+        calls++;
+        return "allow-once";
+      },
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "held.example.com");
+      expect(calls).toBe(1);
+
+      await gate.endTurn();
+      // Same host, immediately — within DEDUP_TTL_MS. Without clearing `seen` this would be
+      // swallowed and the operator never re-asked.
+      await fireWebhook(gate, "held.example.com");
+      expect(calls).toBe(2);
+    } finally {
+      await gate.stop();
+    }
+  });
+
   it("endTurn() leaves an allow-always grant in place", async () => {
     const sb = fakeSandbox();
     const gate = new EgressApprovalGate({

--- a/packages/agent/test/egress-approval.test.ts
+++ b/packages/agent/test/egress-approval.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "bun:test";
+import type { SandboxHandle } from "@alineo-labs/core";
+import { EgressApprovalGate, type EgressDecision } from "../src/agent/egress-approval";
+
+interface FakeSandbox {
+  handle: SandboxHandle;
+  patches: Array<Array<{ action: string; target: string }>>;
+  emits: Array<{ event: string; payload: unknown }>;
+}
+
+function fakeSandbox(): FakeSandbox {
+  const patches: FakeSandbox["patches"] = [];
+  const emits: FakeSandbox["emits"] = [];
+  const handle = {
+    egress: {
+      patch: async (rules: Array<{ action: string; target: string }>) => {
+        patches.push(rules);
+      },
+    },
+    emit: async (event: string, _step: number, payload: unknown) => {
+      emits.push({ event, payload });
+    },
+  } as unknown as SandboxHandle;
+  return { handle, patches, emits };
+}
+
+/** POST a synthetic deny-webhook body to the gate's listener and let it settle. */
+async function fireWebhook(gate: EgressApprovalGate, hostname: string) {
+  await fetch(gate.webhookUrl.replace("172.17.0.1", "127.0.0.1"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ hostname }),
+  });
+  await new Promise((r) => setTimeout(r, 50));
+}
+
+describe("EgressApprovalGate", () => {
+  it("calls the handler for a held host and patches allow on approval", async () => {
+    const sb = fakeSandbox();
+    const seen: string[] = [];
+    const gate = new EgressApprovalGate({
+      heldHosts: ["api.example.com"],
+      handler: (req): EgressDecision => {
+        seen.push(req.host);
+        return "allow-always";
+      },
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "api.example.com");
+      expect(seen).toEqual(["api.example.com"]);
+      expect(sb.patches).toEqual([[{ action: "allow", target: "api.example.com" }]]);
+      expect(sb.emits.map((e) => e.event)).toEqual(["permission_requested", "permission_resolved"]);
+    } finally {
+      await gate.stop();
+    }
+  });
+
+  it("ignores a host it is not holding", async () => {
+    const sb = fakeSandbox();
+    let called = false;
+    const gate = new EgressApprovalGate({
+      heldHosts: ["held.example.com"],
+      handler: () => {
+        called = true;
+        return "allow-once";
+      },
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "other.example.com");
+      expect(called).toBe(false);
+      expect(sb.patches).toEqual([]);
+    } finally {
+      await gate.stop();
+    }
+  });
+
+  it("does not patch on deny", async () => {
+    const sb = fakeSandbox();
+    const gate = new EgressApprovalGate({
+      heldHosts: ["held.example.com"],
+      handler: () => "deny",
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "held.example.com.");
+      expect(sb.patches).toEqual([]);
+      const resolved = sb.emits.find((e) => e.event === "permission_resolved");
+      expect(resolved?.payload).toMatchObject({ decision: { kind: "deny" } });
+    } finally {
+      await gate.stop();
+    }
+  });
+
+  it("dedupes repeated denials of the same host within the TTL", async () => {
+    const sb = fakeSandbox();
+    let calls = 0;
+    const gate = new EgressApprovalGate({
+      heldHosts: ["held.example.com"],
+      handler: () => {
+        calls++;
+        return "allow-always";
+      },
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "held.example.com");
+      await fireWebhook(gate, "held.example.com");
+      await fireWebhook(gate, "held.example.com");
+      expect(calls).toBe(1);
+    } finally {
+      await gate.stop();
+    }
+  });
+
+  it("endTurn() reverts an allow-once grant to deny", async () => {
+    const sb = fakeSandbox();
+    const gate = new EgressApprovalGate({
+      heldHosts: ["held.example.com"],
+      handler: () => "allow-once",
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "held.example.com");
+      expect(sb.patches).toEqual([[{ action: "allow", target: "held.example.com" }]]);
+
+      await gate.endTurn();
+      expect(sb.patches[1]).toEqual([{ action: "deny", target: "held.example.com" }]);
+
+      // A second endTurn is a no-op (nothing left to revert).
+      await gate.endTurn();
+      expect(sb.patches).toHaveLength(2);
+    } finally {
+      await gate.stop();
+    }
+  });
+
+  it("endTurn() leaves an allow-always grant in place", async () => {
+    const sb = fakeSandbox();
+    const gate = new EgressApprovalGate({
+      heldHosts: ["held.example.com"],
+      handler: () => "allow-always",
+    });
+    await gate.start();
+    gate.bind(sb.handle);
+    try {
+      await fireWebhook(gate, "held.example.com");
+      await gate.endTurn();
+      expect(sb.patches).toHaveLength(1);
+    } finally {
+      await gate.stop();
+    }
+  });
+});

--- a/packages/agent/test/egress-approval.test.ts
+++ b/packages/agent/test/egress-approval.test.ts
@@ -1,15 +1,23 @@
 import { describe, expect, it } from "bun:test";
-import type { SandboxHandle } from "@alineo-labs/core";
-import { EgressApprovalGate, type EgressDecision } from "../src/agent/egress-approval";
+import type { CredentialBinding, SandboxHandle } from "@alineo-labs/core";
+import {
+  EgressApprovalGate,
+  type EgressDecision,
+  type HeldCredential,
+} from "../src/agent/egress-approval";
 
 interface FakeSandbox {
   handle: SandboxHandle;
   patches: Array<Array<{ action: string; target: string }>>;
+  credsSet: string[];
+  credsRemoved: string[];
   emits: Array<{ event: string; payload: unknown }>;
 }
 
 function fakeSandbox(): FakeSandbox {
   const patches: FakeSandbox["patches"] = [];
+  const credsSet: string[] = [];
+  const credsRemoved: string[] = [];
   const emits: FakeSandbox["emits"] = [];
   const handle = {
     egress: {
@@ -17,11 +25,24 @@ function fakeSandbox(): FakeSandbox {
         patches.push(rules);
       },
     },
+    credentials: {
+      set: async (name: string) => {
+        credsSet.push(name);
+      },
+      remove: async (name: string) => {
+        credsRemoved.push(name);
+      },
+    },
     emit: async (event: string, _step: number, payload: unknown) => {
       emits.push({ event, payload });
     },
   } as unknown as SandboxHandle;
-  return { handle, patches, emits };
+  return { handle, patches, credsSet, credsRemoved, emits };
+}
+
+function cred(name: string, host: string): HeldCredential {
+  const binding: CredentialBinding = { host, injection: { type: "header", name: "Authorization" } };
+  return { name, value: `${name}-value`, binding };
 }
 
 /** POST a synthetic deny-webhook body to the gate's listener and let it settle. */
@@ -35,11 +56,11 @@ async function fireWebhook(gate: EgressApprovalGate, hostname: string) {
 }
 
 describe("EgressApprovalGate", () => {
-  it("calls the handler for a held host and patches allow on approval", async () => {
+  it("on approval: opens the host first, then registers the credential", async () => {
     const sb = fakeSandbox();
     const seen: string[] = [];
     const gate = new EgressApprovalGate({
-      heldHosts: ["api.example.com"],
+      heldCredentials: [cred("gh", "api.github.com")],
       handler: (req): EgressDecision => {
         seen.push(req.host);
         return "allow-always";
@@ -48,9 +69,10 @@ describe("EgressApprovalGate", () => {
     await gate.start();
     gate.bind(sb.handle);
     try {
-      await fireWebhook(gate, "api.example.com");
-      expect(seen).toEqual(["api.example.com"]);
-      expect(sb.patches).toEqual([[{ action: "allow", target: "api.example.com" }]]);
+      await fireWebhook(gate, "api.github.com");
+      expect(seen).toEqual(["api.github.com"]);
+      expect(sb.patches).toEqual([[{ action: "allow", target: "api.github.com" }]]);
+      expect(sb.credsSet).toEqual(["gh"]);
       expect(sb.emits.map((e) => e.event)).toEqual(["permission_requested", "permission_resolved"]);
     } finally {
       await gate.stop();
@@ -61,7 +83,7 @@ describe("EgressApprovalGate", () => {
     const sb = fakeSandbox();
     let called = false;
     const gate = new EgressApprovalGate({
-      heldHosts: ["held.example.com"],
+      heldCredentials: [cred("gh", "api.github.com")],
       handler: () => {
         called = true;
         return "allow-once";
@@ -73,15 +95,16 @@ describe("EgressApprovalGate", () => {
       await fireWebhook(gate, "other.example.com");
       expect(called).toBe(false);
       expect(sb.patches).toEqual([]);
+      expect(sb.credsSet).toEqual([]);
     } finally {
       await gate.stop();
     }
   });
 
-  it("does not patch on deny", async () => {
+  it("on deny: neither opens the host nor registers the credential", async () => {
     const sb = fakeSandbox();
     const gate = new EgressApprovalGate({
-      heldHosts: ["held.example.com"],
+      heldCredentials: [cred("gh", "held.example.com")],
       handler: () => "deny",
     });
     await gate.start();
@@ -89,6 +112,7 @@ describe("EgressApprovalGate", () => {
     try {
       await fireWebhook(gate, "held.example.com.");
       expect(sb.patches).toEqual([]);
+      expect(sb.credsSet).toEqual([]);
       const resolved = sb.emits.find((e) => e.event === "permission_resolved");
       expect(resolved?.payload).toMatchObject({ decision: { kind: "deny" } });
     } finally {
@@ -100,7 +124,7 @@ describe("EgressApprovalGate", () => {
     const sb = fakeSandbox();
     let calls = 0;
     const gate = new EgressApprovalGate({
-      heldHosts: ["held.example.com"],
+      heldCredentials: [cred("gh", "held.example.com")],
       handler: () => {
         calls++;
         return "allow-always";
@@ -118,10 +142,10 @@ describe("EgressApprovalGate", () => {
     }
   });
 
-  it("endTurn() reverts an allow-once grant to deny", async () => {
+  it("endTurn() reverses an allow-once grant: removes the credential, re-denies the host", async () => {
     const sb = fakeSandbox();
     const gate = new EgressApprovalGate({
-      heldHosts: ["held.example.com"],
+      heldCredentials: [cred("gh", "held.example.com")],
       handler: () => "allow-once",
     });
     await gate.start();
@@ -129,12 +153,13 @@ describe("EgressApprovalGate", () => {
     try {
       await fireWebhook(gate, "held.example.com");
       expect(sb.patches).toEqual([[{ action: "allow", target: "held.example.com" }]]);
+      expect(sb.credsSet).toEqual(["gh"]);
 
       await gate.endTurn();
+      expect(sb.credsRemoved).toEqual(["gh"]);
       expect(sb.patches[1]).toEqual([{ action: "deny", target: "held.example.com" }]);
 
-      // A second endTurn is a no-op (nothing left to revert).
-      await gate.endTurn();
+      await gate.endTurn(); // no-op the second time
       expect(sb.patches).toHaveLength(2);
     } finally {
       await gate.stop();
@@ -144,7 +169,7 @@ describe("EgressApprovalGate", () => {
   it("endTurn() leaves an allow-always grant in place", async () => {
     const sb = fakeSandbox();
     const gate = new EgressApprovalGate({
-      heldHosts: ["held.example.com"],
+      heldCredentials: [cred("gh", "held.example.com")],
       handler: () => "allow-always",
     });
     await gate.start();
@@ -153,6 +178,7 @@ describe("EgressApprovalGate", () => {
       await fireWebhook(gate, "held.example.com");
       await gate.endTurn();
       expect(sb.patches).toHaveLength(1);
+      expect(sb.credsRemoved).toEqual([]);
     } finally {
       await gate.stop();
     }

--- a/packages/agent/test/session-control-endturn.test.ts
+++ b/packages/agent/test/session-control-endturn.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentEvent } from "../src/types";
+import { bash } from "../src/agent/session-control";
+import type { AgentInternal } from "../src/agent/internal";
+
+/** An `AgentInternal` just complete enough for `bash()` → `instrument()`. */
+function fakeAgent(events: AgentEvent[]) {
+  let endTurnCalls = 0;
+  const a = {
+    adapter: {
+      // eslint-disable-next-line require-yield
+      bash: async function* () {
+        for (const ev of events) yield ev;
+      },
+    },
+    sandbox: { emit: async () => {} },
+    env: {},
+    egressGate: {
+      endTurn: async () => {
+        endTurnCalls++;
+      },
+    },
+  } as unknown as AgentInternal;
+  return { a, endTurnCalls: () => endTurnCalls };
+}
+
+const events: AgentEvent[] = [
+  { type: "text", text: "one" },
+  { type: "text", text: "two" },
+  { type: "text", text: "three" },
+];
+
+describe("session-control instrument() — egressGate.endTurn()", () => {
+  it("runs on normal completion", async () => {
+    const { a, endTurnCalls } = fakeAgent(events);
+    for await (const _ of bash(a, "x")) void _;
+    expect(endTurnCalls()).toBe(1);
+  });
+
+  it("runs when the consumer breaks out early", async () => {
+    const { a, endTurnCalls } = fakeAgent(events);
+    for await (const ev of bash(a, "x")) {
+      if (ev.type === "text") break;
+    }
+    expect(endTurnCalls()).toBe(1);
+  });
+
+  it("runs when the consumer's loop body throws", async () => {
+    const { a, endTurnCalls } = fakeAgent(events);
+    let caught: unknown;
+    try {
+      for await (const _ of bash(a, "x")) {
+        void _;
+        throw new Error("boom");
+      }
+    } catch (e) {
+      caught = e;
+    }
+    expect((caught as Error).message).toBe("boom");
+    expect(endTurnCalls()).toBe(1);
+  });
+});

--- a/packages/core/src/credentials.ts
+++ b/packages/core/src/credentials.ts
@@ -3,6 +3,26 @@ import { LedgerEvent } from "./ledger";
 import type { LedgerEntry } from "./ledger";
 
 /**
+ * How a credential reaches an outbound request.
+ *
+ * - `header` — the sidecar adds the header `name: <value>` (value unprefixed; use it for
+ *   `Authorization`, `X-API-Key`, etc.). The common case.
+ * - `substitution` — the sidecar replaces every literal occurrence of `placeholder` in the
+ *   listed request surfaces with the value. **The request must already contain `placeholder`
+ *   verbatim** — the agent or its config puts it there (e.g. a base URL of
+ *   `https://api.example.com/v1?key=__API_KEY__`). This is the escape hatch for APIs that
+ *   only take a key in the URL; `path`/`query` values are URL-encoded, `body` is encoded per
+ *   content-type.
+ */
+export type CredentialInjection =
+  | { type: "header"; name: string }
+  | {
+      type: "substitution";
+      placeholder: string;
+      in: Array<"path" | "query" | "header" | "body">;
+    };
+
+/**
  * Where and how a credential is injected into outbound requests. Matched by `host` (an FQDN
  * or wildcard domain, e.g. `"api.github.com"` or `"*.openai.com"`) and, optionally, a
  * `pathPrefix` to further scope the binding within that host.
@@ -13,10 +33,7 @@ export interface CredentialBinding {
   /** Narrows the binding to requests whose path starts with this prefix. */
   pathPrefix?: string;
   /** How the credential reaches the request. */
-  injection:
-    | { type: "header"; name: string }
-    | { type: "query"; param: string }
-    | { type: "path"; segment: string };
+  injection: CredentialInjection;
 }
 
 /**

--- a/packages/core/src/egress.ts
+++ b/packages/core/src/egress.ts
@@ -1,0 +1,27 @@
+import type { NetworkRule } from "@alineo-labs/opensandbox";
+import { LedgerEvent } from "./ledger";
+import type { LedgerEntry } from "./ledger";
+
+/**
+ * Reconstruct the egress rules that should still be applied to a resumed or forked sandbox,
+ * from that session's ledger history. Egress policy is sidecar-local runtime state — it does
+ * not survive the sidecar restarting and is not restored by OpenSandbox's snapshot/checkpoint
+ * — so `Sandbox.resume()` and `sb.fork()` re-apply whatever `sb.egress.patch()` added and
+ * `sb.egress.delete()` did not later remove.
+ *
+ * Keyed by `target` (the sidecar's own merge key): a later add for the same target wins, a
+ * later delete drops it. Scans the whole history, like `reconstructBoundCredentials`.
+ */
+export function reconstructEgressRules(entries: LedgerEntry[]): NetworkRule[] {
+  const byTarget = new Map<string, NetworkRule>();
+  for (const entry of entries) {
+    if (entry.event === LedgerEvent.EgressRuleAdded) {
+      const { rules } = entry.payload as { rules: NetworkRule[] };
+      for (const rule of rules) byTarget.set(rule.target, rule);
+    } else if (entry.event === LedgerEvent.EgressRuleRemoved) {
+      const { targets } = entry.payload as { targets: string[] };
+      for (const target of targets) byTarget.delete(target);
+    }
+  }
+  return [...byTarget.values()];
+}

--- a/packages/core/src/egress.ts
+++ b/packages/core/src/egress.ts
@@ -2,26 +2,48 @@ import type { NetworkRule } from "@alineo-labs/opensandbox";
 import { LedgerEvent } from "./ledger";
 import type { LedgerEntry } from "./ledger";
 
+/** The still-live outcome of a session's runtime `sb.egress.*` calls. */
+export interface ReconstructedEgress {
+  /** Rules to (re-)apply — a later add for the same target supersedes an earlier one. */
+  apply: NetworkRule[];
+  /**
+   * Targets a `sb.egress.delete()` removed and no later `patch()` re-added — these must be
+   * dropped from the resumed sandbox's boot policy too, not just from the runtime deltas
+   * (a `delete()` of a rule that came from the *original* `networkPolicy` would otherwise be
+   * silently undone on resume).
+   */
+  remove: string[];
+}
+
 /**
- * Reconstruct the egress rules that should still be applied to a resumed or forked sandbox,
- * from that session's ledger history. Egress policy is sidecar-local runtime state — it does
- * not survive the sidecar restarting and is not restored by OpenSandbox's snapshot/checkpoint
- * — so `Sandbox.resume()` and `sb.fork()` re-apply whatever `sb.egress.patch()` added and
- * `sb.egress.delete()` did not later remove.
+ * Reconstruct, from a session's ledger history, what its runtime `sb.egress.patch()` /
+ * `sb.egress.delete()` calls still amount to. Egress policy is sidecar-local runtime state —
+ * it does not survive the sidecar restarting and is not restored by OpenSandbox's
+ * snapshot/checkpoint — so `Sandbox.resume()` folds this back into the resumed sandbox's boot
+ * `networkPolicy`.
  *
- * Keyed by `target` (the sidecar's own merge key): a later add for the same target wins, a
- * later delete drops it. Scans the whole history, like `reconstructBoundCredentials`.
+ * Keyed by `target` (the sidecar's own merge key): a later add for a target wins; a later
+ * delete removes it (and is reported in `remove` so a boot-policy rule can be dropped too);
+ * a re-add after a delete brings it back. Scans the whole history, like
+ * `reconstructBoundCredentials`.
  */
-export function reconstructEgressRules(entries: LedgerEntry[]): NetworkRule[] {
+export function reconstructEgressRules(entries: LedgerEntry[]): ReconstructedEgress {
   const byTarget = new Map<string, NetworkRule>();
+  const removed = new Set<string>();
   for (const entry of entries) {
     if (entry.event === LedgerEvent.EgressRuleAdded) {
       const { rules } = entry.payload as { rules: NetworkRule[] };
-      for (const rule of rules) byTarget.set(rule.target, rule);
+      for (const rule of rules) {
+        byTarget.set(rule.target, rule);
+        removed.delete(rule.target);
+      }
     } else if (entry.event === LedgerEvent.EgressRuleRemoved) {
       const { targets } = entry.payload as { targets: string[] };
-      for (const target of targets) byTarget.delete(target);
+      for (const target of targets) {
+        byTarget.delete(target);
+        removed.add(target);
+      }
     }
   }
-  return [...byTarget.values()];
+  return { apply: [...byTarget.values()], remove: [...removed] };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export type {
 } from "./credentials";
 export { resolveBoundCredential, reconstructBoundCredentials } from "./credentials";
 export { reconstructEgressRules } from "./egress";
+export type { ReconstructedEgress } from "./egress";
 
 export { SandboxHandle, BashSession, resolveExecClient, composeHooks } from "./sandbox/index";
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,12 +13,14 @@ export type { ILogger } from "./logger";
 
 export type {
   CredentialBinding,
+  CredentialInjection,
   CredentialBroker,
   CredentialSource,
   CredentialResolver,
   BoundCredential,
 } from "./credentials";
 export { resolveBoundCredential, reconstructBoundCredentials } from "./credentials";
+export { reconstructEgressRules } from "./egress";
 
 export { SandboxHandle, BashSession, resolveExecClient, composeHooks } from "./sandbox/index";
 export type {

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -94,6 +94,14 @@ export enum LedgerEvent {
   CredentialBound = "credential_bound",
   /** Emitted by `sb.credentials.remove()`. */
   CredentialRevoked = "credential_revoked",
+  /**
+   * Emitted by `sb.egress.patch()`. Payload is `{ rules: NetworkRule[] }` — the exact rules
+   * passed to the sidecar, so `Sandbox.resume()`/`sb.fork()` can re-apply a still-wanted
+   * allowance (egress policy is sidecar-local and does not survive either).
+   */
+  EgressRuleAdded = "egress_rule_added",
+  /** Emitted by `sb.egress.delete()`. Payload is `{ targets: string[] }`. */
+  EgressRuleRemoved = "egress_rule_removed",
 
   // ── Agent human-in-the-loop events (used by the `alineo` agent SDK) ──────────────
   /**

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -96,8 +96,9 @@ export enum LedgerEvent {
   CredentialRevoked = "credential_revoked",
   /**
    * Emitted by `sb.egress.patch()`. Payload is `{ rules: NetworkRule[] }` — the exact rules
-   * passed to the sidecar, so `Sandbox.resume()`/`sb.fork()` can re-apply a still-wanted
-   * allowance (egress policy is sidecar-local and does not survive either).
+   * passed to the sidecar, so `Sandbox.resume()` can fold a still-wanted allowance back into
+   * the resumed sandbox's boot policy (egress policy is sidecar-local and does not survive a
+   * resume). `sb.fork()` does not carry these.
    */
   EgressRuleAdded = "egress_rule_added",
   /** Emitted by `sb.egress.delete()`. Payload is `{ targets: string[] }`. */

--- a/packages/core/src/sandbox/egress.ts
+++ b/packages/core/src/sandbox/egress.ts
@@ -1,0 +1,31 @@
+import { EgressClient, type EgressPolicyStatus, type NetworkRule } from "@alineo-labs/opensandbox";
+import { LedgerEvent } from "../ledger";
+import type { SandboxInternal } from "./internal";
+
+function client(sb: SandboxInternal): EgressClient {
+  return new EgressClient(sb.deps.control, sb.deps.useServerProxy);
+}
+
+/**
+ * Merge allow/deny rules into this sandbox's live egress policy. An incoming rule replaces
+ * any existing rule with the same `target`; every other rule and the `defaultAction` are
+ * untouched. The change is applied to the running sidecar immediately.
+ *
+ * Recorded to the ledger (the rules only, no secrets) so `Sandbox.resume()` / `sb.fork()`
+ * can re-apply a still-wanted allowance — egress policy does not survive either.
+ */
+export async function patch(sb: SandboxInternal, rules: NetworkRule[]): Promise<void> {
+  await client(sb).patchRules(sb.sandboxId, rules);
+  await sb.emit(LedgerEvent.EgressRuleAdded, -1, { rules });
+}
+
+/** Remove egress rules from this sandbox's live policy, by `target`. Unknown targets are ignored. */
+export async function remove(sb: SandboxInternal, targets: string[]): Promise<void> {
+  await client(sb).deleteRules(sb.sandboxId, targets);
+  await sb.emit(LedgerEvent.EgressRuleRemoved, -1, { targets });
+}
+
+/** This sandbox's current egress policy, as the sidecar reports it. */
+export async function get(sb: SandboxInternal): Promise<EgressPolicyStatus> {
+  return client(sb).getPolicy(sb.sandboxId);
+}

--- a/packages/core/src/sandbox/egress.ts
+++ b/packages/core/src/sandbox/egress.ts
@@ -11,8 +11,10 @@ function client(sb: SandboxInternal): EgressClient {
  * any existing rule with the same `target`; every other rule and the `defaultAction` are
  * untouched. The change is applied to the running sidecar immediately.
  *
- * Recorded to the ledger (the rules only, no secrets) so `Sandbox.resume()` / `sb.fork()`
- * can re-apply a still-wanted allowance — egress policy does not survive either.
+ * Recorded to the ledger (the rules only, no secrets) so `Sandbox.resume()` can fold a
+ * still-wanted change back into the resumed sandbox's boot policy — egress policy is
+ * sidecar-local and does not survive a resume. (`sb.fork()` does not carry runtime egress
+ * rules: a fork is a fresh branch and gets a wide-open `defaultAction: "allow"` policy.)
  */
 export async function patch(sb: SandboxInternal, rules: NetworkRule[]): Promise<void> {
   await client(sb).patchRules(sb.sandboxId, rules);

--- a/packages/core/src/sandbox/sandbox.ts
+++ b/packages/core/src/sandbox/sandbox.ts
@@ -1,4 +1,11 @@
-import type { Metrics, DiagnosticLog, DiagnosticEvent, FileInfo } from "@alineo-labs/opensandbox";
+import type {
+  Metrics,
+  DiagnosticLog,
+  DiagnosticEvent,
+  FileInfo,
+  NetworkRule,
+  EgressPolicyStatus,
+} from "@alineo-labs/opensandbox";
 import type { CheckpointInfo } from "../ledger";
 import type { CredentialBinding, CredentialSource, CredentialResolver } from "../credentials";
 import { SandboxCore } from "./core";
@@ -6,6 +13,7 @@ import * as files from "./files";
 import * as lifecycle from "./lifecycle";
 import * as observability from "./observability";
 import * as creds from "./credentials";
+import * as egressRules from "./egress";
 
 /**
  * A live sandbox container. Returned by `Sandbox.sandbox()` and `Sandbox.resume()`.
@@ -151,6 +159,28 @@ export class SandboxHandle extends SandboxCore {
     remove: (name: string): Promise<void> => creds.remove(this, name),
     listBindings: (): Promise<Array<{ name: string; binding: CredentialBinding }>> =>
       creds.listBindings(this),
+  };
+
+  /**
+   * Adjust this sandbox's outbound network policy at runtime, via its egress sidecar. Only
+   * meaningful when the sandbox was created with a `networkPolicy` (otherwise no sidecar is
+   * attached and these calls error).
+   *
+   * `patch` merges rules in (an incoming rule replaces any rule with the same `target`);
+   * `delete` removes rules by `target`. Both take effect on the running sidecar immediately
+   * and are recorded to the ledger so `resume()`/`fork()` can re-apply a still-wanted change.
+   *
+   * @example
+   * ```ts
+   * await sb.egress.patch([{ action: "allow", target: "api.github.com" }]);
+   * // …later
+   * await sb.egress.delete(["api.github.com"]);
+   * ```
+   */
+  readonly egress = {
+    patch: (rules: NetworkRule[]): Promise<void> => egressRules.patch(this, rules),
+    delete: (targets: string[]): Promise<void> => egressRules.remove(this, targets),
+    get: (): Promise<EgressPolicyStatus> => egressRules.get(this),
   };
 
   /**

--- a/packages/core/test/egress-reconstruct.test.ts
+++ b/packages/core/test/egress-reconstruct.test.ts
@@ -8,12 +8,15 @@ function entry(event: LedgerEvent, payload: unknown): LedgerEntry {
 }
 
 describe("reconstructEgressRules", () => {
-  it("returns [] for a history with no egress events", () => {
-    expect(reconstructEgressRules([entry(LedgerEvent.SandboxCreated, {})])).toEqual([]);
+  it("returns empty for a history with no egress events", () => {
+    expect(reconstructEgressRules([entry(LedgerEvent.SandboxCreated, {})])).toEqual({
+      apply: [],
+      remove: [],
+    });
   });
 
   it("collects added rules across multiple patches", () => {
-    const rules = reconstructEgressRules([
+    const { apply, remove } = reconstructEgressRules([
       entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
       entry(LedgerEvent.EgressRuleAdded, {
         rules: [
@@ -22,23 +25,24 @@ describe("reconstructEgressRules", () => {
         ],
       }),
     ]);
-    expect(rules).toEqual([
+    expect(apply).toEqual([
       { action: "allow", target: "a.com" },
       { action: "allow", target: "b.com" },
       { action: "deny", target: "c.com" },
     ]);
+    expect(remove).toEqual([]);
   });
 
   it("a later add for the same target wins", () => {
-    const rules = reconstructEgressRules([
+    const { apply } = reconstructEgressRules([
       entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "deny", target: "a.com" }] }),
       entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
     ]);
-    expect(rules).toEqual([{ action: "allow", target: "a.com" }]);
+    expect(apply).toEqual([{ action: "allow", target: "a.com" }]);
   });
 
-  it("a later delete drops the rule", () => {
-    const rules = reconstructEgressRules([
+  it("a later delete drops a runtime-added rule and reports the target as removed", () => {
+    const { apply, remove } = reconstructEgressRules([
       entry(LedgerEvent.EgressRuleAdded, {
         rules: [
           { action: "allow", target: "a.com" },
@@ -47,15 +51,25 @@ describe("reconstructEgressRules", () => {
       }),
       entry(LedgerEvent.EgressRuleRemoved, { targets: ["a.com"] }),
     ]);
-    expect(rules).toEqual([{ action: "allow", target: "b.com" }]);
+    expect(apply).toEqual([{ action: "allow", target: "b.com" }]);
+    expect(remove).toEqual(["a.com"]);
   });
 
-  it("a re-add after a delete brings the rule back", () => {
-    const rules = reconstructEgressRules([
+  it("reports a delete of a target that was never added (i.e. a boot-policy rule)", () => {
+    const { apply, remove } = reconstructEgressRules([
+      entry(LedgerEvent.EgressRuleRemoved, { targets: ["boot.example.com"] }),
+    ]);
+    expect(apply).toEqual([]);
+    expect(remove).toEqual(["boot.example.com"]);
+  });
+
+  it("a re-add after a delete brings the rule back and clears the removal", () => {
+    const { apply, remove } = reconstructEgressRules([
       entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
       entry(LedgerEvent.EgressRuleRemoved, { targets: ["a.com"] }),
       entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
     ]);
-    expect(rules).toEqual([{ action: "allow", target: "a.com" }]);
+    expect(apply).toEqual([{ action: "allow", target: "a.com" }]);
+    expect(remove).toEqual([]);
   });
 });

--- a/packages/core/test/egress-reconstruct.test.ts
+++ b/packages/core/test/egress-reconstruct.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { reconstructEgressRules } from "../src/egress.ts";
+import { LedgerEvent } from "../src/ledger.ts";
+import type { LedgerEntry } from "../src/ledger.ts";
+
+function entry(event: LedgerEvent, payload: unknown): LedgerEntry {
+  return { ts: 0, name: "s", sandboxId: "sb", stepIndex: -1, event, payload };
+}
+
+describe("reconstructEgressRules", () => {
+  it("returns [] for a history with no egress events", () => {
+    expect(reconstructEgressRules([entry(LedgerEvent.SandboxCreated, {})])).toEqual([]);
+  });
+
+  it("collects added rules across multiple patches", () => {
+    const rules = reconstructEgressRules([
+      entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
+      entry(LedgerEvent.EgressRuleAdded, {
+        rules: [
+          { action: "allow", target: "b.com" },
+          { action: "deny", target: "c.com" },
+        ],
+      }),
+    ]);
+    expect(rules).toEqual([
+      { action: "allow", target: "a.com" },
+      { action: "allow", target: "b.com" },
+      { action: "deny", target: "c.com" },
+    ]);
+  });
+
+  it("a later add for the same target wins", () => {
+    const rules = reconstructEgressRules([
+      entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "deny", target: "a.com" }] }),
+      entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
+    ]);
+    expect(rules).toEqual([{ action: "allow", target: "a.com" }]);
+  });
+
+  it("a later delete drops the rule", () => {
+    const rules = reconstructEgressRules([
+      entry(LedgerEvent.EgressRuleAdded, {
+        rules: [
+          { action: "allow", target: "a.com" },
+          { action: "allow", target: "b.com" },
+        ],
+      }),
+      entry(LedgerEvent.EgressRuleRemoved, { targets: ["a.com"] }),
+    ]);
+    expect(rules).toEqual([{ action: "allow", target: "b.com" }]);
+  });
+
+  it("a re-add after a delete brings the rule back", () => {
+    const rules = reconstructEgressRules([
+      entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
+      entry(LedgerEvent.EgressRuleRemoved, { targets: ["a.com"] }),
+      entry(LedgerEvent.EgressRuleAdded, { rules: [{ action: "allow", target: "a.com" }] }),
+    ]);
+    expect(rules).toEqual([{ action: "allow", target: "a.com" }]);
+  });
+});

--- a/packages/opensandbox/src/egress-target.ts
+++ b/packages/opensandbox/src/egress-target.ts
@@ -1,0 +1,47 @@
+// Validation for `NetworkRule.target` values — mirrors the egress sidecar's own parse order
+// (`components/egress/pkg/policy/policy.go` `normalizePolicy`): try bare IP, then CIDR, then
+// treat it as a domain. We reject only strings that could not be any of the three, so a
+// malformed `networkPolicy` fails locally instead of on a server round-trip.
+
+const IPV4_OCTET = "(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)";
+const IPV4 = `${IPV4_OCTET}(\\.${IPV4_OCTET}){3}`;
+// Deliberately permissive IPv6 — full RFC 4291 is not worth reproducing; this catches the
+// common forms and obvious garbage. The server is the authority.
+const IPV6 = "([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}";
+
+const ipv4Re = new RegExp(`^${IPV4}$`);
+const ipv6Re = new RegExp(`^${IPV6}$`);
+
+/** A single DNS label: alphanumeric plus internal hyphens, 1–63 chars. */
+const LABEL = "(?!-)[A-Za-z0-9-]{1,63}(?<!-)";
+// A domain, optionally with a single leading `*.` wildcard (the sidecar's only wildcard form).
+const domainRe = new RegExp(`^(\\*\\.)?(${LABEL}\\.)*${LABEL}\\.?$`);
+
+function isIpAddress(s: string): boolean {
+  return ipv4Re.test(s) || ipv6Re.test(s);
+}
+
+function isCidr(s: string): boolean {
+  const slash = s.lastIndexOf("/");
+  if (slash === -1) return false;
+  const addr = s.slice(0, slash);
+  const bits = s.slice(slash + 1);
+  if (!/^\d{1,3}$/.test(bits)) return false;
+  const n = Number(bits);
+  if (ipv4Re.test(addr)) return n <= 32;
+  if (ipv6Re.test(addr)) return n <= 128;
+  return false;
+}
+
+/**
+ * Returns whether `target` is a usable `NetworkRule.target`: an FQDN, a `*.`-prefixed
+ * wildcard domain, a bare IPv4/IPv6 address, or a CIDR block. Whitespace-only, URL-shaped
+ * (`http://…`), or otherwise malformed strings return `false`.
+ */
+export function isValidEgressTarget(target: string): boolean {
+  const t = target.trim(); // the sidecar trims too (policy.go normalizePolicy)
+  if (t === "") return false;
+  if (isIpAddress(t)) return true;
+  if (isCidr(t)) return true;
+  return domainRe.test(t);
+}

--- a/packages/opensandbox/src/egress-target.ts
+++ b/packages/opensandbox/src/egress-target.ts
@@ -1,24 +1,29 @@
 // Validation for `NetworkRule.target` values — mirrors the egress sidecar's own parse order
 // (`components/egress/pkg/policy/policy.go` `normalizePolicy`): try bare IP, then CIDR, then
-// treat it as a domain. We reject only strings that could not be any of the three, so a
-// malformed `networkPolicy` fails locally instead of on a server round-trip.
+// treat it as a domain. This is a fast local guard against an obviously-malformed policy, not
+// a re-implementation of `net/netip` — it errs toward accepting: the server is the authority,
+// and a false rejection here is worse than the round-trip the guard exists to save.
 
 const IPV4_OCTET = "(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)";
-const IPV4 = `${IPV4_OCTET}(\\.${IPV4_OCTET}){3}`;
-// Deliberately permissive IPv6 — full RFC 4291 is not worth reproducing; this catches the
-// common forms and obvious garbage. The server is the authority.
-const IPV6 = "([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}";
+const ipv4Re = new RegExp(`^${IPV4_OCTET}(\\.${IPV4_OCTET}){3}$`);
 
-const ipv4Re = new RegExp(`^${IPV4}$`);
-const ipv6Re = new RegExp(`^${IPV6}$`);
+// Permissive IPv6: anything made of hex groups + colons, optionally with a trailing
+// dotted-quad (IPv4-mapped forms like `::ffff:192.168.1.1`). Requires a `::` or ≥2 colons so
+// a bare word can't match. Full RFC 4291 validation is the server's job.
+const ipv6Re =
+  /^(?=.*:)[0-9a-fA-F:]*(?::(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3})?$/;
 
 /** A single DNS label: alphanumeric plus internal hyphens, 1–63 chars. */
 const LABEL = "(?!-)[A-Za-z0-9-]{1,63}(?<!-)";
 // A domain, optionally with a single leading `*.` wildcard (the sidecar's only wildcard form).
 const domainRe = new RegExp(`^(\\*\\.)?(${LABEL}\\.)*${LABEL}\\.?$`);
 
+function isIpv6(s: string): boolean {
+  return (s.includes("::") || (s.match(/:/g)?.length ?? 0) >= 2) && ipv6Re.test(s);
+}
+
 function isIpAddress(s: string): boolean {
-  return ipv4Re.test(s) || ipv6Re.test(s);
+  return ipv4Re.test(s) || isIpv6(s);
 }
 
 function isCidr(s: string): boolean {
@@ -29,18 +34,18 @@ function isCidr(s: string): boolean {
   if (!/^\d{1,3}$/.test(bits)) return false;
   const n = Number(bits);
   if (ipv4Re.test(addr)) return n <= 32;
-  if (ipv6Re.test(addr)) return n <= 128;
+  if (isIpv6(addr)) return n <= 128;
   return false;
 }
 
 /**
- * Returns whether `target` is a usable `NetworkRule.target`: an FQDN, a `*.`-prefixed
+ * Returns whether `target` is a plausible `NetworkRule.target`: an FQDN, a `*.`-prefixed
  * wildcard domain, a bare IPv4/IPv6 address, or a CIDR block. Whitespace-only, URL-shaped
- * (`http://…`), or otherwise malformed strings return `false`.
+ * (`http://…`), space-containing, or otherwise clearly-malformed strings return `false`.
  */
 export function isValidEgressTarget(target: string): boolean {
   const t = target.trim(); // the sidecar trims too (policy.go normalizePolicy)
-  if (t === "") return false;
+  if (t === "" || /\s/.test(t) || t.includes("/") !== isCidr(t)) return false;
   if (isIpAddress(t)) return true;
   if (isCidr(t)) return true;
   return domainRe.test(t);

--- a/packages/opensandbox/src/egress.ts
+++ b/packages/opensandbox/src/egress.ts
@@ -54,20 +54,29 @@ export class EgressClient {
   private async request<T>(sandboxId: string, method: string, body?: unknown): Promise<T> {
     const ep = await this.control.getEndpoint(sandboxId, EgressClient.PORT, this.useServerProxy);
     const baseUrl = ep.endpoint.startsWith("http") ? ep.endpoint : `http://${ep.endpoint}`;
-    const res = await fetch(`${baseUrl}/policy`, {
-      method,
-      headers: {
-        ...ep.headers,
-        ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
-      },
-      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-    });
-    if (!res.ok) {
+    const headers = {
+      ...ep.headers,
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+    };
+    const init = { method, headers, ...(body !== undefined ? { body: JSON.stringify(body) } : {}) };
+
+    // Right after a sandbox (or fork/resume) is created, the egress sidecar can accept a
+    // connection a beat before its request handling is wired up — surfacing as a proxy 500/502
+    // or the sidecar's own 412 "not ready". Same retry `VaultClient` uses on `:18080`.
+    const delaysMs = [0, 300, 600, 1200, 2400];
+    let lastErr: EgressClientError | undefined;
+    for (const delay of delaysMs) {
+      if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+      const res = await fetch(`${baseUrl}/policy`, init);
+      if (res.ok) {
+        if (res.status === 204) return undefined as T;
+        return (await res.json()) as T;
+      }
       const text = await res.text().catch(() => "");
-      throw new EgressClientError(text || "egress policy API error", res.status);
+      lastErr = new EgressClientError(text || "egress policy API error", res.status);
+      if (res.status !== 500 && res.status !== 502 && res.status !== 412) throw lastErr;
     }
-    if (res.status === 204) return undefined as T;
-    return res.json() as Promise<T>;
+    throw lastErr ?? new EgressClientError("egress policy API error", 500);
   }
 
   /** Merge `rules` into the live policy — an incoming rule replaces any rule with the same `target`. */

--- a/packages/opensandbox/src/egress.ts
+++ b/packages/opensandbox/src/egress.ts
@@ -39,9 +39,9 @@ export interface EgressPolicyStatus {
  * - `GET /policy` — returns `{ status, mode, enforcementMode, policy }`.
  *
  * Egress policy is sidecar-local runtime state: it does not survive the sidecar restarting
- * and is not restored by OpenSandbox's snapshot/checkpoint — callers that need a change to
- * outlive a `resume()`/`fork()` must re-apply it (`@alineo-labs/core` replays from the
- * ledger).
+ * and is not restored by OpenSandbox's snapshot/checkpoint — `@alineo-labs/core` folds a
+ * `resume()`d sandbox's still-live changes back into its boot policy from the ledger. (A
+ * `fork()` does not carry them.)
  */
 export class EgressClient {
   private static readonly PORT = 18080;
@@ -70,7 +70,11 @@ export class EgressClient {
       const res = await fetch(`${baseUrl}/policy`, init);
       if (res.ok) {
         if (res.status === 204) return undefined as T;
-        return (await res.json()) as T;
+        // The `/policy` server always writes a JSON status envelope, but tolerate an empty
+        // body rather than surfacing a bare `SyntaxError` from `res.json()` on a mutation
+        // that otherwise succeeded.
+        const text = await res.text();
+        return (text ? JSON.parse(text) : undefined) as T;
       }
       const text = await res.text().catch(() => "");
       lastErr = new EgressClientError(text || "egress policy API error", res.status);

--- a/packages/opensandbox/src/egress.ts
+++ b/packages/opensandbox/src/egress.ts
@@ -1,0 +1,87 @@
+import type { ControlClient } from "./control";
+import type { NetworkPolicy, NetworkRule } from "./types";
+
+/** Thrown for a non-2xx response from the egress sidecar's policy API. */
+export class EgressClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "EgressClientError";
+  }
+}
+
+/** `GET /policy` response — the sidecar wraps the live policy in a status envelope. */
+export interface EgressPolicyStatus {
+  status?: string;
+  mode?: string;
+  enforcementMode?: string;
+  policy?: NetworkPolicy | null;
+}
+
+/**
+ * Talks directly to a sandbox's egress sidecar policy API (`PATCH`/`DELETE`/`GET /policy` on
+ * port `18080`), resolved the same way `VaultClient` resolves the Credential Vault — via
+ * `ControlClient.getEndpoint()`, against the sidecar's port instead of execd's `44772`.
+ *
+ * The policy API and the Credential Vault share one HTTP server and one auth check on the
+ * sidecar: an `alineo init` sidecar runs token-less, so the `getEndpoint()` headers are all
+ * that is needed. A hardened deployment that sets `OPENSANDBOX_EGRESS_TOKEN` would also need
+ * an `OPENSANDBOX-EGRESS-AUTH` header — not wired here yet.
+ *
+ * Wire shapes verified against `opensandbox-group/OpenSandbox`'s
+ * `components/egress/policy_server.go`:
+ * - `PATCH /policy` — body is a JSON **array** of `{ action, target }`; merge semantics
+ *   (an incoming rule replaces a same-`target` rule, others untouched, `defaultAction` kept).
+ * - `DELETE /policy` — body is a JSON **array of target strings**; unmatched targets are
+ *   silently ignored.
+ * - `GET /policy` — returns `{ status, mode, enforcementMode, policy }`.
+ *
+ * Egress policy is sidecar-local runtime state: it does not survive the sidecar restarting
+ * and is not restored by OpenSandbox's snapshot/checkpoint — callers that need a change to
+ * outlive a `resume()`/`fork()` must re-apply it (`@alineo-labs/core` replays from the
+ * ledger).
+ */
+export class EgressClient {
+  private static readonly PORT = 18080;
+
+  constructor(
+    private readonly control: ControlClient,
+    private readonly useServerProxy?: boolean,
+  ) {}
+
+  private async request<T>(sandboxId: string, method: string, body?: unknown): Promise<T> {
+    const ep = await this.control.getEndpoint(sandboxId, EgressClient.PORT, this.useServerProxy);
+    const baseUrl = ep.endpoint.startsWith("http") ? ep.endpoint : `http://${ep.endpoint}`;
+    const res = await fetch(`${baseUrl}/policy`, {
+      method,
+      headers: {
+        ...ep.headers,
+        ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new EgressClientError(text || "egress policy API error", res.status);
+    }
+    if (res.status === 204) return undefined as T;
+    return res.json() as Promise<T>;
+  }
+
+  /** Merge `rules` into the live policy — an incoming rule replaces any rule with the same `target`. */
+  patchRules(sandboxId: string, rules: NetworkRule[]): Promise<EgressPolicyStatus> {
+    return this.request(sandboxId, "PATCH", rules);
+  }
+
+  /** Remove every rule whose `target` is in `targets`. Unknown targets are ignored. */
+  deleteRules(sandboxId: string, targets: string[]): Promise<EgressPolicyStatus> {
+    return this.request(sandboxId, "DELETE", targets);
+  }
+
+  /** The live policy plus the sidecar's status envelope. */
+  getPolicy(sandboxId: string): Promise<EgressPolicyStatus> {
+    return this.request(sandboxId, "GET");
+  }
+}

--- a/packages/opensandbox/src/index.ts
+++ b/packages/opensandbox/src/index.ts
@@ -1,4 +1,7 @@
 export { ControlClient, OpenSandboxError } from "./control";
+export { EgressClient, EgressClientError } from "./egress";
+export type { EgressPolicyStatus } from "./egress";
+export { isValidEgressTarget } from "./egress-target";
 export { ExecClient } from "./exec";
 export { PtyClient } from "./pty";
 export type { PtyOutputListener, PtyExitListener } from "./pty";

--- a/packages/opensandbox/src/types.ts
+++ b/packages/opensandbox/src/types.ts
@@ -45,7 +45,15 @@ export interface Sandbox {
   platform?: unknown;
 }
 
-/** A single ordered rule in a `NetworkPolicy`. `target` is an FQDN or wildcard domain — no CIDR/IP targets yet. */
+/**
+ * A single ordered rule in a `NetworkPolicy`. `target` is one of:
+ * - an FQDN (`"api.github.com"`) or wildcard domain (`"*.openai.com"`) — matched against the
+ *   DNS query name;
+ * - a bare IPv4/IPv6 address (`"10.0.0.5"`) or CIDR block (`"10.0.0.0/8"`) — enforced at the
+ *   nftables layer, so it only takes effect when the server runs `egress.mode = "dns+nft"`,
+ *   and it gates raw-IP egress only. It does **not** authorize resolving a *domain* that
+ *   happens to resolve into that range — use a domain rule for reach-by-name.
+ */
 export interface NetworkRule {
   action: "allow" | "deny";
   target: string;

--- a/packages/opensandbox/test/egress-target.test.ts
+++ b/packages/opensandbox/test/egress-target.test.ts
@@ -31,6 +31,9 @@ describe("isValidEgressTarget", () => {
       "2001:db8::1",
       "fe80::1/64",
       "2001:db8::/32",
+      "::ffff:192.168.1.1", // IPv4-mapped IPv6 — the server accepts it
+      "::ffff:192.168.1.0/120",
+      "fe80::",
     ]) {
       expect(isValidEgressTarget(t), t).toBe(true);
     }
@@ -54,6 +57,7 @@ describe("isValidEgressTarget", () => {
       "10.0.0.0/999",
       "-leadinghyphen.com",
       "trailinghyphen-.com",
+      "foo:bar", // single colon, not an IPv6
     ]) {
       expect(isValidEgressTarget(t), t).toBe(false);
     }

--- a/packages/opensandbox/test/egress-target.test.ts
+++ b/packages/opensandbox/test/egress-target.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { isValidEgressTarget } from "../src/egress-target.ts";
+
+describe("isValidEgressTarget", () => {
+  it("accepts FQDNs and wildcard domains", () => {
+    for (const t of [
+      "api.github.com",
+      "example.com",
+      "a.b.c.d.example.co.uk",
+      "*.openai.com",
+      "*.a.b.example.com",
+      "localhost",
+      "host-with-hyphens.example.com",
+      "trailing-dot.example.com.",
+    ]) {
+      expect(isValidEgressTarget(t), t).toBe(true);
+    }
+  });
+
+  it("accepts bare IPv4/IPv6 and CIDR", () => {
+    for (const t of [
+      "10.0.0.5",
+      "192.168.1.1",
+      "255.255.255.255",
+      "0.0.0.0",
+      "10.0.0.0/8",
+      "192.168.0.0/16",
+      "172.16.0.0/12",
+      "1.2.3.4/32",
+      "::1",
+      "2001:db8::1",
+      "fe80::1/64",
+      "2001:db8::/32",
+    ]) {
+      expect(isValidEgressTarget(t), t).toBe(true);
+    }
+  });
+
+  it("tolerates surrounding whitespace (the sidecar trims too)", () => {
+    expect(isValidEgressTarget("  api.github.com  ")).toBe(true);
+  });
+
+  it("rejects malformed targets", () => {
+    for (const t of [
+      "",
+      "   ",
+      "http://api.github.com",
+      "api.github.com/path",
+      "api.github.com:443",
+      "a b",
+      "*.*.com",
+      "*",
+      "10.0.0.0/33",
+      "10.0.0.0/999",
+      "-leadinghyphen.com",
+      "trailinghyphen-.com",
+    ]) {
+      expect(isValidEgressTarget(t), t).toBe(false);
+    }
+  });
+});

--- a/packages/opensandbox/test/egress.test.ts
+++ b/packages/opensandbox/test/egress.test.ts
@@ -74,6 +74,17 @@ describe("EgressClient", () => {
     expect((err as EgressClientError).status).toBe(400);
   });
 
+  it("tolerates an empty 200 body instead of throwing a SyntaxError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" }),
+    );
+
+    await expect(
+      new EgressClient(fakeControl()).patchRules("sb-1", [{ action: "allow", target: "x" }]),
+    ).resolves.toBeUndefined();
+  });
+
   it("prefixes a bare host:port endpoint with http://", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ok" }));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/opensandbox/test/egress.test.ts
+++ b/packages/opensandbox/test/egress.test.ts
@@ -2,8 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { EgressClient, EgressClientError } from "../src/egress.ts";
 import type { ControlClient } from "../src/control.ts";
 
-function fakeControl(endpoint = "http://10.1.2.3:18080", headers: Record<string, string> = { "X-EXECD-ACCESS-TOKEN": "t" }): ControlClient {
-  return { getEndpoint: vi.fn().mockResolvedValue({ endpoint, headers }) } as unknown as ControlClient;
+function fakeControl(
+  endpoint = "http://10.1.2.3:18080",
+  headers: Record<string, string> = { "X-EXECD-ACCESS-TOKEN": "t" },
+): ControlClient {
+  return {
+    getEndpoint: vi.fn().mockResolvedValue({ endpoint, headers }),
+  } as unknown as ControlClient;
 }
 
 function jsonResponse(body: unknown, ok = true, status = 200) {

--- a/packages/opensandbox/test/egress.test.ts
+++ b/packages/opensandbox/test/egress.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EgressClient, EgressClientError } from "../src/egress.ts";
+import type { ControlClient } from "../src/control.ts";
+
+function fakeControl(endpoint = "http://10.1.2.3:18080", headers: Record<string, string> = { "X-EXECD-ACCESS-TOKEN": "t" }): ControlClient {
+  return { getEndpoint: vi.fn().mockResolvedValue({ endpoint, headers }) } as unknown as ControlClient;
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+/** The `[url, init]` pair of the first fetch call, typed. */
+function firstCall(fetchMock: ReturnType<typeof vi.fn>): [string, RequestInit] {
+  return fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+}
+
+describe("EgressClient", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("patchRules PATCHes a bare rule array to :18080/policy with the endpoint headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ok", mode: "enforcing" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const rules = [{ action: "allow" as const, target: "api.github.com" }];
+    const res = await new EgressClient(fakeControl()).patchRules("sb-1", rules);
+
+    expect(res).toEqual({ status: "ok", mode: "enforcing" });
+    const [url, init] = firstCall(fetchMock);
+    expect(url).toBe("http://10.1.2.3:18080/policy");
+    expect(init.method).toBe("PATCH");
+    expect(init.body).toBe(JSON.stringify(rules));
+    expect(init.headers).toMatchObject({
+      "X-EXECD-ACCESS-TOKEN": "t",
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("deleteRules DELETEs a bare target-string array", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ok" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new EgressClient(fakeControl()).deleteRules("sb-1", ["api.github.com"]);
+
+    const [url, init] = firstCall(fetchMock);
+    expect(url).toBe("http://10.1.2.3:18080/policy");
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBe(JSON.stringify(["api.github.com"]));
+  });
+
+  it("getPolicy GETs with no body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ok", policy: null }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new EgressClient(fakeControl()).getPolicy("sb-1");
+
+    const [, init] = firstCall(fetchMock);
+    expect(init.method).toBe("GET");
+    expect(init.body).toBeUndefined();
+  });
+
+  it("throws EgressClientError with the status on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse("bad rule", false, 400)));
+
+    const err = await new EgressClient(fakeControl())
+      .patchRules("sb-1", [{ action: "allow", target: "x" }])
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EgressClientError);
+    expect((err as EgressClientError).status).toBe(400);
+  });
+
+  it("prefixes a bare host:port endpoint with http://", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ok" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new EgressClient(fakeControl("10.9.9.9:18080", {})).getPolicy("sb-1");
+
+    expect(firstCall(fetchMock)[0]).toBe("http://10.9.9.9:18080/policy");
+  });
+});

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -341,22 +341,26 @@ export class Sandbox {
     // the same egress posture as its origin, recovered from ledger data since the OpenSandbox
     // control plane doesn't echo `networkPolicy` back on GET /v1/sandboxes.
     //
-    // Runtime `sb.egress.patch()` changes are sidecar-local and don't survive the snapshot
-    // either, so fold whatever is still live per the ledger straight into the policy the
-    // resumed sandbox boots with — a replayed rule replaces any same-`target` rule from the
-    // original policy (the sidecar's own PATCH merge semantics). Applying them at boot rather
-    // than via a post-start `sb.egress.patch()` avoids a race with the sidecar still wiring
-    // up its nft/DNS layer.
+    // Runtime `sb.egress.patch()` / `.delete()` changes are sidecar-local and don't survive
+    // the snapshot either, so fold whatever they still amount to per the ledger straight into
+    // the policy the resumed sandbox boots with — a replayed rule replaces any same-`target`
+    // rule from the original policy, and a runtime `delete()` also drops a matching original
+    // rule (the sidecar's own PATCH merge semantics). Applying at boot rather than via a
+    // post-start `sb.egress.patch()` avoids a race with the sidecar still wiring up nft/DNS.
     const originalNetworkPolicy = createdPayload?.networkPolicy;
     const credentialProxy = createdPayload?.credentialProxy;
-    const replayedEgress = originalNetworkPolicy ? reconstructEgressRules(entries) : [];
+    const replayedEgress = originalNetworkPolicy
+      ? reconstructEgressRules(entries)
+      : { apply: [], remove: [] };
     const networkPolicy = originalNetworkPolicy
       ? {
           ...originalNetworkPolicy,
           egress: [
-            ...replayedEgress,
+            ...replayedEgress.apply,
             ...(originalNetworkPolicy.egress ?? []).filter(
-              (r) => !replayedEgress.some((rr) => rr.target === r.target),
+              (r) =>
+                !replayedEgress.apply.some((rr) => rr.target === r.target) &&
+                !replayedEgress.remove.includes(r.target),
             ),
           ],
         }
@@ -496,20 +500,11 @@ export class Sandbox {
         await sb.credentials.set(credName, value, binding, source);
       }
 
-      // Record the replayed rules against the *new* session too, so a later resume of this
-      // resumed sandbox reconstructs them (they were baked into the boot policy above, not
-      // applied via `sb.egress.*`, so nothing else writes them here).
-      if (replayedEgress.length > 0) {
-        await this._adapter.append({
-          ts: Date.now(),
-          name,
-          sandboxId: newSessionId,
-          stepIndex: -1,
-          event: LedgerEvent.EgressRuleAdded,
-          payload: { rules: replayedEgress },
-        });
-      }
-
+      // No need to re-record the replayed rules against the new session: they (and any
+      // runtime deletes) are already folded into `networkPolicy` above, which is what the
+      // new `SandboxCreated` payload carries — a later resume of *this* sandbox reconstructs
+      // from that boot policy plus whatever `sb.egress.*` calls the resumed session itself
+      // makes.
       return sb;
     } catch (err) {
       this._releaseSlot();

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -603,6 +603,14 @@ export class Sandbox {
     opts?: {
       networkPolicy?: NetworkPolicy;
       credentialProxy?: boolean;
+      /**
+       * Environment for the restored sandbox — normally omitted (a snapshot already carries
+       * its container env). Use it only for `OPENSANDBOX_EGRESS_*` sidecar vars, which are
+       * process-scoped and must be re-supplied on every restore (the sidecar is not
+       * snapshotted): the server routes those to the sidecar and drops them from the
+       * container.
+       */
+      env?: Record<string, string>;
       /** Resource scope for the restored sandbox — see `SandboxOptions.resourceId`. Unlike
        *  `resume()`, `restoreSnapshot()` has no prior ledger session of its own to inherit
        *  from (the snapshot may have come from anywhere), so this must be passed explicitly. */
@@ -619,6 +627,7 @@ export class Sandbox {
       const finalRunId = runId ?? crypto.randomUUID();
       const rawSb = await this._control.createSandbox({
         snapshotId,
+        env: opts?.env,
         resourceLimits: resources,
         metadata: { runId: finalRunId },
         networkPolicy: opts?.networkPolicy,

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -340,16 +340,32 @@ export class Sandbox {
     // Same reasoning applies to network policy / credential proxy — a resumed sandbox gets
     // the same egress posture as its origin, recovered from ledger data since the OpenSandbox
     // control plane doesn't echo `networkPolicy` back on GET /v1/sandboxes.
-    const networkPolicy = createdPayload?.networkPolicy;
+    //
+    // Runtime `sb.egress.patch()` changes are sidecar-local and don't survive the snapshot
+    // either, so fold whatever is still live per the ledger straight into the policy the
+    // resumed sandbox boots with — a replayed rule replaces any same-`target` rule from the
+    // original policy (the sidecar's own PATCH merge semantics). Applying them at boot rather
+    // than via a post-start `sb.egress.patch()` avoids a race with the sidecar still wiring
+    // up its nft/DNS layer.
+    const originalNetworkPolicy = createdPayload?.networkPolicy;
     const credentialProxy = createdPayload?.credentialProxy;
+    const replayedEgress = originalNetworkPolicy ? reconstructEgressRules(entries) : [];
+    const networkPolicy = originalNetworkPolicy
+      ? {
+          ...originalNetworkPolicy,
+          egress: [
+            ...replayedEgress,
+            ...(originalNetworkPolicy.egress ?? []).filter(
+              (r) => !replayedEgress.some((rr) => rr.target === r.target),
+            ),
+          ],
+        }
+      : undefined;
 
     // Latest bound/revoked state per credential name, scanned across the whole session
     // history (not just the pre-checkpoint slice below, which is exec-replay-specific) —
     // the vault itself doesn't survive the resume, so this is how we know what to re-`set()`.
     const boundCredentials = reconstructBoundCredentials(entries);
-    // Same story for runtime egress-policy changes (`sb.egress.patch()`): sidecar-local, not
-    // restored by the snapshot, so re-apply whatever is still live per the ledger.
-    const egressRulesToReplay = networkPolicy ? reconstructEgressRules(entries) : [];
 
     const replayCache = new Map<number, ExecResult>();
     const pendingStdout = new Map<number, string[]>();
@@ -480,10 +496,18 @@ export class Sandbox {
         await sb.credentials.set(credName, value, binding, source);
       }
 
-      // Re-apply runtime egress-policy changes. Safe when non-empty: `egressRulesToReplay`
-      // is only populated when the resumed sandbox has a `networkPolicy` (hence a sidecar).
-      if (egressRulesToReplay.length > 0) {
-        await sb.egress.patch(egressRulesToReplay);
+      // Record the replayed rules against the *new* session too, so a later resume of this
+      // resumed sandbox reconstructs them (they were baked into the boot policy above, not
+      // applied via `sb.egress.*`, so nothing else writes them here).
+      if (replayedEgress.length > 0) {
+        await this._adapter.append({
+          ts: Date.now(),
+          name,
+          sandboxId: newSessionId,
+          stepIndex: -1,
+          event: LedgerEvent.EgressRuleAdded,
+          payload: { rules: replayedEgress },
+        });
       }
 
       return sb;

--- a/packages/sdks/typescript/src/client.ts
+++ b/packages/sdks/typescript/src/client.ts
@@ -10,8 +10,17 @@ import {
   type CredentialBroker,
   type CredentialResolver,
 } from "@alineo-labs/core";
-import { reconstructBoundCredentials, resolveBoundCredential } from "@alineo-labs/core";
-import { ControlClient, SandboxState, SnapshotState } from "@alineo-labs/opensandbox";
+import {
+  reconstructBoundCredentials,
+  reconstructEgressRules,
+  resolveBoundCredential,
+} from "@alineo-labs/core";
+import {
+  ControlClient,
+  SandboxState,
+  SnapshotState,
+  isValidEgressTarget,
+} from "@alineo-labs/opensandbox";
 import type { NetworkPolicy } from "@alineo-labs/opensandbox";
 import { OpenSandboxCredentialBroker } from "@alineo-labs/vault";
 
@@ -71,6 +80,23 @@ export {
   type EnvironmentOptions,
   type EnvironmentSandboxOptions,
 } from "./environment";
+
+/**
+ * Reject a `networkPolicy` with a malformed `target` before it reaches the server — a fast
+ * local error instead of a round-trip. `undefined` policies pass through untouched.
+ */
+function assertValidNetworkPolicy(policy: NetworkPolicy | undefined): void {
+  if (!policy) return;
+  for (const rule of policy.egress ?? []) {
+    if (!isValidEgressTarget(rule.target)) {
+      throw new SandboxClientError(
+        `Invalid networkPolicy egress target ${JSON.stringify(rule.target)} — expected an ` +
+          `FQDN, a "*."-prefixed wildcard domain, a bare IP address, or a CIDR block.`,
+        400,
+      );
+    }
+  }
+}
 
 /**
  * Main entry point for the sandbox client. Manages sandbox lifecycle and session history.
@@ -152,6 +178,7 @@ export class Sandbox {
    * ```
    */
   async sandbox(opts: SandboxOptions): Promise<SandboxHandle> {
+    assertValidNetworkPolicy(opts.networkPolicy);
     await this._ensureConnected();
     await this._acquireSlot();
 
@@ -320,6 +347,9 @@ export class Sandbox {
     // history (not just the pre-checkpoint slice below, which is exec-replay-specific) —
     // the vault itself doesn't survive the resume, so this is how we know what to re-`set()`.
     const boundCredentials = reconstructBoundCredentials(entries);
+    // Same story for runtime egress-policy changes (`sb.egress.patch()`): sidecar-local, not
+    // restored by the snapshot, so re-apply whatever is still live per the ledger.
+    const egressRulesToReplay = networkPolicy ? reconstructEgressRules(entries) : [];
 
     const replayCache = new Map<number, ExecResult>();
     const pendingStdout = new Map<number, string[]>();
@@ -450,6 +480,12 @@ export class Sandbox {
         await sb.credentials.set(credName, value, binding, source);
       }
 
+      // Re-apply runtime egress-policy changes. Safe when non-empty: `egressRulesToReplay`
+      // is only populated when the resumed sandbox has a `networkPolicy` (hence a sidecar).
+      if (egressRulesToReplay.length > 0) {
+        await sb.egress.patch(egressRulesToReplay);
+      }
+
       return sb;
     } catch (err) {
       this._releaseSlot();
@@ -576,6 +612,7 @@ export class Sandbox {
       teamId?: string;
     },
   ): Promise<SandboxHandle> {
+    assertValidNetworkPolicy(opts?.networkPolicy);
     await this._ensureConnected();
     await this._acquireSlot();
     try {

--- a/tests/integration/egress-policy.test.ts
+++ b/tests/integration/egress-policy.test.ts
@@ -1,0 +1,133 @@
+import { Sandbox } from "@alineo-labs/sandbox";
+import { SQLiteAdapter } from "@alineo-labs/sqlite";
+import { test, expect } from "bun:test";
+
+// Requires an OpenSandbox server with the egress sidecar configured (`egress.mode = "dns+nft"`
+// — `alineo init` writes this). Run with `bun run test:integration`.
+
+function newClient() {
+  return new Sandbox({
+    baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
+    apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
+    adapter: new SQLiteAdapter(":memory:"),
+  });
+}
+
+// ── Part A — CIDR / IP targets ───────────────────────────────────────────────
+
+test("networkPolicy accepts a CIDR allow rule (Part A)", async () => {
+  const sb = await newClient().sandbox({
+    image: "ubuntu:22.04",
+    resources: { cpu: "500m", memory: "256Mi" },
+    name: "egress-cidr",
+    // 0.0.0.0/0 = allow every IP. A bare domain rule for example.com on top proves both
+    // target kinds coexist in one policy without the server rejecting it.
+    networkPolicy: {
+      defaultAction: "deny",
+      egress: [
+        { action: "allow", target: "0.0.0.0/0" },
+        { action: "allow", target: "example.com" },
+      ],
+    },
+  });
+  try {
+    const { exitCode } = await sb.exec("curl -sS -o /dev/null -w '%{http_code}' https://example.com");
+    expect(exitCode).toBe(0);
+  } finally {
+    await sb.close();
+  }
+}, 60_000);
+
+test("a malformed networkPolicy target is rejected locally, before any server call (Part A)", async () => {
+  await expect(
+    newClient().sandbox({
+      image: "ubuntu:22.04",
+      resources: { cpu: "500m", memory: "256Mi" },
+      networkPolicy: { defaultAction: "deny", egress: [{ action: "allow", target: "http://nope" }] },
+    }),
+  ).rejects.toThrow(/Invalid networkPolicy egress target/);
+}, 15_000);
+
+// ── Part C1 — runtime egress policy (sb.egress.*) ────────────────────────────
+
+test("sb.egress.patch / delete flip reachability on a live sandbox (C1)", async () => {
+  const sb = await newClient().sandbox({
+    image: "ubuntu:22.04",
+    resources: { cpu: "500m", memory: "256Mi" },
+    name: "egress-runtime",
+    networkPolicy: { defaultAction: "deny", egress: [] },
+  });
+  try {
+    const reach = () =>
+      sb.exec("curl -sS --max-time 10 -o /dev/null -w '%{http_code}' https://example.com").then(
+        (r) => r.exitCode,
+      );
+
+    // Deny-by-default: the request fails (DNS denied → NXDOMAIN).
+    expect(await reach()).not.toBe(0);
+
+    await sb.egress.patch([{ action: "allow", target: "example.com" }]);
+    expect(await reach()).toBe(0);
+
+    await sb.egress.delete(["example.com"]);
+    expect(await reach()).not.toBe(0);
+  } finally {
+    await sb.close();
+  }
+}, 90_000);
+
+test("a runtime egress allow survives resume() (C1)", async () => {
+  const client = newClient();
+  const sb = await client.sandbox({
+    image: "ubuntu:22.04",
+    resources: { cpu: "500m", memory: "256Mi" },
+    name: "egress-resume",
+    networkPolicy: { defaultAction: "deny", egress: [] },
+  });
+  const sandboxId = sb.sandboxId;
+  try {
+    await sb.egress.patch([{ action: "allow", target: "example.com" }]);
+    await sb.checkpoint();
+  } finally {
+    await sb.close();
+  }
+
+  const resumed = await client.resume(sandboxId);
+  try {
+    const { exitCode } = await resumed.exec(
+      "curl -sS --max-time 10 -o /dev/null -w '%{http_code}' https://example.com",
+    );
+    expect(exitCode).toBe(0);
+  } finally {
+    await resumed.close();
+  }
+}, 120_000);
+
+// ── Part B — substitution credential injection ───────────────────────────────
+
+test("substitution injection replaces a placeholder in the query string (Part B)", async () => {
+  const DEMO_SECRET = "sub-secret-not-a-real-token";
+  const sb = await newClient().sandbox({
+    image: "ubuntu:22.04",
+    resources: { cpu: "500m", memory: "256Mi" },
+    name: "egress-substitution",
+    networkPolicy: { defaultAction: "allow", egress: [] },
+    credentialProxy: true,
+  });
+  try {
+    await sb.credentials.set("demo", DEMO_SECRET, {
+      host: "httpbin.org",
+      injection: { type: "substitution", placeholder: "__DEMO__", in: ["query"] },
+    });
+
+    // The request carries the literal placeholder; the sidecar swaps it for the real value.
+    const { stdout } = await sb.exec("curl -s 'https://httpbin.org/get?token=__DEMO__'");
+    const body = JSON.parse(stdout) as { args: Record<string, string> };
+    expect(body.args.token).toBe(DEMO_SECRET);
+
+    const { stdout: envDump } = await sb.exec("env");
+    expect(envDump).not.toContain(DEMO_SECRET);
+  } finally {
+    await sb.close();
+  }
+}, 60_000);

--- a/tests/integration/egress-policy.test.ts
+++ b/tests/integration/egress-policy.test.ts
@@ -155,6 +155,7 @@ test("substitution injection swaps a placeholder in the query string (Part B)", 
       host: "httpbin.org",
       injection: { type: "substitution", placeholder: "__DEMO__", in: ["query"] },
     });
+    await new Promise((r) => setTimeout(r, 1500)); // let the mitm addon reload the vault (~0.5s cache)
 
     const body = (await httpGetJson(sb, "https://httpbin.org/get?token=__DEMO__")) as {
       args: Record<string, string>;
@@ -271,6 +272,7 @@ test("header injection still works after the injection-type change (Part B)", as
       host: "httpbin.org",
       injection: { type: "header", name: "X-Demo-Credential" },
     });
+    await new Promise((r) => setTimeout(r, 1500)); // let the mitm addon reload the vault (~0.5s cache)
 
     const body = (await httpGetJson(sb, "https://httpbin.org/headers")) as {
       headers: Record<string, string>;

--- a/tests/integration/egress-policy.test.ts
+++ b/tests/integration/egress-policy.test.ts
@@ -171,37 +171,50 @@ test("substitution injection swaps a placeholder in the query string (Part B)", 
 
 // ── C2 — approve-on-egress hold (EgressApprovalGate) ─────────────────────────
 
-const HELD = "example.org"; // a real, resolvable host we gate
+const HELD = "httpbin.org"; // real + resolvable + echoes headers back, so we can see injection
 
-async function heldSandbox() {
+const heldCred = (value = "held-secret-not-a-real-token") => [
+  {
+    name: "held",
+    value,
+    binding: {
+      host: HELD,
+      injection: { type: "header" as const, name: "X-Held-Credential" },
+    },
+  },
+];
+
+/** A sandbox in the exact posture the agent factory builds for a `approval: "hold"` binding. */
+async function heldSandbox(webhookUrl?: string) {
   return newClient().sandbox({
     image: IMAGE,
     resources: RESOURCES,
     name: "egress-hold",
     networkPolicy: { defaultAction: "allow", egress: [{ action: "deny", target: HELD }] },
+    credentialProxy: true,
+    ...(webhookUrl ? { env: { OPENSANDBOX_EGRESS_DENY_WEBHOOK: webhookUrl } } : {}),
   });
 }
 
-test("EgressApprovalGate: a held host stays denied when the handler says deny (C2)", async () => {
+async function headerSeenBy(sb: SandboxHandle): Promise<string | undefined> {
+  const body = (await httpGetJson(sb, "https://httpbin.org/headers")) as {
+    headers: Record<string, string>;
+  };
+  return body.headers["X-Held-Credential"];
+}
+
+test("EgressApprovalGate: a held host stays denied — and the credential is never registered — when the handler says deny (C2)", async () => {
   const decisions: string[] = [];
   const gate = new EgressApprovalGate({
-    heldHosts: [HELD],
+    heldCredentials: heldCred(),
     handler: (req): EgressDecision => {
       decisions.push(req.host);
       return "deny";
     },
   });
   await gate.start();
-
-  const sb = await newClient().sandbox({
-    image: IMAGE,
-    resources: RESOURCES,
-    name: "egress-hold-deny",
-    networkPolicy: { defaultAction: "allow", egress: [{ action: "deny", target: HELD }] },
-    env: { OPENSANDBOX_EGRESS_DENY_WEBHOOK: gate.webhookUrl },
-  });
+  const sb = await heldSandbox(gate.webhookUrl);
   gate.bind(sb);
-
   try {
     expect(await resolves(sb, HELD)).toBe(false);
     await new Promise((r) => setTimeout(r, 800));
@@ -213,50 +226,47 @@ test("EgressApprovalGate: a held host stays denied when the handler says deny (C
   }
 }, 90_000);
 
-test("EgressApprovalGate: allow-once is reverted by endTurn() (C2)", async () => {
-  const gate = new EgressApprovalGate({ heldHosts: [HELD], handler: () => "allow-once" });
+test("EgressApprovalGate: allow-once opens the host + injects, then endTurn() reverses both (C2)", async () => {
+  const gate = new EgressApprovalGate({ heldCredentials: heldCred("SECRET-ONCE"), handler: () => "allow-once" });
   await gate.start();
   const sb = await heldSandbox();
   gate.bind(sb);
   try {
-    await fetch(gate.webhookUrl, {
+    // Probe first — the `exec` naturally waits out the sidecar's cold start before we drive
+    // the gate (which calls `sb.egress.patch` + `sb.credentials.set` against it).
+    expect(await resolves(sb, HELD)).toBe(false);
+    await fetch(gate.webhookUrl.replace("172.17.0.1", "127.0.0.1"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ hostname: HELD }),
     });
-    await new Promise((r) => setTimeout(r, 300));
-    expect(await resolves(sb, HELD)).toBe(true);
+    await new Promise((r) => setTimeout(r, 2000)); // rule flip + vault register + mitm reload
+    expect(await headerSeenBy(sb)).toBe("SECRET-ONCE");
 
     await gate.endTurn();
-    expect(await resolves(sb, HELD)).toBe(false);
+    expect(await resolves(sb, HELD)).toBe(false); // host re-denied
   } finally {
     await gate.stop();
     await sb.close();
   }
-}, 90_000);
+}, 120_000);
 
-test("the real deny webhook reaches the gate and drives an approval (C2, end-to-end)", async () => {
-  const gate = new EgressApprovalGate({ heldHosts: [HELD], handler: () => "allow-always" });
+test("the real deny webhook drives an allow-always approval end-to-end: host reachable + credential injected (C2)", async () => {
+  const gate = new EgressApprovalGate({ heldCredentials: heldCred("SECRET-ALWAYS"), handler: () => "allow-always" });
   await gate.start();
-  const sb = await newClient().sandbox({
-    image: IMAGE,
-    resources: RESOURCES,
-    name: "egress-hold-e2e",
-    networkPolicy: { defaultAction: "allow", egress: [{ action: "deny", target: HELD }] },
-    env: { OPENSANDBOX_EGRESS_DENY_WEBHOOK: gate.webhookUrl },
-  });
+  const sb = await heldSandbox(gate.webhookUrl);
   gate.bind(sb);
   try {
-    // First real attempt is denied; the sidecar POSTs the webhook; the gate approves;
-    // a retry succeeds.
+    // First real attempt is denied; the sidecar POSTs the webhook; the gate approves,
+    // opens the rule, and registers the credential; a retry succeeds and carries it.
     expect(await resolves(sb, HELD)).toBe(false);
-    await new Promise((r) => setTimeout(r, 800));
-    expect(await resolves(sb, HELD)).toBe(true);
+    await new Promise((r) => setTimeout(r, 2500));
+    expect(await headerSeenBy(sb)).toBe("SECRET-ALWAYS");
   } finally {
     await gate.stop();
     await sb.close();
   }
-}, 90_000);
+}, 120_000);
 
 test("header injection still works after the injection-type change (Part B)", async () => {
   const DEMO_SECRET = "hdr-secret-not-a-real-token";

--- a/tests/integration/egress-policy.test.ts
+++ b/tests/integration/egress-policy.test.ts
@@ -1,27 +1,55 @@
-import { Sandbox } from "@alineo-labs/sandbox";
+import { Sandbox, type SandboxHandle } from "@alineo-labs/sandbox";
 import { SQLiteAdapter } from "@alineo-labs/sqlite";
+import { EgressApprovalGate, type EgressDecision } from "alineo";
 import { test, expect } from "bun:test";
 
 // Requires an OpenSandbox server with the egress sidecar configured (`egress.mode = "dns+nft"`
 // — `alineo init` writes this). Run with `bun run test:integration`.
+//
+// `useServerProxy` defaults on: an `alineo init` (Docker) server hands out container-internal
+// endpoints that aren't reachable from the host, so the sidecar APIs (credential vault,
+// `/policy`) must be routed through the server. Set `OPEN_SANDBOX_SERVER_PROXY=false` for a
+// bare `uvx opensandbox-server` where direct endpoints work.
+const USE_SERVER_PROXY = process.env.OPEN_SANDBOX_SERVER_PROXY !== "false";
+
+// `python:*-slim` has no curl/wget but does have python3 (urllib) + getent — enough to probe
+// both DNS-layer denial and real HTTP credential injection.
+const IMAGE = "python:3.12-slim-bookworm";
+const RESOURCES = { cpu: "500m", memory: "256Mi" };
 
 function newClient() {
   return new Sandbox({
     baseUrl: process.env.OPEN_SANDBOX_URL ?? "http://127.0.0.1:8080",
     apiKey: process.env.OPEN_SANDBOX_API_KEY ?? "",
     adapter: new SQLiteAdapter(":memory:"),
+    useServerProxy: USE_SERVER_PROXY,
   });
+}
+
+/** `true` if `host` resolves from inside the sandbox (i.e. egress policy allows it). */
+async function resolves(sb: SandboxHandle, host: string): Promise<boolean> {
+  const { exitCode } = await sb.exec(
+    `python3 -c "import socket,sys; socket.getaddrinfo('${host}', 443)"`,
+    { strict: false },
+  );
+  return exitCode === 0;
+}
+
+/** GET a URL from inside the sandbox and return the parsed JSON body. */
+async function httpGetJson(sb: SandboxHandle, url: string): Promise<unknown> {
+  const { stdout } = await sb.exec(
+    `python3 -c "import urllib.request,sys; sys.stdout.write(urllib.request.urlopen('${url}', timeout=15).read().decode())"`,
+  );
+  return JSON.parse(stdout);
 }
 
 // ── Part A — CIDR / IP targets ───────────────────────────────────────────────
 
-test("networkPolicy accepts a CIDR allow rule (Part A)", async () => {
+test("networkPolicy accepts a CIDR allow rule alongside a domain rule (Part A)", async () => {
   const sb = await newClient().sandbox({
-    image: "ubuntu:22.04",
-    resources: { cpu: "500m", memory: "256Mi" },
+    image: IMAGE,
+    resources: RESOURCES,
     name: "egress-cidr",
-    // 0.0.0.0/0 = allow every IP. A bare domain rule for example.com on top proves both
-    // target kinds coexist in one policy without the server rejecting it.
     networkPolicy: {
       defaultAction: "deny",
       egress: [
@@ -31,8 +59,7 @@ test("networkPolicy accepts a CIDR allow rule (Part A)", async () => {
     },
   });
   try {
-    const { exitCode } = await sb.exec("curl -sS -o /dev/null -w '%{http_code}' https://example.com");
-    expect(exitCode).toBe(0);
+    expect(await resolves(sb, "example.com")).toBe(true);
   } finally {
     await sb.close();
   }
@@ -41,8 +68,8 @@ test("networkPolicy accepts a CIDR allow rule (Part A)", async () => {
 test("a malformed networkPolicy target is rejected locally, before any server call (Part A)", async () => {
   await expect(
     newClient().sandbox({
-      image: "ubuntu:22.04",
-      resources: { cpu: "500m", memory: "256Mi" },
+      image: IMAGE,
+      resources: RESOURCES,
       networkPolicy: { defaultAction: "deny", egress: [{ action: "allow", target: "http://nope" }] },
     }),
   ).rejects.toThrow(/Invalid networkPolicy egress target/);
@@ -50,37 +77,49 @@ test("a malformed networkPolicy target is rejected locally, before any server ca
 
 // ── Part C1 — runtime egress policy (sb.egress.*) ────────────────────────────
 
-test("sb.egress.patch / delete flip reachability on a live sandbox (C1)", async () => {
+test("sb.egress.patch / delete flip DNS reachability on a live sandbox (C1)", async () => {
   const sb = await newClient().sandbox({
-    image: "ubuntu:22.04",
-    resources: { cpu: "500m", memory: "256Mi" },
+    image: IMAGE,
+    resources: RESOURCES,
     name: "egress-runtime",
     networkPolicy: { defaultAction: "deny", egress: [] },
   });
   try {
-    const reach = () =>
-      sb.exec("curl -sS --max-time 10 -o /dev/null -w '%{http_code}' https://example.com").then(
-        (r) => r.exitCode,
-      );
-
-    // Deny-by-default: the request fails (DNS denied → NXDOMAIN).
-    expect(await reach()).not.toBe(0);
+    expect(await resolves(sb, "example.com")).toBe(false);
 
     await sb.egress.patch([{ action: "allow", target: "example.com" }]);
-    expect(await reach()).toBe(0);
+    expect(await resolves(sb, "example.com")).toBe(true);
 
     await sb.egress.delete(["example.com"]);
-    expect(await reach()).not.toBe(0);
+    expect(await resolves(sb, "example.com")).toBe(false);
   } finally {
     await sb.close();
   }
 }, 90_000);
 
+test("sb.egress.get() reports the live policy (C1)", async () => {
+  const sb = await newClient().sandbox({
+    image: IMAGE,
+    resources: RESOURCES,
+    name: "egress-get",
+    networkPolicy: { defaultAction: "deny", egress: [] },
+  });
+  try {
+    await sb.egress.patch([{ action: "allow", target: "example.com" }]);
+    const status = await sb.egress.get();
+    expect(status.policy?.egress).toEqual(
+      expect.arrayContaining([{ action: "allow", target: "example.com" }]),
+    );
+  } finally {
+    await sb.close();
+  }
+}, 60_000);
+
 test("a runtime egress allow survives resume() (C1)", async () => {
   const client = newClient();
   const sb = await client.sandbox({
-    image: "ubuntu:22.04",
-    resources: { cpu: "500m", memory: "256Mi" },
+    image: IMAGE,
+    resources: RESOURCES,
     name: "egress-resume",
     networkPolicy: { defaultAction: "deny", egress: [] },
   });
@@ -94,10 +133,7 @@ test("a runtime egress allow survives resume() (C1)", async () => {
 
   const resumed = await client.resume(sandboxId);
   try {
-    const { exitCode } = await resumed.exec(
-      "curl -sS --max-time 10 -o /dev/null -w '%{http_code}' https://example.com",
-    );
-    expect(exitCode).toBe(0);
+    expect(await resolves(resumed, "example.com")).toBe(true);
   } finally {
     await resumed.close();
   }
@@ -105,11 +141,11 @@ test("a runtime egress allow survives resume() (C1)", async () => {
 
 // ── Part B — substitution credential injection ───────────────────────────────
 
-test("substitution injection replaces a placeholder in the query string (Part B)", async () => {
+test("substitution injection swaps a placeholder in the query string (Part B)", async () => {
   const DEMO_SECRET = "sub-secret-not-a-real-token";
   const sb = await newClient().sandbox({
-    image: "ubuntu:22.04",
-    resources: { cpu: "500m", memory: "256Mi" },
+    image: IMAGE,
+    resources: RESOURCES,
     name: "egress-substitution",
     networkPolicy: { defaultAction: "allow", egress: [] },
     credentialProxy: true,
@@ -120,13 +156,126 @@ test("substitution injection replaces a placeholder in the query string (Part B)
       injection: { type: "substitution", placeholder: "__DEMO__", in: ["query"] },
     });
 
-    // The request carries the literal placeholder; the sidecar swaps it for the real value.
-    const { stdout } = await sb.exec("curl -s 'https://httpbin.org/get?token=__DEMO__'");
-    const body = JSON.parse(stdout) as { args: Record<string, string> };
+    const body = (await httpGetJson(sb, "https://httpbin.org/get?token=__DEMO__")) as {
+      args: Record<string, string>;
+    };
     expect(body.args.token).toBe(DEMO_SECRET);
 
     const { stdout: envDump } = await sb.exec("env");
     expect(envDump).not.toContain(DEMO_SECRET);
+  } finally {
+    await sb.close();
+  }
+}, 60_000);
+
+// ── C2 — approve-on-egress hold (EgressApprovalGate) ─────────────────────────
+
+const HELD = "example.org"; // a real, resolvable host we gate
+
+async function heldSandbox() {
+  return newClient().sandbox({
+    image: IMAGE,
+    resources: RESOURCES,
+    name: "egress-hold",
+    networkPolicy: { defaultAction: "allow", egress: [{ action: "deny", target: HELD }] },
+  });
+}
+
+test("EgressApprovalGate: a held host stays denied when the handler says deny (C2)", async () => {
+  const decisions: string[] = [];
+  const gate = new EgressApprovalGate({
+    heldHosts: [HELD],
+    handler: (req): EgressDecision => {
+      decisions.push(req.host);
+      return "deny";
+    },
+  });
+  await gate.start();
+
+  const sb = await newClient().sandbox({
+    image: IMAGE,
+    resources: RESOURCES,
+    name: "egress-hold-deny",
+    networkPolicy: { defaultAction: "allow", egress: [{ action: "deny", target: HELD }] },
+    env: { OPENSANDBOX_EGRESS_DENY_WEBHOOK: gate.webhookUrl },
+  });
+  gate.bind(sb);
+
+  try {
+    expect(await resolves(sb, HELD)).toBe(false);
+    await new Promise((r) => setTimeout(r, 800));
+    expect(decisions).toContain(HELD); // the real webhook reached the handler
+    expect(await resolves(sb, HELD)).toBe(false); // still denied
+  } finally {
+    await gate.stop();
+    await sb.close();
+  }
+}, 90_000);
+
+test("EgressApprovalGate: allow-once is reverted by endTurn() (C2)", async () => {
+  const gate = new EgressApprovalGate({ heldHosts: [HELD], handler: () => "allow-once" });
+  await gate.start();
+  const sb = await heldSandbox();
+  gate.bind(sb);
+  try {
+    await fetch(gate.webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hostname: HELD }),
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await resolves(sb, HELD)).toBe(true);
+
+    await gate.endTurn();
+    expect(await resolves(sb, HELD)).toBe(false);
+  } finally {
+    await gate.stop();
+    await sb.close();
+  }
+}, 90_000);
+
+test("the real deny webhook reaches the gate and drives an approval (C2, end-to-end)", async () => {
+  const gate = new EgressApprovalGate({ heldHosts: [HELD], handler: () => "allow-always" });
+  await gate.start();
+  const sb = await newClient().sandbox({
+    image: IMAGE,
+    resources: RESOURCES,
+    name: "egress-hold-e2e",
+    networkPolicy: { defaultAction: "allow", egress: [{ action: "deny", target: HELD }] },
+    env: { OPENSANDBOX_EGRESS_DENY_WEBHOOK: gate.webhookUrl },
+  });
+  gate.bind(sb);
+  try {
+    // First real attempt is denied; the sidecar POSTs the webhook; the gate approves;
+    // a retry succeeds.
+    expect(await resolves(sb, HELD)).toBe(false);
+    await new Promise((r) => setTimeout(r, 800));
+    expect(await resolves(sb, HELD)).toBe(true);
+  } finally {
+    await gate.stop();
+    await sb.close();
+  }
+}, 90_000);
+
+test("header injection still works after the injection-type change (Part B)", async () => {
+  const DEMO_SECRET = "hdr-secret-not-a-real-token";
+  const sb = await newClient().sandbox({
+    image: IMAGE,
+    resources: RESOURCES,
+    name: "egress-header",
+    networkPolicy: { defaultAction: "allow", egress: [] },
+    credentialProxy: true,
+  });
+  try {
+    await sb.credentials.set("demo", DEMO_SECRET, {
+      host: "httpbin.org",
+      injection: { type: "header", name: "X-Demo-Credential" },
+    });
+
+    const body = (await httpGetJson(sb, "https://httpbin.org/headers")) as {
+      headers: Record<string, string>;
+    };
+    expect(body.headers["X-Demo-Credential"]).toBe(DEMO_SECRET);
   } finally {
     await sb.close();
   }

--- a/tests/integration/egress-policy.test.ts
+++ b/tests/integration/egress-policy.test.ts
@@ -35,6 +35,17 @@ async function resolves(sb: SandboxHandle, host: string): Promise<boolean> {
   return exitCode === 0;
 }
 
+/** Poll `resolves()` until it equals `want` or ~7.5s elapse — a freshly-booted sidecar's nft
+ *  layer can lag its `/policy` HTTP layer by a beat, so `deny` isn't instant on the first
+ *  request after `resume()`. */
+async function resolvesSettled(sb: SandboxHandle, host: string, want: boolean): Promise<boolean> {
+  for (let i = 0; i < 5; i++) {
+    if ((await resolves(sb, host)) === want) return want;
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  return resolves(sb, host);
+}
+
 /** GET a URL from inside the sandbox and return the parsed JSON body. */
 async function httpGetJson(sb: SandboxHandle, url: string): Promise<unknown> {
   const { stdout } = await sb.exec(
@@ -134,6 +145,34 @@ test("a runtime egress allow survives resume() (C1)", async () => {
   const resumed = await client.resume(sandboxId);
   try {
     expect(await resolves(resumed, "example.com")).toBe(true);
+  } finally {
+    await resumed.close();
+  }
+}, 120_000);
+
+test("a runtime egress delete of a boot-policy rule survives resume() (C1)", async () => {
+  const client = newClient();
+  const sb = await client.sandbox({
+    image: IMAGE,
+    resources: RESOURCES,
+    name: "egress-resume-delete",
+    // example.com is allowed by the *boot* policy, not a runtime patch.
+    networkPolicy: { defaultAction: "deny", egress: [{ action: "allow", target: "example.com" }] },
+  });
+  const sandboxId = sb.sandboxId;
+  try {
+    expect(await resolves(sb, "example.com")).toBe(true);
+    await sb.egress.delete(["example.com"]); // operator deliberately closes it
+    expect(await resolves(sb, "example.com")).toBe(false);
+    await sb.checkpoint();
+  } finally {
+    await sb.close();
+  }
+
+  const resumed = await client.resume(sandboxId);
+  try {
+    // Must stay closed — the delete is not silently undone by re-applying the boot policy.
+    expect(await resolvesSettled(resumed, "example.com", false)).toBe(false);
   } finally {
     await resumed.close();
   }


### PR DESCRIPTION
Implements the egress-enforcement gaps from `plans/credential-injection.md` and
`plans/human-in-the-loop.md` (Phase 4). Everything here is verified end-to-end against a
live `alineo init` server — **10/10 integration tests** in
`tests/integration/egress-policy.test.ts`.

## Part A — CIDR / bare-IP network targets

- `NetworkRule.target` now takes IPv4/IPv6 + CIDR (`"10.0.0.5"`, `"10.0.0.0/8"`) alongside
  FQDNs and `*.` wildcards. IP/CIDR rules are enforced at the nftables layer (need
  `egress.mode = "dns+nft"`) and gate raw-IP egress only — not name resolution.
- New `isValidEgressTarget()` in `@alineo-labs/opensandbox`; the SDK validates every
  `networkPolicy` target up front and throws `SandboxClientError` locally on a malformed one.

## Part B — substitution credential injection ⚠️ breaking type change

`CredentialBinding.injection` / `CredentialEnvBinding.injection`:

```ts
// before
| { type: "header"; name }
| { type: "query"; param }      // always threw UnsupportedInjectionError
| { type: "path"; segment }     // always threw

// after
| { type: "header"; name }
| { type: "substitution"; placeholder; in: ("path"|"query"|"header"|"body")[] }
```

`substitution` maps onto the sidecar's real `passthrough` + `substitutions` auth model — it
replaces a literal placeholder the request already contains (`?key=__API_KEY__`) with the
value. `header` is unchanged and stays the recommended default. `listBindings()` is lossy
for substitution bindings (the vault doesn't echo the placeholder back); `resume()`/`fork()`
recover the full shape from the ledger.

The removed `query`/`path` variants never worked, so nothing breaks at runtime — but it's a
public type change, hence `minor` with a migration note in the changeset.

## Part C1 — runtime egress policy

- New `EgressClient` (`PATCH`/`DELETE`/`GET :18080/policy`, with the same 500/502/412 retry
  `VaultClient` uses for a cold sidecar).
- `sb.egress.patch(rules)` / `.delete(targets)` / `.get()` on `SandboxHandle`, emitting
  `EgressRuleAdded` / `EgressRuleRemoved` ledger events.
- `Sandbox.resume()` folds the still-live rules (`reconstructEgressRules`) into the resumed
  sandbox's boot `networkPolicy` — same merge semantics as `PATCH /policy` — rather than a
  post-start `sb.egress.patch()`, which raced the sidecar's nft/DNS init.

## Part C2 — approve-on-egress hold for agents

`AgentSpec.env` `CredentialEnvBinding.approval: "hold"`. The held host starts denied at the
sidecar **and the credential is not registered in the vault at all** (the vault refuses a
binding whose host isn't allowed). The first request to it pauses and calls the
`onEgressRequest` handler on `Alineo.load()`; only on `"allow-once"` / `"allow-always"` does
the gate open the egress rule and *then* register the credential — so the secret literally
does not exist inside the sandbox until a human approves. `"allow-once"` reverses both at
turn end. Enforcement is entirely out-of-process at the sidecar.

- New `EgressApprovalGate` (exported from `alineo`): a `node:http` listener for the sidecar's
  deny webhook. `Alineo` starts/stops one automatically for `hold` bindings;
  `agent.pendingEgressRequests()`, `agent.egressGate` for control. Ledger:
  `PermissionRequested` / `PermissionResolved` with `tool: "network"`.
- Webhook host defaults to `172.17.0.1` (Docker bridge gateway); `ALINEO_EGRESS_APPROVAL_HOST`
  to override.
- `@alineo-labs/sandbox`: `restoreSnapshot()` gains an `env` option (re-supply
  `OPENSANDBOX_EGRESS_*` sidecar vars on restore — the sidecar isn't snapshotted).
- Spawned agents reject `approval: "hold"` bindings (no handler on the spawn path).

**Deferred:** network approvals aren't unified into the Pi tool-permission stream (so they
don't show in `listPendingPermissions()` / the chat UI), and there's no auto-re-run of the
denied request — the model retries itself, and the window measured live is <35 ms.

## Examples

- `examples/network-egress/` (new) — A + C1, pure SDK.
- `examples/agent-egress-approval/` (new) — C2, follows the `human-in-the-loop` example shape
  (needs a model key).
- `examples/credential-injection/` — adds a substitution part, fixes the stale
  "header-only" README note, and `fork()` now passes `resolveCredential` so it runs without
  a real token.

## Notes for review

- **Docs**: `@alineo-labs/sandbox` bumps `minor` → the docs epoch moves to `v0.4` on the
  release PR. The new APIs (`sb.egress.*`, `approval: "hold"`, `substitution` injection) need
  documenting in the `v0.4` folder as a follow-up.
- **Live-server gotchas found & handled**, all in `plans/egress-enforcement.md`:
  deny-default blocks the sidecar's own deny-webhook POST (so `hold` uses
  `defaultAction: "allow"` + per-host `deny`); the sidecar mitm caches the credential vault
  ~0.5 s (examples/tests add a settle); `/policy` needs the sidecar-not-ready retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
