### PR TITLE
fix(seo): rebrand favicon SVGs from drej to alineo

### DIFF
--- a/apps/registry/public/favicon.svg
+++ b/apps/registry/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="8" fill="#0a0a0a"/>
-  <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, monospace" font-size="18" font-weight="600" fill="white">d</text>
+  <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, monospace" font-size="18" font-weight="600" fill="white">a</text>
 </svg>

--- a/apps/sandbox/public/favicon.svg
+++ b/apps/sandbox/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="8" fill="#0a0a0a"/>
-  <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, monospace" font-size="18" font-weight="600" fill="white">d</text>
+  <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, monospace" font-size="18" font-weight="600" fill="white">a</text>
 </svg>


### PR DESCRIPTION
## Summary
- `apps/registry/public/favicon.svg` and `apps/sandbox/public/favicon.svg` still shipped the old "drej" monogram (a lowercase `d` on a dark rounded square) left over from the rename to alineo.
- Swapped the glyph to `a` in both SVGs.

## Why
SEO/metadata assets should reflect the current `alineo` branding, not the legacy `drej` codename — this was flagged as a task-list item.

## Scope
Checked more broadly for other leftover "drej" branding in SEO/metadata surfaces (OG image generators, twitter-image, icon.svg, webmanifests) across `apps/docs`, `apps/registry`, `apps/sandbox` — everything else was already alineo-branded. These two favicons were the only stragglers.

## Test plan
- [x] Visual diff of both SVGs (rect/fill unchanged, only the text glyph changed)
- [ ] Confirm favicon renders correctly on next deploy of `apps/registry` / `apps/sandbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)