### PR TITLE
fix(docs): force light theme instead of following system preference

### DIFF
--- a/.changeset/docs-force-light-theme.md
+++ b/.changeset/docs-force-light-theme.md
@@ -1,0 +1,10 @@
+---
+---
+
+Docs site only, no publishable package changes: force the docs site to light mode.
+
+PR #233 removed the forced-dark theme but left `themeSwitch` disabled, so the site fell
+back to next-themes' `system` default — dark-OS visitors got the (now burgundy) `html.dark`
+palette with no way to switch. Restore an explicit default: `forcedTheme: "light"` on
+`RootProvider` plus a `light` class on `<html>`, matching the "light mode only" brand
+direction.

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -51,13 +51,17 @@ const jsonLd = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${geistMono.variable}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${inter.variable} ${geistMono.variable} light`}
+      suppressHydrationWarning
+    >
       <body suppressHydrationWarning>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        <RootProvider search={{ SearchDialog }}>
+        <RootProvider theme={{ forcedTheme: "light" }} search={{ SearchDialog }}>
           <HomeLayout
             nav={{ title: "alineo", url: "/" }}
             themeSwitch={{ enabled: false }}


### PR DESCRIPTION
## What

Force the docs site to light mode: `theme={{ forcedTheme: "light" }}` on `RootProvider` + a `light` class on `<html>`.

## Why

#233 removed the forced-dark theme (`forcedTheme: "dark"` + `<html class="dark">`) but left `themeSwitch={{ enabled: false }}` in place. With no forced theme and no switch, next-themes falls back to its `system` default — so visitors on a dark-mode OS got the (now burgundy `#7A1B48`) `html.dark` palette with no way to switch back. This pins it to light, matching the light-mode-only brand direction.

The intentional dark sidebar (the `aside { ... }` overrides in `globals.css`) is unaffected — those don't depend on `html.dark`.

## Testing

- `bunx tsc --noEmit -p apps/docs/tsconfig.json` — passes
- `oxfmt` clean
- Changeset added (docs-only, no version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)