### PR TITLE
docs: egress network policy + human-in-the-loop permission gate

### DIFF
--- a/.changeset/docs-egress-and-hitl.md
+++ b/.changeset/docs-egress-and-hitl.md
@@ -1,0 +1,20 @@
+---
+---
+
+Docs site only, no publishable package changes: document the 0.4.0 features that shipped
+without docs.
+
+- **New** `core/concepts/network-policy.mdx` — `networkPolicy` at sandbox creation,
+  `NetworkRule` targets (FQDN / wildcard / IP / CIDR, and the `dns+nft` caveat), runtime
+  `sb.egress.patch()` / `delete()` / `get()`, and the ledger/resume behavior.
+- **New** `agent/getting-started/permissions.mdx` — the human-in-the-loop permission gate
+  (`AgentSpec.permissions` modes + full `PermissionPolicy`, `resolvePermission()`,
+  `prompt({ onPermission })`, `listPendingPermissions()`, the audit trail) and the
+  approve-on-egress hold (`approval: "hold"`, `onEgressRequest`, `EgressApprovalGate`).
+- **Fixed** `core/concepts/credentials.mdx` — the injection table said "header injection
+  only" and still described the removed `query` / `path` shapes. Now documents
+  `substitution` and links the migration.
+- `agent/api-reference/agent.mdx` and `agent/getting-started/streaming.mdx` updated:
+  `Alineo.load({ onEgressRequest })`, `prompt({ onPermission })`, the `permissions`
+  `AgentSpec` field, the `permission_request` / `permission_resolved` events, and the new
+  `agent.*` permission/egress methods.

--- a/apps/docs/content/docs/agent/api-reference/agent.mdx
+++ b/apps/docs/content/docs/agent/api-reference/agent.mdx
@@ -30,7 +30,13 @@ A live AI coding agent running inside an OpenSandbox container. Wraps a Pi CLI p
 ```ts
 static async load(
   spec: AgentSpec | Record<string, unknown>,
-  opts: { adapter: IStorageAdapter; rebuild?: boolean; spawnDepth?: number; maxAgents?: number },
+  opts: {
+    adapter: IStorageAdapter;
+    rebuild?: boolean;
+    spawnDepth?: number;
+    maxAgents?: number;
+    onEgressRequest?: EgressRequestHandler;
+  },
 ): Promise<Alineo>
 ```
 
@@ -47,6 +53,8 @@ const agent2 = await Alineo.load(spec, { adapter, rebuild: true });
 ```
 
 `spawnDepth`/`maxAgents` override the spec's own fields — see [Spawning child agents](#spawning-child-agents) below.
+
+`onEgressRequest` is **required** when the spec has any `env` credential binding with `approval: "hold"` — it decides each first outbound request to a held host. See [Permission gate — holding network egress](/docs/agent/getting-started/permissions#holding-network-egress-for-approval).
 
 ### Alineo.resume()
 
@@ -131,10 +139,19 @@ Refuses immediately unless this agent's own spawn-depth budget (`spawnDepth` in 
 ### agent.prompt()
 
 ```ts
-prompt(message: string, opts?: { streamingBehavior?: "steer" | "followUp" }): AgentStream
+prompt(
+  message: string,
+  opts?: {
+    streamingBehavior?: "steer" | "followUp";
+    inactivityTimeoutMs?: number;
+    onPermission?: (req: PermissionRequest) => PermissionDecision | Promise<PermissionDecision>;
+  },
+): AgentStream
 ```
 
 Send a message to Pi and stream the response. Pi maintains its own conversation context across calls within a session.
+
+`onPermission` auto-resolves each `permission_request` on the stream with the handler's decision, instead of calling `resolvePermission()` by hand — the events still flow through the stream. Only meaningful when the spec sets `permissions`. See [Permission gate](/docs/agent/getting-started/permissions).
 
 ```ts
 // Text only (most common):
@@ -195,7 +212,53 @@ Queue a message for Pi to process after it finishes the current task. Pi receive
 async abort(): Promise<void>
 ```
 
-Cancel Pi's current operation. The in-flight `prompt()` stream ends with whatever was generated before the abort.
+Cancel Pi's current operation. The in-flight `prompt()` stream ends with whatever was generated before the abort. Any pending permission requests are auto-rejected (`steer()` leaves them open).
+
+---
+
+## Permissions & approvals
+
+Active only when `AgentSpec.permissions` is set to something other than `"auto"`. See [Permission gate](/docs/agent/getting-started/permissions) for the full model.
+
+### agent.resolvePermission()
+
+```ts
+async resolvePermission(requestId: string, decision: PermissionDecision): Promise<void>
+```
+
+Answer a `permission_request` event. `PermissionDecision` is `{ kind: "once" }`, `{ kind: "always" }`, or `{ kind: "reject"; feedback?: string }`. `always` / `reject` also clear every other still-pending request for the same tool.
+
+```ts
+for await (const ev of agent.prompt("Refactor auth")) {
+  if (ev.type === "permission_request") {
+    await agent.resolvePermission(ev.requestId, { kind: "once" });
+  }
+}
+```
+
+### agent.listPendingPermissions()
+
+```ts
+async listPendingPermissions(): Promise<PendingPermission[]>
+```
+
+Tool calls currently paused awaiting a decision — each `{ requestId, tool, target, title, since }`. Useful after reconnecting to a session to discover approvals still outstanding.
+
+### agent.pendingEgressRequests()
+
+```ts
+pendingEgressRequests(): EgressRequest[]
+```
+
+Outbound network requests to `approval: "hold"` hosts currently waiting for an `onEgressRequest` decision — each `{ host, since }`. Empty unless the spec has held credential bindings.
+
+### agent.egressGate
+
+```ts
+readonly egressGate?: EgressApprovalGate
+```
+
+The host-side listener that holds egress to `approval: "hold"` hosts until `onEgressRequest` approves. Present only when the spec has held bindings; started on `load()`, stopped on `close()`.
 
 ---
 
@@ -557,25 +620,26 @@ The JSON shape of an agent spec file. Pass the path to `Alineo.load(specPath)`.
 import type { AgentSpec } from "alineo";
 ```
 
