### PR TITLE
fix(model-providers): swap EOL NVIDIA embed model to nemotron-3-embed-1b

### DIFF
--- a/.changeset/nvidia-embed-model-eol.md
+++ b/.changeset/nvidia-embed-model-eol.md
@@ -1,0 +1,12 @@
+---
+"@alineo-labs/model-providers": patch
+---
+
+Swap the default NVIDIA NIM embedding model from `nvidia/nv-embedqa-e5-v5` to
+`nvidia/nemotron-3-embed-1b`. The old model reached end of life on 2026-08-25 and now returns
+`410 Gone` from `integrate.api.nvidia.com`, breaking every `createNvidiaEmbeddingProvider()`
+caller that relied on the default (notably `@alineo-labs/memory`'s semantic memory).
+
+Note: the new model emits **2048-dim** vectors (was 1024). The memory adapters size their
+vector tables lazily from the first embedding seen, so fresh stores are fine, but any
+persisted semantic-memory store created with the old default must be re-embedded.

--- a/packages/model-providers/src/nvidia-embeddings.ts
+++ b/packages/model-providers/src/nvidia-embeddings.ts
@@ -2,7 +2,7 @@ import { requireApiKey } from "./types";
 
 const BASE_URL = "https://integrate.api.nvidia.com/v1";
 const ENV_VAR = "NVIDIA_API_KEY";
-const DEFAULT_MODEL = "nvidia/nv-embedqa-e5-v5";
+const DEFAULT_MODEL = "nvidia/nemotron-3-embed-1b";
 
 /**
  * Shape any `EmbeddingProvider`-consuming package (`@alineo-labs/memory`'s
@@ -21,7 +21,7 @@ export interface NvidiaEmbeddingProvider {
 }
 
 export interface NvidiaEmbeddingOptions {
-  /** NIM embedding model ID. Defaults to `"nvidia/nv-embedqa-e5-v5"`. */
+  /** NIM embedding model ID. Defaults to `"nvidia/nemotron-3-embed-1b"` (2048-dim). */
   model?: string;
   /**
    * NIM's embedding endpoint asks whether the text being embedded is a search query or a

--- a/packages/model-providers/test/nvidia-embeddings.test.ts
+++ b/packages/model-providers/test/nvidia-embeddings.test.ts
@@ -25,7 +25,7 @@ async function freshModule(): Promise<typeof NvidiaEmbeddingsModule> {
 describe("createNvidiaEmbeddingProvider", () => {
   it("defaults id to the default model", async () => {
     const { createNvidiaEmbeddingProvider } = await freshModule();
-    expect(createNvidiaEmbeddingProvider().id).toBe("nvidia:nvidia/nv-embedqa-e5-v5");
+    expect(createNvidiaEmbeddingProvider().id).toBe("nvidia:nvidia/nemotron-3-embed-1b");
   });
 
   it("id reflects a custom model", async () => {
@@ -103,7 +103,7 @@ describe("createNvidiaEmbeddingProvider", () => {
     ]);
     expect(capturedBody).toEqual({
       input: ["first", "second"],
-      model: "nvidia/nv-embedqa-e5-v5",
+      model: "nvidia/nemotron-3-embed-1b",
       input_type: "passage",
     });
   });


### PR DESCRIPTION
## Problem

`nvidia/nv-embedqa-e5-v5` — the `DEFAULT_MODEL` in `packages/model-providers/src/nvidia-embeddings.ts` — reached **end of life on 2026-08-25** and now returns `410 Gone` from `integrate.api.nvidia.com`:

```
{"status":410,"detail":"The model 'nvidia/nv-embedqa-e5-v5' has reached its end of life on 2026-08-25T09:00:00Z and is no longer available."}
```

Every `createNvidiaEmbeddingProvider()` caller relying on the default is broken on `main` — notably `@alineo-labs/memory`'s semantic memory.

## Change

- `DEFAULT_MODEL` → `nvidia/nemotron-3-embed-1b` (verified live against the NIM API — returns embeddings, accepts `input_type`).
- Doc comment + tests updated to the new model id.

## Dimension change

The new model emits **2048-dim** vectors (old was 1024). Both memory adapters (`sqlite-memory`, `postgres-memory`) size their vector tables lazily from the first embedding seen, so **fresh stores are unaffected**. Any semantic-memory store already persisted with the old default must be re-embedded. No hardcoded `1024` exists anywhere in the tree.

`cookbooks/persistent-agent-memory/index.ts` already pinned `nemotron-3-embed-1b` explicitly — it's now consistent with the default.

## Verification

- `bun test packages/model-providers/ packages/memory/` → 133 pass, 0 fail
- `bunx tsc --noEmit` on `packages/model-providers` → clean
- `bunx changeset status --since origin/main` → passes (patch bump for `@alineo-labs/model-providers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)