### PR TITLE
docs: SEO / AEO / GEO pass

### DIFF
--- a/.changeset/docs-seo-aeo-geo.md
+++ b/.changeset/docs-seo-aeo-geo.md
@@ -1,0 +1,26 @@
+---
+---
+
+Docs site only, no publishable package changes: SEO / AEO / GEO pass, benchmarked
+against the better-auth docs.
+
+- **`public/_headers`** — Next's metadata image routes (`opengraph-image`,
+  `twitter-image`, `docs-og/*`) are emitted as extension-less files that Cloudflare
+  served as `application/octet-stream`, so every link-preview crawler (Slack, X,
+  LinkedIn, Discord, iMessage) refused to render them. Force `image/png`. Also serve
+  `llms.txt` / `llms-full.txt` as `text/markdown`.
+- **Real sitemap dates** — `source.config.ts` now runs fumadocs' `last-modified`
+  plugin (git commit date per file); `sitemap.ts` uses it for `<lastmod>` instead of
+  the build timestamp, and dates the changelog from its newest release. The docs
+  deploy workflow checks out with `fetch-depth: 0` so the history is present.
+- **`/llms.txt` rewrite** — adds a "how to use this file" preamble (fetch the `.md`
+  form, cite the canonical URL without `.md`, pointer to `llms-full.txt`) and points
+  every entry at its `/llms.mdx/*.md` URL instead of the HTML page. Sections are `##`,
+  not a second `#`.
+- **New `/docs/core/ai-resources`** — documents llms.txt / llms-full.txt / per-page
+  Markdown / agent skills so the GEO surface is discoverable.
+- **Structured data** — `FAQPage` on `/faq`; per-page `TechArticle` + `BreadcrumbList`
+  (`DocStructuredData`) across all six doc collections, with `dateModified` from the
+  git date. The site-wide `WebSite` object is unchanged.
+- **`/use-cases`** — placeholder page is now `noindex` and dropped from the sitemap
+  until it has content.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,6 +18,10 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so fumadocs' last-modified plugin can read each doc file's
+          # git commit date (feeds sitemap <lastmod> + per-page TechArticle dateModified).
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/apps/docs/content/docs/core/ai-resources.mdx
+++ b/apps/docs/content/docs/core/ai-resources.mdx
@@ -1,0 +1,55 @@
+---
+title: AI Resources
+description: Use the alineo docs with LLMs and coding agents — llms.txt, per-page Markdown, and agent skills.
+---
+
+The entire alineo documentation is published in formats built for LLMs and coding
+agents, not just browsers. These cover every section — Core SDK, Workflow Builder,
+Agent SDK, and the CLI.
+
+## llms.txt
+
+[`/llms.txt`](https://docs.alineo.tech/llms.txt) is a structured index of every
+documentation page, each entry linking to that page's Markdown form. Point an agent
+at it to let it discover and pull only the pages it needs.
+
+[`/llms-full.txt`](https://docs.alineo.tech/llms-full.txt) is the entire
+documentation concatenated into a single Markdown file — drop it into a context
+window whole.
+
+## Per-page Markdown
+
+Every documentation page has a clean Markdown version at the same path under
+`/llms.mdx/`. For example:
+
+```
+https://docs.alineo.tech/docs/core/getting-started      (HTML)
+https://docs.alineo.tech/llms.mdx/core/getting-started.md   (Markdown)
+```
+
+At the top of any page, the **Copy Markdown** button copies that Markdown to your
+clipboard, and the **Open** menu opens the page directly in ChatGPT, Claude, or
+Cursor, or shows it as raw Markdown.
+
+When citing or linking a page, use its canonical URL — the one without the `.md`
+suffix.
+
+## Agent skills
+
+Install the alineo [skill](https://skills.sh) so your coding agent follows the
+SDK's conventions and knows where to look in the docs:
+
+```bash
+npx skills add DrejT/alineo --skill alineo
+```
+
+Two skills are published from the repo:
+
+| Skill    | Covers                                                                                                                 |
+| -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `alineo` | The agent SDK (`load` / `resume` / `attach` / `spawn`, prompt & bash streaming, session control) and the `alineo` CLI. |
+| `bun`    | The Bun runtime, package manager, test runner, and bundler used across the repo.                                       |
+
+Add `--skill bun` (or omit `--skill` to install both). The source lives in
+[`.agents/skills/`](https://github.com/DrejT/alineo/tree/main/.agents/skills) in the
+repo.

--- a/apps/docs/content/docs/core/meta.json
+++ b/apps/docs/content/docs/core/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "Core SDK",
-  "pages": ["getting-started", "concepts", "building", "patterns", "adapters", "api-reference"]
+  "pages": [
+    "getting-started",
+    "concepts",
+    "building",
+    "patterns",
+    "adapters",
+    "api-reference",
+    "ai-resources"
+  ]
 }

--- a/apps/docs/public/_headers
+++ b/apps/docs/public/_headers
@@ -1,0 +1,22 @@
+# Cloudflare Pages response headers. apps/docs is a static export (output: "export"),
+# so per-route headers can't come from next.config.ts — Cloudflare Pages reads this
+# file at the edge, same as _redirects.
+
+# Next's metadata image routes (opengraph-image, twitter-image, the docs-og/* OG
+# images) are emitted as extension-less files, which Cloudflare serves as
+# application/octet-stream. Link-preview crawlers (Slack, X, LinkedIn, Discord,
+# iMessage, Facebook) and image search then refuse to render them. Force PNG.
+/opengraph-image
+  Content-Type: image/png
+/twitter-image
+  Content-Type: image/png
+/docs-og/*
+  Content-Type: image/png
+
+# llms.txt / llms-full.txt are Markdown. Serve them as such — matches the per-page
+# /llms.mdx/*.md responses (Cloudflare already types those correctly from the .md
+# extension).
+/llms.txt
+  Content-Type: text/markdown; charset=utf-8
+/llms-full.txt
+  Content-Type: text/markdown; charset=utf-8

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,4 +1,5 @@
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
+import lastModified from "fumadocs-mdx/plugins/last-modified";
 
 const docs = { postprocess: { includeProcessedMarkdown: true } };
 
@@ -9,4 +10,10 @@ export const agentDocs = defineDocs({ dir: "content/docs/agent", docs });
 export const examplesDocs = defineDocs({ dir: "content/docs/examples", docs });
 export const cookbooksDocs = defineDocs({ dir: "content/docs/cookbooks", docs });
 
-export default defineConfig();
+// `lastModified` (git commit date per file) feeds the sitemap's <lastmod> and the
+// per-page TechArticle `dateModified`. Needs full git history — the docs deploy
+// workflow checks out with fetch-depth: 0. Degrades to `undefined` on a shallow
+// clone (e.g. CI), which the sitemap handles by omitting <lastmod>.
+export default defineConfig({
+  plugins: [lastModified()],
+});

--- a/apps/docs/src/app/docs/agent/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/agent/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
+import { DocStructuredData } from "@/components/doc-structured-data";
 import { githubSourceUrl, pageMarkdownUrl } from "@/lib/doc-markdown";
 
 const OVERVIEW_SLUGS = new Set(["", "getting-started", "api-reference"]);
@@ -21,6 +22,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
 
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocStructuredData page={page} tree={agentSource.pageTree} collection="agent" />
       <DocPageHeader
         title={page.data.title}
         description={page.data.description}

--- a/apps/docs/src/app/docs/alineo/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/alineo/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
+import { DocStructuredData } from "@/components/doc-structured-data";
 import { githubSourceUrl, pageMarkdownUrl } from "@/lib/doc-markdown";
 
 const OVERVIEW_SLUGS = new Set(["", "getting-started", "commands", "registry"]);
@@ -21,6 +22,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
 
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocStructuredData page={page} tree={alineoSource.pageTree} collection="alineo" />
       <DocPageHeader
         title={page.data.title}
         description={page.data.description}

--- a/apps/docs/src/app/docs/cookbooks/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/cookbooks/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
+import { DocStructuredData } from "@/components/doc-structured-data";
 import { githubSourceUrl, pageMarkdownUrl } from "@/lib/doc-markdown";
 import { CookbookPlayground } from "@/components/cookbook/playground";
 import { CookbookMeta } from "@/components/cookbook/meta";
@@ -26,6 +27,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
 
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocStructuredData page={page} tree={cookbooksSource.pageTree} collection="cookbooks" />
       <DocPageHeader
         title={page.data.title}
         description={page.data.description}

--- a/apps/docs/src/app/docs/core/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/core/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
+import { DocStructuredData } from "@/components/doc-structured-data";
 import { githubSourceUrl, pageMarkdownUrl } from "@/lib/doc-markdown";
 
 const OVERVIEW_SLUGS = new Set([
@@ -29,6 +30,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
 
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocStructuredData page={page} tree={coreSource.pageTree} collection="core" />
       <DocPageHeader
         title={page.data.title}
         description={page.data.description}

--- a/apps/docs/src/app/docs/examples/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/examples/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
+import { DocStructuredData } from "@/components/doc-structured-data";
 import { githubSourceUrl, pageMarkdownUrl } from "@/lib/doc-markdown";
 
 const OVERVIEW_SLUGS = new Set([""]);
@@ -21,6 +22,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
 
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocStructuredData page={page} tree={examplesSource.pageTree} collection="examples" />
       <DocPageHeader
         title={page.data.title}
         description={page.data.description}

--- a/apps/docs/src/app/docs/workflow/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/workflow/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
+import { DocStructuredData } from "@/components/doc-structured-data";
 import { githubSourceUrl, pageMarkdownUrl } from "@/lib/doc-markdown";
 
 const OVERVIEW_SLUGS = new Set(["", "getting-started", "building", "api-reference"]);
@@ -21,6 +22,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
 
   return (
     <DocsPage toc={isOverview ? [] : page.data.toc} full={isOverview}>
+      <DocStructuredData page={page} tree={workflowSource.pageTree} collection="workflow" />
       <DocPageHeader
         title={page.data.title}
         description={page.data.description}

--- a/apps/docs/src/app/faq/page.tsx
+++ b/apps/docs/src/app/faq/page.tsx
@@ -1,51 +1,114 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 export const metadata: Metadata = {
   title: "FAQ",
   description: "Common questions about alineo, OpenSandbox, and getting set up.",
+  alternates: { canonical: "https://docs.alineo.tech/faq" },
+};
+
+interface Faq {
+  question: string;
+  /** Rendered answer (may contain links / code). */
+  answer: ReactNode;
+  /** Plain-text answer for the FAQPage structured data. */
+  text: string;
+}
+
+const FAQS: Faq[] = [
+  {
+    question: "What is OpenSandbox, and do I need Docker?",
+    answer: (
+      <>
+        alineo runs sandboxes against an <a href="https://open-sandbox.ai">OpenSandbox</a> instance
+        — it&apos;s the container runtime underneath. The fastest way to get one locally is{" "}
+        <code>bunx alineo-cli init</code>, which starts OpenSandbox in Docker and configures alineo
+        to talk to it automatically. If you&apos;d rather not use Docker, you can run{" "}
+        <code>uvx opensandbox-server</code> directly on your host instead — see the{" "}
+        <a href="/docs/alineo/getting-started">alineo CLI docs</a> for both paths.
+      </>
+    ),
+    text: "alineo runs sandboxes against an OpenSandbox instance — the container runtime underneath. The fastest way to get one locally is `bunx alineo-cli init`, which starts OpenSandbox in Docker and configures alineo automatically. If you'd rather not use Docker, run `uvx opensandbox-server` directly on your host instead.",
+  },
+  {
+    question: "SQLite or Postgres — which storage adapter should I use?",
+    answer: (
+      <>
+        SQLite (<code>@alineo-labs/sqlite</code>) is the right default for local development and
+        single-process deployments — zero config, WAL mode, nothing to run. Postgres (
+        <code>@alineo-labs/postgres</code>) is for production, multi-process deployments that need a
+        shared ledger across instances. Both implement the same <code>IStorageAdapter</code>{" "}
+        interface, so switching later is a one-line change — see{" "}
+        <a href="/docs/core/adapters">Storage Adapters</a>.
+      </>
+    ),
+    text: "SQLite (@alineo-labs/sqlite) is the right default for local development and single-process deployments — zero config, WAL mode, nothing to run. Postgres (@alineo-labs/postgres) is for production, multi-process deployments that need a shared ledger across instances. Both implement the same IStorageAdapter interface, so switching later is a one-line change.",
+  },
+  {
+    question:
+      "What's the difference between alineo, @alineo-labs/workflow, and @alineo-labs/agent?",
+    answer: (
+      <>
+        <code>alineo</code> is the core SDK — the <code>Alineo</code> client and the{" "}
+        <code>Sandbox</code> object itself (spawn, exec, checkpoint, resume).{" "}
+        <code>@alineo-labs/workflow</code> adds a lazy pipeline builder on top — retry, branching,
+        and fan-out across multiple sandboxes. <code>@alineo-labs/agent</code> runs Pi coding agents
+        inside a sandbox container. You only need <code>workflow</code> or <code>agent</code> if
+        you&apos;re using their specific features — plain sandbox usage only needs the core{" "}
+        <code>alineo</code> package.
+      </>
+    ),
+    text: "`alineo` is the core SDK — the Alineo client and the Sandbox object itself (spawn, exec, checkpoint, resume). `@alineo-labs/workflow` adds a lazy pipeline builder on top — retry, branching, and fan-out across multiple sandboxes. `@alineo-labs/agent` runs Pi coding agents inside a sandbox container. You only need workflow or agent if you're using their specific features.",
+  },
+  {
+    question: "Does alineo work on Windows?",
+    answer: (
+      <>
+        Yes — the repo has native cross-platform support and can be developed directly on Windows
+        without WSL or Git Bash. Repository scripts use Bun&apos;s native shell APIs, and{" "}
+        <code>alineo init</code> detects Windows and uses named pipes (
+        <code>//./pipe/docker_engine</code>) for Docker socket injection automatically.
+      </>
+    ),
+    text: "Yes — the repo has native cross-platform support and can be developed directly on Windows without WSL or Git Bash. Repository scripts use Bun's native shell APIs, and `alineo init` detects Windows and uses named pipes (//./pipe/docker_engine) for Docker socket injection automatically.",
+  },
+  {
+    question: "Is alineo open source?",
+    answer: (
+      <>
+        Yes — Apache 2.0, and published to npm as <code>alineo</code>. The source is at{" "}
+        <a href="https://github.com/DrejT/alineo">github.com/DrejT/alineo</a>.
+      </>
+    ),
+    text: "Yes — Apache 2.0, and published to npm as `alineo`. The source is at github.com/DrejT/alineo.",
+  },
+];
+
+const faqStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQS.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: { "@type": "Answer", text: faq.text },
+  })),
 };
 
 export default function FaqPage() {
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-6 py-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqStructuredData) }}
+      />
       <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">FAQ</h1>
       <Accordions type="single">
