### PR TITLE
fix(cookbooks): swap EOL NVIDIA model for a live one in the 3 agent recipes

### DIFF
--- a/.changeset/cookbook-nvidia-model.md
+++ b/.changeset/cookbook-nvidia-model.md
@@ -1,0 +1,19 @@
+---
+---
+
+Cookbooks only, no publishable package changes: point the three agent recipes at a live
+NVIDIA NIM model.
+
+`ai-agent-bugfix`, `persistent-agent-memory` and `credential-scoped-agent` pinned
+`nvidia/nemotron-3-nano-30b-a3b`, which reached end-of-life on the NVIDIA NIM API on
+2026-09-01 — `/v1/chat/completions` now returns `410 Gone`. The agent's completion call
+failed silently (empty event stream) and each recipe still exited 0 while doing nothing.
+
+Swapped all three specs to **`nvidia/nemotron-3.5-lightning-30b-a3b`** (same 30B-a3b class,
+still on the free tier). Verified end-to-end against a local OpenSandbox server: the bugfix
+agent diagnoses and fixes the off-by-one and passes independent verification; the memory
+agent recalls the customer profile across sandbox sessions and answers grounded in it; the
+credential agent runs its own authenticated `curl` and the inject/revoke audit behaves.
+
+`examples/*` and `packages/model-providers/test/nvidia.test.ts` still reference the dead
+id — separate follow-up.

--- a/cookbooks/ai-agent-bugfix/agents/bugfix-agent.json
+++ b/cookbooks/ai-agent-bugfix/agents/bugfix-agent.json
@@ -6,7 +6,7 @@
   "author": "alineo",
   "cli": "pi",
   "provider": "nvidia",
-  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
   "packages": ["python3", "python3-pip"],
   "env": {
     "NVIDIA_API_KEY": "${NVIDIA_API_KEY}"

--- a/cookbooks/credential-scoped-agent/agents/github-agent.json
+++ b/cookbooks/credential-scoped-agent/agents/github-agent.json
@@ -6,7 +6,7 @@
   "author": "alineo",
   "cli": "pi",
   "provider": "nvidia",
-  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
   "packages": ["curl", "jq", "ca-certificates"],
   "env": {
     "NVIDIA_API_KEY": "${NVIDIA_API_KEY}",

--- a/cookbooks/persistent-agent-memory/agents/support-agent.json
+++ b/cookbooks/persistent-agent-memory/agents/support-agent.json
@@ -6,7 +6,7 @@
   "author": "alineo",
   "cli": "pi",
   "provider": "nvidia",
-  "model": "nvidia/nemotron-3-nano-30b-a3b",
+  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
   "env": {
     "NVIDIA_API_KEY": "${NVIDIA_API_KEY}"
   },


### PR DESCRIPTION
## What

Repoint the three agent cookbook specs from `nvidia/nemotron-3-nano-30b-a3b` to `nvidia/nemotron-3.5-lightning-30b-a3b`.

- `cookbooks/ai-agent-bugfix/agents/bugfix-agent.json`
- `cookbooks/persistent-agent-memory/agents/support-agent.json`
- `cookbooks/credential-scoped-agent/agents/github-agent.json`

## Why

`nvidia/nemotron-3-nano-30b-a3b` reached **end-of-life on the NVIDIA NIM API on 2026-09-01**. `/v1/chat/completions` now returns:

```
HTTP 410 — "The model 'nvidia/nemotron-3-nano-30b-a3b' has reached its
end of life on 2026-09-01T09:00:00Z and is no longer available."
```

The agent's completion call fails, the event stream yields nothing, and each recipe **still exits 0** while doing nothing — e.g. `ai-agent-bugfix` prints an empty "Alineo fixing the bug" section then `Still failing.`

`nvidia/nemotron-3.5-lightning-30b-a3b` is the same 30B-a3b class, still on the free tier, and streams cleanly through the Pi bridge with correct tool calls.

## Testing

Ran all three end-to-end against a local OpenSandbox server (`alineo init`):

| Recipe | Result |
|---|---|
| ai-agent-bugfix | agent diagnoses `sum(nums)/len(nums) - 1`, removes the `- 1`, independent pytest re-run → `1 passed` → "Agent fixed the bug." |
| persistent-agent-memory | session 2 (new sandbox) recalls `name: Ada` / `plan: pro` + the verified fact, answers grounded ("refund for customer Ada on the pro plan") |
| credential-scoped-agent | agent runs its own `curl … \| jq -r .login` → `DrejT`, env-grep empty, raw curl `200` → revoke → `401` |

- Changeset added (cookbooks only, no publishable package change).

## Out of scope

`examples/*` (pi-agent, rlm-*, human-in-the-loop, agent-egress-approval) and `packages/model-providers/test/nvidia.test.ts` reference the same dead id — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)