-| Field                  | Type                                     | Description                                                                                                                                                                                                                                                                                                     |
-| ---------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                 | `string`                                 | Unique identifier. Used as the sandbox session name.                                                                                                                                                                                                                                                            |
-| `cli`                  | `"pi"`                                   | CLI to run. Only `"pi"` is supported.                                                                                                                                                                                                                                                                           |
-| `cliVersion`           | `string?`                                | npm version specifier for the Pi CLI (e.g. `"1.2.3"`, `"^1.2.0"`, or a dist-tag like `"latest"`). Passed to `npm install -g @earendil-works/pi-coding-agent@<cliVersion>`. Omit to install whatever npm resolves as latest. Included in the setup-hash cache key, so changing it forces a fresh Pi CLI install. |
-| `model`                | `string?`                                | Model ID passed to Pi via `--model`.                                                                                                                                                                                                                                                                            |
-| `provider`             | `string?`                                | AI provider passed via `--provider`. Omit for a direct Google API key.                                                                                                                                                                                                                                          |
-| `packages`             | `string[]?`                              | APT packages to install before Pi (e.g. `["python3", "git"]`).                                                                                                                                                                                                                                                  |
-| `env`                  | `Record<string,string>?`                 | Env vars for the sandbox. Values may reference host env: `"${MY_VAR}"`.                                                                                                                                                                                                                                         |
-| `resources`            | `{ cpu: string; memory: string; gpu? }?` | Container resource limits. Falls back to `alineo.config.json` defaults.                                                                                                                                                                                                                                         |
-| `setup`                | `SetupStep[]?`                           | Workspace setup steps — run after Pi install, baked into the snapshot.                                                                                                                                                                                                                                          |
-| `title`                | `string?`                                | Human-readable display name.                                                                                                                                                                                                                                                                                    |
-| `description`          | `string?`                                | Short description of the agent.                                                                                                                                                                                                                                                                                 |
-| `author`               | `string?`                                | Author name.                                                                                                                                                                                                                                                                                                    |
-| `categories`           | `string[]?`                              | Arbitrary category tags.                                                                                                                                                                                                                                                                                        |
-| `metadata`             | `Record<string,string>?`                 | Not read anywhere in `alineo`; has no effect on the sandbox.                                                                                                                                                                                                                                                    |
-| `registryDependencies` | `string[]?`                              | Other agent spec URLs. Not read by `alineo` itself — used by `alineo add`, which fetches and saves each one first, depth-first.                                                                                                                                                                                 |
-| `spawnDepth`           | `number?`                                | Nesting-depth budget for `agent.spawn()`, force-decremented into each child's env. Non-negative integer. Required (directly or via `--depth`/`opts.spawnDepth`) for `agent.spawn()` to be allowed at all.                                                                                                       |
-| `maxAgents`            | `number?`                                | Optional cap on total descendants for this lineage, independent of `spawnDepth`. Non-negative integer. Unset means uncapped — unlike `spawnDepth`, omitting this doesn't disable spawning.                                                                                                                      |
+| Field                  | Type                                                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | `string`                                             | Unique identifier. Used as the sandbox session name.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `cli`                  | `"pi"`                                               | CLI to run. Only `"pi"` is supported.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `cliVersion`           | `string?`                                            | npm version specifier for the Pi CLI (e.g. `"1.2.3"`, `"^1.2.0"`, or a dist-tag like `"latest"`). Passed to `npm install -g @earendil-works/pi-coding-agent@<cliVersion>`. Omit to install whatever npm resolves as latest. Included in the setup-hash cache key, so changing it forces a fresh Pi CLI install.                                                                                                                                                                        |
+| `model`                | `string?`                                            | Model ID passed to Pi via `--model`.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `provider`             | `string?`                                            | AI provider passed via `--provider`. Omit for a direct Google API key.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `packages`             | `string[]?`                                          | APT packages to install before Pi (e.g. `["python3", "git"]`).                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `env`                  | `Record<string, string \| CredentialEnvBinding>?`    | Env vars for the sandbox. Values may reference host env: `"${MY_VAR}"`. A value can also be a `CredentialEnvBinding` (`{ credential, host, injection, approval? }`) — that key never becomes a container env var; it's registered with the credential broker instead. `approval: "hold"` holds egress to `host` until approved. See [Credentials](/docs/core/concepts/credentials) and [Permission gate](/docs/agent/getting-started/permissions#holding-network-egress-for-approval). |
+| `resources`            | `{ cpu: string; memory: string; gpu? }?`             | Container resource limits. Falls back to `alineo.config.json` defaults.                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `setup`                | `SetupStep[]?`                                       | Workspace setup steps — run after Pi install, baked into the snapshot.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `permissions`          | `"auto" \| "ask" \| "readonly" \| PermissionPolicy?` | Human-in-the-loop tool-call gate. Omit (or `"auto"`) for the current behavior — no gate. See [Permission gate](/docs/agent/getting-started/permissions).                                                                                                                                                                                                                                                                                                                               |
+| `title`                | `string?`                                            | Human-readable display name.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `description`          | `string?`                                            | Short description of the agent.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `author`               | `string?`                                            | Author name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `categories`           | `string[]?`                                          | Arbitrary category tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `metadata`             | `Record<string,string>?`                             | Not read anywhere in `alineo`; has no effect on the sandbox.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `registryDependencies` | `string[]?`                                          | Other agent spec URLs. Not read by `alineo` itself — used by `alineo add`, which fetches and saves each one first, depth-first.                                                                                                                                                                                                                                                                                                                                                        |
+| `spawnDepth`           | `number?`                                            | Nesting-depth budget for `agent.spawn()`, force-decremented into each child's env. Non-negative integer. Required (directly or via `--depth`/`opts.spawnDepth`) for `agent.spawn()` to be allowed at all.                                                                                                                                                                                                                                                                              |
+| `maxAgents`            | `number?`                                            | Optional cap on total descendants for this lineage, independent of `spawnDepth`. Non-negative integer. Unset means uncapped — unlike `spawnDepth`, omitting this doesn't disable spawning.                                                                                                                                                                                                                                                                                             |
 
 ### Example
 