-        <Accordion title="What is OpenSandbox, and do I need Docker?">
-          alineo runs sandboxes against an <a href="https://open-sandbox.ai">OpenSandbox</a>{" "}
-          instance — it's the container runtime underneath. The fastest way to get one locally is{" "}
-          <code>bunx alineo-cli init</code>, which starts OpenSandbox in Docker and configures
-          alineo to talk to it automatically. If you'd rather not use Docker, you can run{" "}
-          <code>uvx opensandbox-server</code> directly on your host instead — see the{" "}
-          <a href="/docs/alineo/getting-started">alineo CLI docs</a> for both paths.
-        </Accordion>
-        <Accordion title="SQLite or Postgres — which storage adapter should I use?">
-          SQLite (<code>@alineo-labs/sqlite</code>) is the right default for local development and
-          single-process deployments — zero config, WAL mode, nothing to run. Postgres (
-          <code>@alineo-labs/postgres</code>) is for production, multi-process deployments that need
-          a shared ledger across instances. Both implement the same <code>IStorageAdapter</code>{" "}
-          interface, so switching later is a one-line change — see{" "}
-          <a href="/docs/core/adapters">Storage Adapters</a>.
-        </Accordion>
-        <Accordion title="What's the difference between alineo, @alineo-labs/workflow, and @alineo-labs/agent?">
-          <code>alineo</code> is the core SDK — the <code>Alineo</code> client and the{" "}
-          <code>Sandbox</code> object itself (spawn, exec, checkpoint, resume).{" "}
-          <code>@alineo-labs/workflow</code> adds a lazy pipeline builder on top — retry, branching,
-          and fan-out across multiple sandboxes. <code>@alineo-labs/agent</code> runs Pi coding
-          agents inside a sandbox container. You only need <code>workflow</code> or{" "}
-          <code>agent</code> if you're using their specific features — plain sandbox usage only
-          needs the core <code>alineo</code> package.
-        </Accordion>
-        <Accordion title="Does alineo work on Windows?">
-          Yes — the repo has native cross-platform support and can be developed directly on Windows
-          without WSL or Git Bash. Repository scripts use Bun's native shell APIs, and{" "}
-          <code>alineo init</code> detects Windows and uses named pipes (
-          <code>//./pipe/docker_engine</code>) for Docker socket injection automatically.
-        </Accordion>
-        <Accordion title="Is alineo open source?">
-          Yes — Apache 2.0, and published to npm as <code>alineo</code>. The source is at{" "}
-          <a href="https://github.com/DrejT/alineo">github.com/DrejT/alineo</a>.
-        </Accordion>
+        {FAQS.map((faq) => (
+          <Accordion key={faq.question} title={faq.question}>
+            {faq.answer}
+          </Accordion>
+        ))}
       </Accordions>
     </div>
   );

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -1,26 +1,41 @@
 import { llms } from "fumadocs-core/source";
