### PR TITLE
fix(docs): stop the navbar overlapping the sidebar/TOC on scroll

### DIFF
--- a/.changeset/docs-navbar-sticky-overlap.md
+++ b/.changeset/docs-navbar-sticky-overlap.md
@@ -1,0 +1,12 @@
+---
+---
+
+Docs site only, no publishable package changes: fix the top navbar overlapping the
+sidebar and "On this page" TOC on scroll.
+
+Every page is wrapped in `HomeLayout` (navbar: `sticky h-14 top-0 z-40`), and the docs
+pages nest `DocsLayout` inside it. `DocsLayout` assumes nothing sits above it on desktop
+(`--fd-header-height: 0px`), so its sticky sidebar and TOC anchored at `top: 0` and slid
+under the 56px navbar. Set `--fd-banner-height: 3.5rem` — the offset fumadocs feeds into
+`--fd-docs-row-1` for exactly this "fixed bar above the layout" case — so the sticky rails
+park below the navbar.

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -7,6 +7,18 @@ html {
   color-scheme: light;
 }
 
+/* The root layout wraps every page in `HomeLayout`, whose navbar is `sticky h-14
+   top-0 z-40`. The docs pages then nest `DocsLayout` inside it — and DocsLayout
+   assumes nothing sits above it on desktop (`--fd-header-height: 0px`), so its
+   sticky sidebar and "On this page" TOC anchor at `top: 0` and slide under the
+   56px navbar on scroll. `--fd-docs-row-1` is `var(--fd-banner-height, 0px)`, the
+   offset fumadocs exposes for exactly this "fixed bar above the layout" case —
+   feed it the navbar height so the sticky rails (and the mobile docs header) park
+   below it instead. */
+:root {
+  --fd-banner-height: 3.5rem;
+}
+
 /* Set dark color scheme for browser defaults (scrollbars, etc.) */
 html.dark {
   color-scheme: dark;


### PR DESCRIPTION
## Problem

On scroll, the sticky top navbar overlays the left sidebar and the right "On this page" TOC — the TOC heading is clipped behind the 56px bar.

## Cause

`src/app/layout.tsx` wraps **every** page in `HomeLayout`, whose navbar is `sticky h-14 top-0 z-40`. The docs sections then nest `DocsLayout` inside that. `DocsLayout` assumes nothing sits above it on desktop — its container hardcodes `--fd-header-height: 0px` and `--fd-docs-row-1: var(--fd-banner-height, 0px)` — so its `sticky top-(--fd-docs-row-1)` sidebar and TOC anchor at `top: 0` and slide under the navbar (`z-40`, opaque).

## Fix

One line in `globals.css`:

```css
:root {
  --fd-banner-height: 3.5rem;
}
```

`--fd-banner-height` is the offset fumadocs feeds into `--fd-docs-row-1` for exactly this "fixed bar above the layout" case. With it set to the `h-14` navbar height, the sticky sidebar, the TOC, and the mobile docs header all park below the navbar.

Verified against the static build: `--fd-docs-row-1` resolves to `3.5rem` and the `sticky top-(--fd-docs-row-1)` rails now clear the navbar. `bun run build` passes; `oxfmt --check` clean. Docs site only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)