@@ -642,6 +706,8 @@ type AgentEvent =
   | { type: "tool_update"; toolCallId: string; toolName: string; partialResult: unknown }
   | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
   | { type: "extension_ui"; method: string; params: unknown; isDialog: boolean; requestId?: string }
+  | { type: "permission_request"; requestId: string; tool: string; target: string; title: string }
+  | { type: "permission_resolved"; requestId: string; decision: PermissionDecision }
   | {
       type: "auto_retry_start";
       attempt: number;

--- a/apps/docs/content/docs/agent/getting-started/index.mdx
+++ b/apps/docs/content/docs/agent/getting-started/index.mdx
@@ -34,4 +34,9 @@ description: Load an agent spec, send a prompt, and understand snapshotting, wor
     title="Session inspection & control"
     description="Inspect token usage, retrieve session history, list available commands, and export HTML transcripts."
   />
+  <Card
+    href="/docs/agent/getting-started/permissions"
+    title="Permission gate (human-in-the-loop)"
+    description="Pause tool calls for human approval, restrict the toolset, and hold network egress until someone approves."
+  />
 </Cards>

--- a/apps/docs/content/docs/agent/getting-started/meta.json
+++ b/apps/docs/content/docs/agent/getting-started/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "Getting Started",
-  "pages": ["quickstart", "snapshotting", "workspace-setup", "streaming"]
+  "pages": [
+    "quickstart",
+    "snapshotting",
+    "workspace-setup",
+    "streaming",
+    "reliability",
+    "session-inspection",
+    "permissions"
+  ]
 }