-import {
-  coreSource,
-  workflowSource,
-  agentSource,
-  alineoSource,
-  examplesSource,
-  cookbooksSource,
-} from "@/lib/source";
+import { docCollections, docUrlToMarkdownUrl } from "@/lib/doc-markdown";
 import { DEFAULT_DESCRIPTION } from "@/lib/metadata";
 
 export const dynamic = "force-static";
 
-const SECTIONS = [
-  ["Core SDK", coreSource],
-  ["Workflow Builder", workflowSource],
-  ["Agent SDK", agentSource],
-  ["alineo CLI", alineoSource],
-  ["Examples", examplesSource],
-  ["Cookbooks", cookbooksSource],
-] as const;
+const SITE = "https://docs.alineo.tech";
+
+const PREAMBLE = `# alineo docs
+
+> ${DEFAULT_DESCRIPTION}
+
+alineo is an AI agent platform built on sandboxed execution: live sandbox containers
+as first-class objects (spawn, exec, checkpoint, resume) with a durable audit ledger,
+a lazy workflow builder, and an agent SDK on top.
+
+How to use this file:
+
+- Each entry links to the page's Markdown (.md) form — fetch that for clean parsing.
+- When citing or linking a page, use its canonical URL without the .md suffix
+  (e.g. ${SITE}/docs/core/getting-started).
+- The entire documentation as one file: ${SITE}/llms-full.txt
+`;
+
+/** Rewrite every `](/docs/...)` link in an llms index to its `.md` form. */
+function toMarkdownLinks(index: string): string {
+  return index.replace(
+    /\]\((\/docs\/[^)]+)\)/g,
+    (_, url: string) => `](${SITE}${docUrlToMarkdownUrl(url)})`,
+  );
+}
 
 export function GET() {
-  const body = SECTIONS.map(([, source]) => llms(source).index()).join("\n\n");
-  return new Response(`# alineo docs\n\n> ${DEFAULT_DESCRIPTION}\n\n${body}\n`);
+  const body = Object.values(docCollections)
+    .map((source) => toMarkdownLinks(llms(source).index()).replace(/^# /gm, "## "))
+    .join("\n\n");
+
+  return new Response(`${PREAMBLE}\n${body}\n`, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
 }

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -1,67 +1,37 @@
 import type { MetadataRoute } from "next";
-import {
-  coreSource,
-  workflowSource,
-  alineoSource,
-  agentSource,
-  examplesSource,
-  cookbooksSource,
-} from "@/lib/source";
+import { docCollections } from "@/lib/doc-markdown";
+import { getChangelogEntries } from "@/lib/changelog";
 
 export const dynamic = "force-static";
 
 const BASE_URL = "https://docs.alineo.tech";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const sources = [
-    coreSource,
-    workflowSource,
-    alineoSource,
-    agentSource,
-    examplesSource,
-    cookbooksSource,
-  ];
-
-  const docPages = sources.flatMap((source) =>
-    source.getPages().map((page) => ({
-      url: `${BASE_URL}${page.url}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.8,
-    })),
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const docPages: MetadataRoute.Sitemap = Object.values(docCollections).flatMap((source) =>
+    source.getPages().map((page) => {
+      const lastModified = (page.data as { lastModified?: Date }).lastModified;
+      return {
+        url: `${BASE_URL}${page.url}`,
+        ...(lastModified ? { lastModified } : {}),
+        changeFrequency: "weekly" as const,
+        priority: 0.8,
+      };
+    }),
   );
 
+  const changelogEntries = await getChangelogEntries();
+  const changelogUpdated = changelogEntries.find((e) => e.date)?.date;
+
   return [
-    {
-      url: BASE_URL,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 1,
-    },
+    { url: BASE_URL, changeFrequency: "monthly", priority: 1 },
     {
       url: `${BASE_URL}/changelog`,
-      lastModified: new Date(),
+      ...(changelogUpdated ? { lastModified: new Date(changelogUpdated) } : {}),
       changeFrequency: "weekly",
       priority: 0.5,
     },
-    {
-      url: `${BASE_URL}/use-cases`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.5,
-    },
-    {
-      url: `${BASE_URL}/cookbook`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.5,
-    },
-    {
-      url: `${BASE_URL}/faq`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.5,
-    },
+    { url: `${BASE_URL}/cookbook`, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${BASE_URL}/faq`, changeFrequency: "weekly", priority: 0.5 },
     ...docPages,
   ];
 }

--- a/apps/docs/src/app/use-cases/page.tsx
+++ b/apps/docs/src/app/use-cases/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Use Cases",
   description: "Real-world patterns for building agent sandboxes with alineo.",
+  // Placeholder page — keep it out of the index (and the sitemap) until it has content.
+  robots: { index: false, follow: true },
 };
 
 export default function UseCasesPage() {

--- a/apps/docs/src/components/doc-structured-data.tsx
+++ b/apps/docs/src/components/doc-structured-data.tsx
@@ -1,0 +1,80 @@
+import { getBreadcrumbItems } from "fumadocs-core/breadcrumb";
+import type { Root } from "fumadocs-core/page-tree";
+import type { ReactNode } from "react";
+import type { DocCollection } from "@/lib/doc-markdown";
+
+const SITE = "https://docs.alineo.tech";
+
+interface DocPage {
+  url: string;
+  data: { title: string; description?: string; lastModified?: Date };
+}
+
+/**
+ * Per-page `TechArticle` + `BreadcrumbList` JSON-LD. The site-wide `WebSite` object
+ * is emitted separately in the root layout; this adds the article-level and
+ * navigation context answer engines (Google AI Overviews, Perplexity, Bing) use for
+ * attribution and breadcrumb rich results.
+ */
+export function DocStructuredData({
+  page,
+  tree,
+  collection,
+}: {
+  page: DocPage;
+  tree: Root;
+  collection: DocCollection;
+}) {
+  const sectionUrl = `/docs/${collection}`;
+  const sectionName = typeof tree.name === "string" ? tree.name : collection;
+
+  // fumadocs' `includeRoot` only fires on nested root folders, which these collections
+  // don't use — so prepend the site root and the section root by hand, then drop the
+  // trailing duplicate that appears when the page *is* the section index.
+  const chain: { name: ReactNode; url?: string }[] = [
+    { name: "alineo docs", url: "/" },
+    { name: sectionName, url: sectionUrl },
+    ...getBreadcrumbItems(page.url, tree, { includePage: true }),
+  ];
+  const seen = new Set<string>();
+  const crumbs = chain.filter((c) => {
+    if (!c.url) return true;
+    if (seen.has(c.url)) return false;
+    seen.add(c.url);
+    return true;
+  });
+  // The current page is always the last crumb — use its article title.
+  crumbs[crumbs.length - 1] = { name: page.data.title, url: page.url };
+
+  const itemListElement = crumbs.map((crumb, i) => ({
+    "@type": "ListItem" as const,
+    position: i + 1,
+    name: typeof crumb.name === "string" && crumb.name ? crumb.name : sectionName,
+    ...(crumb.url ? { item: `${SITE}${crumb.url}` } : {}),
+  }));
+
+  const graph = [
+    {
+      "@type": "TechArticle",
+      headline: page.data.title,
+      ...(page.data.description ? { description: page.data.description } : {}),
+      url: `${SITE}${page.url}`,
+      ...(page.data.lastModified
+        ? { dateModified: new Date(page.data.lastModified).toISOString() }
+        : {}),
+      inLanguage: "en",
+      isPartOf: { "@type": "WebSite", name: "alineo docs", url: SITE },
+      publisher: { "@type": "Organization", name: "alineo", url: "https://alineo.tech" },
+    },
+    { "@type": "BreadcrumbList", itemListElement },
+  ];
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({ "@context": "https://schema.org", "@graph": graph }),
+      }}
+    />
+  );
+}

--- a/apps/docs/src/lib/doc-markdown.ts
+++ b/apps/docs/src/lib/doc-markdown.ts
@@ -50,6 +50,18 @@ export function pageMarkdownUrl(collection: DocCollection, slugs: string[]) {
   return `/llms.mdx/${markdownSlugSegments(collection, slugs).join("/")}`;
 }
 
+/**
+ * Rewrite a docs page URL (`/docs/core/adapters/postgres`) to its raw-markdown URL
+ * (`/llms.mdx/core/adapters/postgres.md`). Used to point llms.txt entries at clean
+ * Markdown instead of HTML.
+ */
+export function docUrlToMarkdownUrl(url: string): string {
+  const rest = url.replace(/^\/docs\//, "").replace(/\/+$/, "");
+  const segments = rest.split("/");
+  segments[segments.length - 1] += ".md";
+  return `/llms.mdx/${segments.join("/")}`;
+}
+
 /** Resolve a `/llms.mdx/...` slug back to its collection and page slugs. */
 export function parseMarkdownSlug(
   slug: string[],


### PR DESCRIPTION
Benchmarked against the [better-auth docs](https://github.com/better-auth/better-auth/tree/main/docs). All changes are `apps/docs`-only; empty changeset included (matches the existing `docs-*` changesets).

## 1. Fix OG image content-type — live bug

`curl -I https://docs.alineo.tech/opengraph-image` → `content-type: application/octet-stream`. Next's static export writes the metadata image routes (`opengraph-image`, `twitter-image`, `docs-og/*`) as extension-less files, and Cloudflare serves them as octet-stream + `nosniff`. **Slack, X, LinkedIn, Discord, iMessage all refuse to render a link preview without `image/*`.**

New `public/_headers` (Cloudflare Pages, sibling of the existing `_redirects`) forces `Content-Type: image/png` on those routes, and `text/markdown` on `llms.txt` / `llms-full.txt`.

> ⚠️ Needs a post-deploy check — `_headers` `Content-Type` override is documented for Pages but this repo hasn't used `_headers` before.

## 2. Real sitemap `<lastmod>`

`sitemap.ts` stamped `new Date()` on every URL, so every page looked modified on every deploy. Now `source.config.ts` runs fumadocs' `last-modified` plugin (git commit date per file) — the same mechanism better-auth uses — and the sitemap uses it, dating `/changelog` from its newest release. `deploy-docs.yml` checks out with `fetch-depth: 0` so the history is present; degrades to omitting `<lastmod>` on CI's shallow clone.

```
/docs/agent/getting-started/session-inspection | 2026-07-02T09:54:33.000Z
/docs/agent/getting-started/streaming          | 2026-09-05T17:48:12.000Z
```

## 3. `/llms.txt` rewrite

Adopts better-auth's framing:

```
How to use this file:
- Each entry links to the page's Markdown (.md) form — fetch that for clean parsing.
- When citing or linking a page, use its canonical URL without the .md suffix ...
- The entire documentation as one file: https://docs.alineo.tech/llms-full.txt
```

Every entry now points at its `/llms.mdx/*.md` URL instead of the HTML page; section headers demoted from `#` to `##` (was emitting a second `<h1>`).

## 4. New `/docs/core/ai-resources`

Documents `llms.txt`, `llms-full.txt`, per-page Markdown (the Copy Markdown / Open buttons from #244), and `npx skills add DrejT/alineo`. The GEO surface existed but nothing linked to it. Shows in the Core SDK sidebar, sitemap, search index, and llms.txt.

## 5. Structured data

The only JSON-LD on the site was a site-wide `WebSite` object repeated on 107 pages (better-auth has none at all — this is the AEO win it skips).

- **`FAQPage`** on `/faq` — it's an accordion of Q&A, the canonical use case; consumed by Bing/Perplexity/Google AI Overviews.
- **`TechArticle` + `BreadcrumbList`** per doc page via a shared `<DocStructuredData>`, e.g.:
  `alineo docs › Core SDK › Storage Adapters › Postgres adapter`, `dateModified` from the git date.

## 6. `/use-cases`

"Coming soon" placeholder is now `noindex, follow` and dropped from the sitemap until it has content.

---

## Verified

- `bunx tsc --noEmit`, `bun run build`, `oxfmt --check`, `oxlint`, `apps/docs` tests (6/6) all pass.
- Built output inspected: `_headers` + `_redirects` both in `out/`; `llms.txt` preamble + `.md` links; FAQ page carries `FAQPage` JSON-LD; doc pages carry `TechArticle` + `BreadcrumbList` with real `dateModified`; `/use-cases` has `<meta name="robots" content="noindex, follow">` and is absent from `sitemap.xml`.
- Screenshotted the new AI Resources page and the (visually unchanged) FAQ page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)