### PR TITLE
chore: reformat apps/README.md table after registry rename

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -2,9 +2,9 @@
 
 Deployable sites for alineo, separate from the publishable SDK packages in `packages/`.
 
-| App                    | Description                                                                                          | Stack              | Deploy                             |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------- |
-| [`docs`](docs)         | Documentation site ([docs.alineo.tech](https://docs.alineo.tech))                                    | Next.js + Fumadocs | Cloudflare Pages (`alineo-docs`)   |
+| App                    | Description                                                                                          | Stack              | Deploy                               |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------ |
+| [`docs`](docs)         | Documentation site ([docs.alineo.tech](https://docs.alineo.tech))                                    | Next.js + Fumadocs | Cloudflare Pages (`alineo-docs`)     |
 | [`registry`](registry) | Curated `AgentSpec` examples for `alineo add` ([registry.alineo.tech](https://registry.alineo.tech)) | Astro              | Cloudflare Pages (`alineo-registry`) |
 
 ## Commands


### PR DESCRIPTION
`oxfmt --check` broke on `main` after #240 — renaming `drej-registry` → `alineo-registry` widened that table cell and left the column misaligned. This realigns it. No content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)