--- a/apps/docs/content/docs/agent/getting-started/permissions.mdx
+++ b/apps/docs/content/docs/agent/getting-started/permissions.mdx
@@ -1,0 +1,212 @@
+---
+title: Permission gate (human-in-the-loop)
+description: Pause an agent's tool calls for human approval — a mode shorthand or a full per-tool policy, plus a gate that holds outbound network egress until someone approves.
+---
+
+By default a sandboxed Pi agent runs its tools without asking (`pi --mode rpc --approve`). `AgentSpec.permissions` puts a gate in front of every tool call: some run free, some pause and wait for a human, some are refused outright.
+
+Enforcement runs **inside the Pi process** (its `tool_call` hook). It stops a misbehaving _model_ — it is not a barrier against a process with shell access inside the sandbox actively working around it. For that, hold the network itself: see [Holding network egress for approval](#holding-network-egress-for-approval) below.
+
+## Modes
+
+The quickest form is a string:
+
+```json
+{
+  "name": "my-agent",
+  "cli": "pi",
+  "permissions": "readonly"
+}
+```
+
+| Mode         | Behavior                                                                                                                                                                                                   |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"auto"`     | Never ask. Identical to omitting `permissions` — no gate is loaded at all. (Default.)                                                                                                                      |
+| `"ask"`      | Pause before **every** tool call.                                                                                                                                                                          |
+| `"readonly"` | Restrict the model's toolset to the read-only tools (`read`, `grep`, `find`, `ls`) via Pi's `setActiveTools`, so it never sees `write` / `edit` / `bash`. Any `bash` left reachable is `classify`-triaged. |
+
+## Full policy
+
+For anything finer, `permissions` takes an object:
+
+```jsonc
+{
+  "permissions": {
+    "default": "ask",
+    "rules": [
+      { "tool": "read", "action": "allow" },
+      { "tool": "grep", "action": "allow" },
+      { "tool": "bash", "action": "classify" },
+      { "tool": "bash", "pattern": "*rm -rf*", "action": "deny" },
+      { "tool": "write", "pattern": "*/package.json", "action": "ask" },
+    ],
+  },
+}
+```
+
+| `PermissionPolicy` field | Type               | Description                                                                                                                                                                  |
+| ------------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`                | `PermissionAction` | Action when no rule matches. Defaults to `"ask"`.                                                                                                                            |
+| `rules`                  | `PermissionRule[]` | Evaluated in order; the **last** matching rule wins.                                                                                                                         |
+| `disabledTools`          | `string[]`         | Tools the agent may never call. Stripped from the model's tool list at session start, with an unconditional `deny` backstop for anything registered later (SDK / MCP tools). |
+| `restrictToTools`        | `string[]`         | If set, the **only** tools the model may see. An allowlist (`disabledTools` is a denylist). `"readonly"` expands to this.                                                    |
+
+### PermissionRule
+
+| Field     | Type                   | Description                                                                                                                                                                                                                                                                            |
+| --------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tool`    | `string`               | Tool name or glob (`*` = any run of chars, `?` = one). `"bash"`, `"write"`, `"*"`.                                                                                                                                                                                                     |
+| `pattern` | `string?`              | Glob matched against a tool-specific target: the command for `bash`, the path for `read` / `write` / `edit`, the query for `grep`. **Anchored** — `"git *"` matches `"git status"` but not `"x && git status"`; use `"*git*"` for a substring match. Omit to match any call to `tool`. |
+| `action`  | `PermissionAction`     | What to do on a match.                                                                                                                                                                                                                                                                 |
+| `limit`   | `{ count, windowMs }?` | `rate_limit` only: the ceiling and rolling window.                                                                                                                                                                                                                                     |
+
+### Actions
+
+| Action       | Effect                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow`      | Run it, no prompt.                                                                                                                                                                                                                                                                                                                                                                          |
+| `ask`        | Pause, emit a `permission_request`, wait for a human decision.                                                                                                                                                                                                                                                                                                                              |
+| `deny`       | Refuse, with a reason the model reads and can adjust to.                                                                                                                                                                                                                                                                                                                                    |
+| `rate_limit` | Allow up to `limit.count` matching calls per `limit.windowMs`, then deny.                                                                                                                                                                                                                                                                                                                   |
+| `classify`   | Best-effort read-vs-write triage (today: `bash` / `powershell` only). Splits the command on `&&` / `\|\|` / `;` / `\|` / newline and checks each part against a built-in safe-reader list (`ls`, `cat`, `grep`, `git status`, …). All parts read-only → `allow`; anything unrecognised, a redirect, `sudo`, `rm` → falls through to `ask`. For any other tool, `classify` behaves as `ask`. |
+
+## Resolving a request from the stream
+
+When the gate pauses a call it emits a `permission_request` event. Answer it with `agent.resolvePermission()`:
+
+```ts
+for await (const ev of agent.prompt("Refactor the auth module")) {
+  if (ev.type === "text") process.stdout.write(ev.text);
+  else if (ev.type === "permission_request") {
+    console.log(`${ev.tool}: ${ev.target}`);
+    await agent.resolvePermission(ev.requestId, { kind: "once" });
+  }
+}
+```
+
+`PermissionDecision`:
+
+| `kind`     | Effect                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"once"`   | Allow this one call.                                                                                                                           |
+| `"always"` | Allow this call and auto-allow every other still-pending request for the same tool. Does **not** persist past the session.                     |
+| `"reject"` | Block the call. `feedback` (if given) becomes the reason the model reads. Every other still-pending request for the same tool is rejected too. |
+
+```ts
+await agent.resolvePermission(ev.requestId, {
+  kind: "reject",
+  feedback: "No package installs — use the standard library.",
+});
+```
+
+## Handler form — `prompt({ onPermission })`
+
+To skip the hand-wired loop, pass an `onPermission` handler. It's called for each request and its return value auto-resolves it; the `permission_request` / `permission_resolved` events still flow through the stream.
+
+```ts
+import { Alineo, type PermissionRequest, type PermissionDecision } from "alineo";
+
+async function onPermission(req: PermissionRequest): Promise<PermissionDecision> {
+  if (/\b(pip|npm|apt)\b.*\binstall\b/.test(req.target)) {
+    return { kind: "reject", feedback: "No installs in this run." };
+  }
+  return { kind: "once" };
+}
+
+for await (const ev of agent.prompt("Do the task", { onPermission })) {
+  if (ev.type === "text") process.stdout.write(ev.text);
+}
+```
+
+## Inspecting what's paused
+
+`agent.listPendingPermissions()` returns the tool calls currently waiting — useful after reconnecting to a session:
+
+```ts
+for (const p of await agent.listPendingPermissions()) {
+  console.log(`${p.tool}: ${p.target}  (waiting since ${new Date(p.since).toISOString()})`);
+  await agent.resolvePermission(p.requestId, { kind: "once" });
+}
+```
+
+An operator reconnecting over `/permission-stream` is replayed the outstanding requests, and the auto-deny timeout is suspended while an operator is attached.
+
+## Audit trail
+
+Every request and resolution is written to the ledger as `permission_requested` / `permission_resolved` — **metadata only, never raw tool arguments**. Read it back with any storage adapter or `alineo logs <session>`.
+
+```ts
+for (const e of await adapter.readAll(agent.name, agent.sandboxId)) {
+  if (e.event === "permission_requested" || e.event === "permission_resolved") {
+    console.log(e.event, e.payload);
+  }
+}
+```
+
+## Lifecycle notes
+
+- `abort()` auto-rejects any pending approvals; `steer()` leaves them open.
+- `Alineo.resume()` closes out approvals that were dropped when the previous Pi process ended.
+- Ambient user extensions (`settings.json`, `.pi/extensions/`) still load but cannot bypass the gate — Pi's hook semantics are first-block-wins.
+- Fully durable pauses across `sb.pause()` / checkpoint need an upstream Pi change and are tracked as a follow-up.
+
+See the runnable [`examples/human-in-the-loop`](https://github.com/DrejT/alineo/tree/main/examples/human-in-the-loop) for an end-to-end walkthrough.
+
+---
+
+## Holding network egress for approval
+
+The permission gate above stops a misbehaving model. To gate a _host_ regardless of what runs inside the sandbox, mark a credential binding in `AgentSpec.env` with `approval: "hold"`:
+
+```jsonc
+{
+  "env": {
+    "NVIDIA_API_KEY": "${NVIDIA_API_KEY}",
+    "GITHUB_TOKEN": {
+      "credential": "${GITHUB_TOKEN}",
+      "host": "api.github.com",
+      "injection": { "type": "header", "name": "Authorization" },
+      "approval": "hold",
+    },
+  },
+}
+```
+
+On `Alineo.load()`:
+
+1. The sandbox starts `defaultAction: "allow"` with a single `deny` rule for `api.github.com` — everything else, including the agent's own model traffic, works normally.
+2. The `GITHUB_TOKEN` credential is **not registered in the vault at all** (the vault refuses a binding whose host isn't allowed).
+3. The first outbound request to the held host is denied at the sidecar, which fires a webhook. That pauses the request and calls the `onEgressRequest` handler you passed to `Alineo.load()`.
+4. On approval the gate opens the egress rule (`sb.egress.patch`) and **then** registers the credential — so the secret literally does not exist inside the sandbox until a human approves.
+
+```ts
+import { Alineo, type EgressRequest, type EgressDecision } from "alineo";
+
+async function onEgressRequest(req: EgressRequest): Promise<EgressDecision> {
+  return req.host === "api.github.com" ? "allow-once" : "deny";
+}
+
+const agent = await Alineo.load(spec, { adapter, onEgressRequest });
+```
+
+| `EgressDecision` | Effect                                                                         |
+| ---------------- | ------------------------------------------------------------------------------ |
+| `"allow-once"`   | Open the host and inject the credential; both are reversed when the turn ends. |
+| `"allow-always"` | Open the host and inject the credential permanently (for the agent's life).    |
+| `"deny"`         | Leave the host denied. The model sees the failed request and moves on.         |
+
+Loading a spec that has a `"hold"` binding **without** an `onEgressRequest` handler throws.
+
+- Enforcement is entirely **out-of-process at the egress sidecar** — a compromised in-sandbox agent cannot reach a held host until a human approves, no matter what it does inside the sandbox.
+- `agent.pendingEgressRequests()` lists what's waiting; `agent.egressGate` (an `EgressApprovalGate`) is exposed for direct control. The listener is started on `load()` and stopped on `close()`.
+- Requests and resolutions land on the ledger as `PermissionRequested` / `PermissionResolved` with `tool: "network"`.
+- The sidecar reaches the host process at the Docker bridge gateway (`172.17.0.1`) by default — override with `ALINEO_EGRESS_APPROVAL_HOST` for other network topologies.
+
+<Callout title="Deferred">
+  The deny-webhook signal is not yet unified into the Pi tool-permission stream, so network
+  approvals do **not** appear in `listPendingPermissions()` or the chat UI alongside tool
+  permissions. There is also no automatic re-run of the request that hit the denial — the model
+  retries on its own (the window is effectively instant). Both are tracked follow-ups.
+</Callout>
+
+See the runnable [`examples/agent-egress-approval`](https://github.com/DrejT/alineo/tree/main/examples/agent-egress-approval).

--- a/apps/docs/content/docs/agent/getting-started/streaming.mdx
+++ b/apps/docs/content/docs/agent/getting-started/streaming.mdx
@@ -14,6 +14,8 @@ type AgentEvent =
   | { type: "tool_update"; toolCallId: string; toolName: string; partialResult: unknown }
   | { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
   | { type: "extension_ui"; method: string; params: unknown; isDialog: boolean; requestId?: string }
+  | { type: "permission_request"; requestId: string; tool: string; target: string; title: string }
+  | { type: "permission_resolved"; requestId: string; decision: PermissionDecision }
   | {
       type: "auto_retry_start";
       attempt: number;
@@ -47,26 +49,28 @@ type AgentEvent =
   | { type: "extension_error"; extensionPath: string; event: string; error: string };
 ```
 
-| Event              | When it fires                                                                                                  |
-| ------------------ | -------------------------------------------------------------------------------------------------------------- |
-| `text`             | Pi is writing a text chunk                                                                                     |
-| `tool_start`       | Pi has invoked a tool (e.g. `bash`, `write_file`)                                                              |
-| `tool_update`      | Partial output from a long-running tool                                                                        |
-| `tool_end`         | Tool completed — includes the full result and whether it errored                                               |
-| `extension_ui`     | A Pi extension requested UI interaction (dialog auto-cancelled; forwarded for observability)                   |
-| `auto_retry_start` | Pi is retrying after a transient error (429, 5xx)                                                              |
-| `auto_retry_end`   | Retry sequence completed — `success` indicates whether it recovered                                            |
-| `agent_start`      | Pi began processing the prompt                                                                                 |
-| `agent_end`        | Pi finished the full agent run (all turns complete); includes all messages                                     |
-| `turn_start`       | A new LLM turn began; includes `turnIndex` and `timestamp`                                                     |
-| `turn_end`         | A turn completed with its assistant message and tool results                                                   |
-| `message_start`    | A new assistant message began streaming                                                                        |
-| `message_update`   | Streaming delta from an in-flight message; `delta` is the raw Pi event (text, thinking, tool call delta, etc.) |
-| `message_end`      | An assistant message completed                                                                                 |
-| `queue_update`     | The steering/follow-up queue changed (e.g. after `followUp()`)                                                 |
-| `compaction_start` | Pi began compacting context (manual or automatic)                                                              |
-| `compaction_end`   | Context compaction finished; `result` has token counts, `aborted` if it was cancelled                          |
-| `extension_error`  | A Pi extension threw an error                                                                                  |
+| Event                 | When it fires                                                                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`                | Pi is writing a text chunk                                                                                                                |
+| `tool_start`          | Pi has invoked a tool (e.g. `bash`, `write_file`)                                                                                         |
+| `tool_update`         | Partial output from a long-running tool                                                                                                   |
+| `tool_end`            | Tool completed — includes the full result and whether it errored                                                                          |
+| `extension_ui`        | A Pi extension requested UI interaction (dialog auto-cancelled; forwarded for observability)                                              |
+| `permission_request`  | The [permission gate](/docs/agent/getting-started/permissions) paused a tool call for approval — resolve with `agent.resolvePermission()` |
+| `permission_resolved` | A `permission_request` was answered (by a caller, a batched decision, or the timeout)                                                     |
+| `auto_retry_start`    | Pi is retrying after a transient error (429, 5xx)                                                                                         |
+| `auto_retry_end`      | Retry sequence completed — `success` indicates whether it recovered                                                                       |
+| `agent_start`         | Pi began processing the prompt                                                                                                            |
+| `agent_end`           | Pi finished the full agent run (all turns complete); includes all messages                                                                |
+| `turn_start`          | A new LLM turn began; includes `turnIndex` and `timestamp`                                                                                |
+| `turn_end`            | A turn completed with its assistant message and tool results                                                                              |
+| `message_start`       | A new assistant message began streaming                                                                                                   |
+| `message_update`      | Streaming delta from an in-flight message; `delta` is the raw Pi event (text, thinking, tool call delta, etc.)                            |
+| `message_end`         | An assistant message completed                                                                                                            |
+| `queue_update`        | The steering/follow-up queue changed (e.g. after `followUp()`)                                                                            |
+| `compaction_start`    | Pi began compacting context (manual or automatic)                                                                                         |
+| `compaction_end`      | Context compaction finished; `result` has token counts, `aborted` if it was cancelled                                                     |
+| `extension_error`     | A Pi extension threw an error                                                                                                             |
 
 ## Text-only with textOnly()
 

--- a/apps/docs/content/docs/core/concepts/credentials.mdx
+++ b/apps/docs/content/docs/core/concepts/credentials.mdx
@@ -9,7 +9,7 @@ Sandboxes often need to call an authenticated API — GitHub, Slack, an internal
 
 ## Enabling it
 
-Credential injection rides on the same opt-in egress layer as network policy — pass `credentialProxy: true` when creating the sandbox:
+Credential injection rides on the same opt-in egress layer as [network policy](/docs/core/concepts/network-policy) — pass `credentialProxy: true` when creating the sandbox:
 
 ```ts
 const sb = await client.sandbox({
@@ -20,7 +20,7 @@ const sb = await client.sandbox({
 });
 ```
 
-A sandbox created without `networkPolicy`/`credentialProxy` has ordinary, unrestricted egress — nothing here applies to it, and `sb.credentials.*` throws if you call it on one. `networkPolicy` itself is a separate concern (which hosts the sandbox may reach at all, allow/deny style); `credentialProxy` is what makes injection available. Setting `defaultAction: "allow"` with an empty `egress` list, as above, keeps egress wide open while turning injection on — tighten `egress` if you also want to restrict which hosts are reachable at all.
+A sandbox created without `networkPolicy`/`credentialProxy` has ordinary, unrestricted egress — nothing here applies to it, and `sb.credentials.*` throws if you call it on one. `networkPolicy` itself is a separate concern (which hosts the sandbox may reach at all, allow/deny style — see [Network policy](/docs/core/concepts/network-policy)); `credentialProxy` is what makes injection available. Setting `defaultAction: "allow"` with an empty `egress` list, as above, keeps egress wide open while turning injection on — tighten `egress` if you also want to restrict which hosts are reachable at all. `credentialProxy` also needs the server on `egress.mode = "dns+nft"` (the `alineo init` default).
 
 ## Registering a credential
 
@@ -33,11 +33,52 @@ await sb.credentials.set("github", process.env.GH_TOKEN!, {
 
 Any request the sandbox makes to `api.github.com` now gets that header added automatically — a plain `curl https://api.github.com/user` with no `Authorization` header of its own comes back authenticated. Requests to any other host are untouched. Run `env` inside the sandbox and the token isn't there.
 
-| `CredentialBinding` field | Type                       | Description                                                 |
-| ------------------------- | -------------------------- | ----------------------------------------------------------- |
-| `host`                    | `string`                   | FQDN the credential applies to                              |
-| `pathPrefix`              | `string` (optional)        | Narrows the binding to requests whose path starts with this |
-| `injection`               | `{ type: "header"; name }` | Where the value goes — currently header injection only      |
+| `CredentialBinding` field | Type                  | Description                                                 |
+| ------------------------- | --------------------- | ----------------------------------------------------------- |
+| `host`                    | `string`              | FQDN the credential applies to                              |
+| `pathPrefix`              | `string` (optional)   | Narrows the binding to requests whose path starts with this |
+| `injection`               | `CredentialInjection` | Where the value goes — see below                            |
+
+## Injection modes
+
+```ts
+type CredentialInjection =
+  | { type: "header"; name: string }
+  | { type: "substitution"; placeholder: string; in: Array<"path" | "query" | "header" | "body"> };
+```
+
+### `header` (recommended)
+
+Adds `name: <value>` to every matching outbound request. This is the default and the right choice for anything that takes a bearer token or API-key header.
+
+```ts
+injection: { type: "header", name: "Authorization" }
+```
+
+### `substitution`
+
+For APIs that want the secret in the URL or body rather than a header. The sidecar replaces **every literal occurrence** of `placeholder` in the listed request surfaces with the real value.
+
+```ts
+await sb.credentials.set("openai", process.env.OPENAI_API_KEY!, {
+  host: "api.example.com",
+  injection: { type: "substitution", placeholder: "__API_KEY__", in: ["query"] },
+});
+```
+
+The outbound request **must already contain `placeholder` verbatim** — the sidecar only substitutes, it doesn't append. Put it in the base URL you give your client:
+
+```ts
+// inside the sandbox
+fetch("https://api.example.com/v1/data?key=__API_KEY__");
+// leaves the sandbox as ...?key=<real value>
+```
+
+`sb.credentials.listBindings()` is lossy for substitution bindings (the vault doesn't echo the substitution config back), but `resume()` / `fork()` recover the full shape from the ledger.
+
+<Callout type="warn" title="Migrating from query / path injection">
+The old `{ type: "query"; param }` and `{ type: "path"; segment }` shapes were removed in 0.4.0 (they only ever threw `UnsupportedInjectionError`). Replace `{ type: "query"; param: "k" }` with `{ type: "substitution"; placeholder: "__CRED__"; in: ["query"] }` and add `?k=__CRED__` to the request URL.
+</Callout>
 
 ## Removing a credential
 

--- a/apps/docs/content/docs/core/concepts/meta.json
+++ b/apps/docs/content/docs/core/concepts/meta.json
@@ -8,6 +8,7 @@
     "refs-and-state",
     "event-stream",
     "storage-adapters",
+    "network-policy",
     "credentials"
   ]
 }

--- a/apps/docs/content/docs/core/concepts/network-policy.mdx
+++ b/apps/docs/content/docs/core/concepts/network-policy.mdx
@@ -1,0 +1,85 @@
+---
+title: Network policy
+description: Control which hosts a sandbox may reach — set an allow/deny policy at creation, or change it at runtime with sb.egress.*.
+---
+
+By default a sandbox has ordinary, unrestricted outbound network access. Pass a `networkPolicy` to `client.sandbox()` and an **egress sidecar** is attached to the container: every DNS query and (in `dns+nft` mode) every raw-IP connection is checked against your rules before it leaves.
+
+```ts
+const sb = await client.sandbox({
+  image: "ubuntu:22.04",
+  resources: { cpu: "500m", memory: "256Mi" },
+  networkPolicy: {
+    defaultAction: "deny",
+    egress: [
+      { action: "allow", target: "api.github.com" },
+      { action: "allow", target: "*.npmjs.org" },
+    ],
+  },
+});
+```
+
+<Callout title="Server requirement">
+  The egress sidecar needs the OpenSandbox server to have `egress.image` configured. `alineo init`
+  sets this up by default (`opensandbox/egress:v1.1.7`, `mode = "dns+nft"`). On an older config or a
+  `uvx opensandbox-server` host, add an `[egress]` section to `~/.config/alineo/server.toml` (or
+  `~/.sandbox.toml`) and restart the server. Omit `networkPolicy` entirely and none of this applies
+  — no sidecar is attached.
+</Callout>
+
+## NetworkPolicy
+
+| Field           | Type                | Description                                                                   |
+| --------------- | ------------------- | ----------------------------------------------------------------------------- |
+| `defaultAction` | `"allow" \| "deny"` | What to do when no rule matches. Defaults to `"deny"` server-side if omitted. |
+| `egress`        | `NetworkRule[]`     | Ordered allow/deny rules.                                                     |
+
+Each `NetworkRule` is `{ action: "allow" | "deny"; target: string }`.
+
+### Rule targets
+
+`target` is one of:
+
+- **An FQDN** — `"api.github.com"`. Matched against the DNS query name.
+- **A wildcard domain** — `"*.openai.com"`. The `*.` prefix is the sidecar's only wildcard form (it matches one or more leading labels).
+- **A bare IPv4/IPv6 address** — `"10.0.0.5"`, `"2606:4700::1111"`.
+- **A CIDR block** — `"10.0.0.0/8"`, `"fd00::/8"`.
+
+IP and CIDR rules are enforced at the **nftables layer**, so they only take effect when the server runs `egress.mode = "dns+nft"`, and they gate **raw-IP egress only**. A CIDR rule does _not_ authorize resolving a _domain_ that happens to point into that range — for reach-by-name you still need a domain rule.
+
+A malformed `target` (a URL, whitespace, a space-containing string) throws `SandboxClientError` locally before any server round-trip. The same check is exported as `isValidEgressTarget` from `@alineo-labs/opensandbox`.
+
+## Changing the policy at runtime
+
+`sb.egress.*` adjusts a **running** sandbox's policy through its sidecar. The change applies immediately — no restart, no new sandbox.
+
+```ts
+// Allow a host on a sandbox that's already running:
+await sb.egress.patch([{ action: "allow", target: "example.com" }]);
+
+// Revoke it — the host is blocked again:
+await sb.egress.delete(["example.com"]);
+
+// Read back the live policy from the sidecar:
+const { policy } = await sb.egress.get();
+```
+
+| Method                      | Behavior                                                                                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sb.egress.patch(rules)`    | Merge rules in. An incoming rule **replaces** any existing rule with the same `target`; every other rule and `defaultAction` are untouched. |
+| `sb.egress.delete(targets)` | Remove rules by `target`. Unknown targets are silently ignored.                                                                             |
+| `sb.egress.get()`           | Returns the sidecar's status envelope: `{ status?, mode?, enforcementMode?, policy? }`.                                                     |
+
+These only work on a sandbox created **with** a `networkPolicy` — without one there is no sidecar and the calls error.
+
+## Persistence across resume and fork
+
+Runtime `sb.egress.*` changes are **sidecar-local**: they don't survive the sidecar restarting and OpenSandbox's snapshot/checkpoint doesn't capture them. Every `patch` / `delete` is written to the ledger (`EgressRuleAdded` / `EgressRuleRemoved`), and `Sandbox.resume()` folds whatever is still live back into the resumed sandbox's boot policy — so a still-wanted allowance is re-applied automatically.
+
+`sb.fork()` does **not** carry runtime egress rules. A fork is a fresh branch and starts with a wide-open `defaultAction: "allow"` policy.
+
+## Relationship to credential injection
+
+`networkPolicy` (which hosts are reachable) and `credentialProxy` (transparent credential injection) are separate concerns that ride the same sidecar. `credentialProxy: true` **requires** `networkPolicy` to also be set. See [Credentials](/docs/core/concepts/credentials).
+
+For an agent that should hold a specific host behind a **human decision** before it's reachable, see [Permission gate](/docs/agent/getting-started/permissions#holding-network-egress-for-approval).

--- a/apps/docs/content/docs/core/concepts/sandboxes.mdx
+++ b/apps/docs/content/docs/core/concepts/sandboxes.mdx
@@ -23,17 +23,17 @@ const sb = await client.sandbox({
 
 ## SandboxOptions
 
-| Option            | Type                                            | Description                                                                                                                                                  |
-| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `image`           | `string \| { uri, auth? }`                      | Container image. String form: `"ubuntu:22.04"`. Object form for private registries: `{ uri: "ghcr.io/org/image", auth: { username, password } }`             |
-| `resources`       | `{ cpu: string; memory: string; gpu?: string }` | Resource limits. Required. `cpu` is a Kubernetes-style string like `"500m"` or `"2"`. `memory` is `"256Mi"`, `"1Gi"`, etc.                                   |
-| `env`             | `Record<string, string>`                        | Environment variables set in the container at startup                                                                                                        |
-| `metadata`        | `Record<string, string>`                        | Arbitrary key-value labels attached to the sandbox (e.g. `{ runId: "ci-42" }`)                                                                               |
-| `name`            | `string`                                        | User-provided name for the run — used as the ledger key. Auto-generated if omitted.                                                                          |
-| `timeout`         | `number`                                        | Sandbox lifetime in seconds. Defaults to the OpenSandbox server's default.                                                                                   |
-| `hooks`           | `SandboxHooks`                                  | Lifecycle callbacks for observability. See [Observability](/docs/core/patterns/observability).                                                               |
-| `networkPolicy`   | `{ defaultAction, egress }`                     | Optional outbound network policy — which hosts the sandbox may reach. Required to use `credentialProxy`. See [Credentials](/docs/core/concepts/credentials). |
-| `credentialProxy` | `boolean`                                       | Opt-in to credential injection via `sb.credentials.*`. See [Credentials](/docs/core/concepts/credentials).                                                   |
+| Option            | Type                                            | Description                                                                                                                                                        |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `image`           | `string \| { uri, auth? }`                      | Container image. String form: `"ubuntu:22.04"`. Object form for private registries: `{ uri: "ghcr.io/org/image", auth: { username, password } }`                   |
+| `resources`       | `{ cpu: string; memory: string; gpu?: string }` | Resource limits. Required. `cpu` is a Kubernetes-style string like `"500m"` or `"2"`. `memory` is `"256Mi"`, `"1Gi"`, etc.                                         |
+| `env`             | `Record<string, string>`                        | Environment variables set in the container at startup                                                                                                              |
+| `metadata`        | `Record<string, string>`                        | Arbitrary key-value labels attached to the sandbox (e.g. `{ runId: "ci-42" }`)                                                                                     |
+| `name`            | `string`                                        | User-provided name for the run — used as the ledger key. Auto-generated if omitted.                                                                                |
+| `timeout`         | `number`                                        | Sandbox lifetime in seconds. Defaults to the OpenSandbox server's default.                                                                                         |
+| `hooks`           | `SandboxHooks`                                  | Lifecycle callbacks for observability. See [Observability](/docs/core/patterns/observability).                                                                     |
+| `networkPolicy`   | `{ defaultAction, egress }`                     | Optional outbound network policy — which hosts the sandbox may reach. Required to use `credentialProxy`. See [Network policy](/docs/core/concepts/network-policy). |
+| `credentialProxy` | `boolean`                                       | Opt-in to credential injection via `sb.credentials.*`. See [Credentials](/docs/core/concepts/credentials).                                                         |
 
 ## Sandbox lifecycle
 


### PR DESCRIPTION
## Why

0.4.0 shipped two features with **no documentation**:

- **#230 egress** — CIDR/IP targets, runtime `sb.egress.patch/delete/get`, `substitution` credential injection (a breaking change), approve-on-egress `hold`
- **#226 HITL** — `AgentSpec.permissions` permission gate

It also left `core/concepts/credentials.mdx` **actively wrong**: the injection table still said "currently header injection only" and described the `query` / `path` shapes that 0.4.0 removed.

## What

| File | Change |
|---|---|
| `core/concepts/network-policy.mdx` | **new** — `networkPolicy` at creation, `NetworkRule` targets (FQDN / wildcard / IP / CIDR, `dns+nft` caveat), runtime `sb.egress.*`, ledger + resume/fork behavior |
| `agent/getting-started/permissions.mdx` | **new** — `permissions` modes + full `PermissionPolicy` / `PermissionRule` / actions, `resolvePermission()`, `prompt({ onPermission })`, `listPendingPermissions()`, audit trail; plus the approve-on-egress hold (`approval: "hold"`, `onEgressRequest`, `EgressApprovalGate`, `pendingEgressRequests()`) |
| `core/concepts/credentials.mdx` | fix stale injection table; document `substitution` + a migration callout |
| `agent/api-reference/agent.mdx` | `Alineo.load({ onEgressRequest })`, `prompt({ onPermission })`, `permissions` AgentSpec row, `CredentialEnvBinding` env values, `permission_request` / `permission_resolved` events, new `agent.*` methods |
| `agent/getting-started/streaming.mdx` | the two new events in the `AgentEvent` union + table |
| `meta.json` ×2 | surface `network-policy`, `permissions`, and the previously-unlisted `reliability` / `session-inspection` pages in the sidebar |

Content verified against the 0.4.0 source (`packages/agent/src/permissions.ts`, `packages/opensandbox/src/egress.ts`, `packages/agent/src/agent/egress-approval.ts`, the schema, and the `human-in-the-loop` / `agent-egress-approval` / `network-egress` examples).

Docs site only — no publishable package changes. `bun run build` (apps/docs) passes; `oxfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)