### PR TITLE
chore(registry): rename Cloudflare Pages project drej-registry → alineo-registry

### DIFF
--- a/.github/workflows/deploy-registry.yml
+++ b/.github/workflows/deploy-registry.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: drej-registry
+          projectName: alineo-registry
           directory: apps/registry/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/README.md
+++ b/apps/README.md
@@ -5,7 +5,7 @@ Deployable sites for alineo, separate from the publishable SDK packages in `pack
 | App                    | Description                                                                                          | Stack              | Deploy                             |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------- |
 | [`docs`](docs)         | Documentation site ([docs.alineo.tech](https://docs.alineo.tech))                                    | Next.js + Fumadocs | Cloudflare Pages (`alineo-docs`)   |
-| [`registry`](registry) | Curated `AgentSpec` examples for `alineo add` ([registry.alineo.tech](https://registry.alineo.tech)) | Astro              | Cloudflare Pages (`drej-registry`) |
+| [`registry`](registry) | Curated `AgentSpec` examples for `alineo add` ([registry.alineo.tech](https://registry.alineo.tech)) | Astro              | Cloudflare Pages (`alineo-registry`) |
 
 ## Commands
 

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -25,5 +25,5 @@ Adding a new example: drop an `AgentSpec` JSON file into `public/agents/`, match
 bun run dev      # astro dev
 bun run build    # astro build -> dist/
 bun run preview  # preview the production build locally
-bun run deploy   # build + wrangler pages deploy (project: drej-registry)
+bun run deploy   # build + wrangler pages deploy (project: alineo-registry)
 ```

--- a/apps/registry/wrangler.toml
+++ b/apps/registry/wrangler.toml
@@ -1,3 +1,3 @@
-name = "drej-registry"
+name = "alineo-registry"
 compatibility_date = "2024-09-23"
 pages_build_output_dir = "dist"


### PR DESCRIPTION
## What

Renames the Cloudflare Pages project for `apps/registry` from `drej-registry` to `alineo-registry`:

| File | Change |
|---|---|
| `.github/workflows/deploy-registry.yml` | `projectName: drej-registry` → `alineo-registry` |
| `apps/registry/wrangler.toml` | `name = "drej-registry"` → `"alineo-registry"` |
| `apps/README.md` | deploy-target column |
| `apps/registry/README.md` | `bun run deploy` comment |

## Why

`drej` is the old internal codename. The registry deploys under it while its site (docs.alineo.tech's sibling) is branded `alineo`, and the Deployments page shows a `drej-registry (Production)` environment that reads as leftover cruft. This is part of the same cleanup as the dead `registry.alineo.tech` schema URL (#198).

## ⚠️ Merge order

`cloudflare/pages-action@v1` **does not create** Pages projects. Before this merges:

1. Create the `alineo-registry` Pages project in Cloudflare (or `wrangler pages project create alineo-registry`).
2. Attach the `registry.alineo.tech` custom domain to it **and add the DNS record** — it's currently `NXDOMAIN`, so the site is only reachable at `*.pages.dev` today.
3. Merge this PR; confirm the next `apps/registry/**` deploy runs green against `alineo-registry`.
4. Delete the old bits:
   ```
   gh api -X DELETE "repos/DrejT/alineo/environments/drej-registry%20(Production)"
   wrangler pages project delete drej-registry
   ```

Marking as draft until step 1–2 are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)