### PR TITLE
docs: blog, mermaid diagrams, brand page, search index, light OG

### DIFF
--- a/.changeset/docs-blog-diagrams-brand.md
+++ b/.changeset/docs-blog-diagrams-brand.md
@@ -1,0 +1,24 @@
+---
+---
+
+Docs site only, no publishable package changes: blog, Mermaid diagrams, a brand
+page, a machine-readable search index, and a light-themed OG image redesign.
+
+- **Blog** — new `content/blog` collection with `/blog` (index), `/blog/<slug>`
+  (`BlogPosting` JSON-LD, per-post OG image), and `/blog/rss.xml`. Seeded with one
+  post. "Blog" added to the nav; "Use Cases" (a noindexed stub) removed from it.
+- **Mermaid** — ` ```mermaid ` fences render as diagrams (`remarkMdxMermaid` +
+  a lazy-loaded `<Mermaid>` component themed to the docs light palette). The
+  Markdown/LLM output restores the raw fence so agents and GitHub still get it.
+  Added a first diagram to `core/getting-started/how-it-works`.
+- **`/brand`** — the logo, the single brand color, the neutral palette, and
+  typography, plus usage principles.
+- **`/search-index.json`** — a flat, machine-readable index of every docs page
+  (title, description, headings, section text, canonical + Markdown URLs) — a
+  companion to `/llms.txt` and `/api/search`. Linked from the AI Resources page and
+  the seed blog post.
+- **OG images** — `renderOgImage` redesigned to match the docs light theme (white
+  field, burgundy edge + eyebrow, dark title) instead of the previous black card.
+  Covers `opengraph-image`, `twitter-image`, `docs-og/*`, and the new `blog-og/*`.
+- `src/lib/mdx-components.tsx` — the per-collection MDX component maps are now one
+  shared object.

--- a/apps/docs/content/blog/docs-built-for-agents.mdx
+++ b/apps/docs/content/blog/docs-built-for-agents.mdx
@@ -1,0 +1,44 @@
+---
+title: The docs are now built for agents
+description: Every alineo docs page is available as clean Markdown, indexed in llms.txt, and one click away from ChatGPT, Claude, or Cursor.
+date: 2026-09-08
+author: The alineo team
+---
+
+alineo is a tool for building agents, so it would be strange if the docs only spoke
+to browsers. As of this week, every page is published in a form a coding agent can
+actually use.
+
+## Clean Markdown for every page
+
+Append nothing, learn nothing — every docs URL has a Markdown twin under
+`/llms.mdx/`:
+
+```
+https://docs.alineo.tech/docs/core/getting-started        (HTML)
+https://docs.alineo.tech/llms.mdx/core/getting-started.md    (Markdown)
+```
+
+At the top of any page there's a **Copy Markdown** button and an **Open** menu that
+hands the page straight to ChatGPT, Claude, or Cursor.
+
+## llms.txt
+
+[`/llms.txt`](https://docs.alineo.tech/llms.txt) is a structured index of the whole
+documentation — every page, its description, and a link to its Markdown. Point an
+agent at it and it can pull only what it needs.
+[`/llms-full.txt`](https://docs.alineo.tech/llms-full.txt) is the entire corpus in
+one file. There's also a flat
+[`/search-index.json`](https://docs.alineo.tech/search-index.json) with per-section
+text for retrieval.
+
+## Skills
+
+If your agent supports [skills](https://skills.sh), install the alineo skill so it
+follows the SDK's conventions:
+
+```bash
+npx skills add DrejT/alineo --skill alineo
+```
+
+See [AI Resources](/docs/core/ai-resources) for the full list.

--- a/apps/docs/content/docs/core/getting-started/how-it-works.mdx
+++ b/apps/docs/content/docs/core/getting-started/how-it-works.mdx
@@ -7,16 +7,13 @@ description: SandboxHandle as a first-class object, ExecHandle, the durable ledg
 
 `client.sandbox()` creates a container and returns a live `SandboxHandle` object. You hold it as a variable, call methods on it, and `close()` it when done. Multiple sandboxes are just multiple variables — no special API.
 
-```
-client.sandbox(opts)
-      ↓
-  SandboxHandle    ← you hold this
-  ├── exec()       ← returns ExecHandle
-  ├── execCode()   ← returns ExecHandle
-  ├── writeFile()
-  ├── readFile()
-  ├── checkpoint() ← snapshot the container
-  └── close()      ← delete the container
+```mermaid
+flowchart LR
+  A["client.sandbox(opts)"] --> B["SandboxHandle<br/>(you hold this)"]
+  B --> C["exec() / execCode()<br/>→ ExecHandle"]
+  B --> D["writeFile() / readFile()"]
+  B --> E["checkpoint()<br/>snapshot the container"]
+  B --> F["close()<br/>delete the container"]
 ```
 
 Always wrap sandbox usage in `try/finally` so the container is cleaned up even if an exec throws:

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,9 +16,11 @@
     "fumadocs-mdx": "^15.0.12",
     "fumadocs-ui": "^16.10.5",
     "lucide-react": "^1.22.0",
+    "mermaid": "^11.17.2",
     "next": "16.3.1",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "zod": "^4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/docs/public/_headers
+++ b/apps/docs/public/_headers
@@ -12,6 +12,8 @@
   Content-Type: image/png
 /docs-og/*
   Content-Type: image/png
+/blog-og/*
+  Content-Type: image/png
 
 # llms.txt / llms-full.txt are Markdown. Serve them as such — matches the per-page
 # /llms.mdx/*.md responses (Cloudflare already types those correctly from the .md
@@ -20,3 +22,7 @@
   Content-Type: text/markdown; charset=utf-8
 /llms-full.txt
   Content-Type: text/markdown; charset=utf-8
+
+# Feed readers want application/rss+xml (Cloudflare would serve .xml as application/xml).
+/blog/rss.xml
+  Content-Type: application/rss+xml; charset=utf-8

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,5 +1,7 @@
-import { defineDocs, defineConfig } from "fumadocs-mdx/config";
+import { defineDocs, defineConfig, defineCollections } from "fumadocs-mdx/config";
 import lastModified from "fumadocs-mdx/plugins/last-modified";
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins/remark-mdx-mermaid";
+import { z } from "zod";
 
 const docs = { postprocess: { includeProcessedMarkdown: true } };
 
@@ -10,10 +12,26 @@ export const agentDocs = defineDocs({ dir: "content/docs/agent", docs });
 export const examplesDocs = defineDocs({ dir: "content/docs/examples", docs });
 export const cookbooksDocs = defineDocs({ dir: "content/docs/cookbooks", docs });
 
+export const blogPosts = defineCollections({
+  type: "doc",
+  dir: "content/blog",
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.coerce.date(),
+    author: z.string().default("The alineo team"),
+  }),
+});
+
 // `lastModified` (git commit date per file) feeds the sitemap's <lastmod> and the
 // per-page TechArticle `dateModified`. Needs full git history — the docs deploy
 // workflow checks out with fetch-depth: 0. Degrades to `undefined` on a shallow
 // clone (e.g. CI), which the sitemap handles by omitting <lastmod>.
 export default defineConfig({
   plugins: [lastModified()],
+  // Turn ```mermaid fences into <Mermaid /> (registered in src/lib/mdx-components.tsx).
+  mdxOptions: {
+    preset: "fumadocs",
+    remarkPlugins: (v) => [remarkMdxMermaid, ...v],
+  },
 });

--- a/apps/docs/src/app/blog-og/[slug]/route.tsx
+++ b/apps/docs/src/app/blog-og/[slug]/route.tsx
@@ -1,0 +1,20 @@
+import { ImageResponse } from "next/og";
+import { blogSource } from "@/lib/source";
+import { loadOgFonts, ogImageSize, renderOgImage } from "@/lib/og-image";
+
+export const dynamic = "force-static";
+
+export function generateStaticParams() {
+  return blogSource.getPages().map((page) => ({ slug: page.slugs[0] }));
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const page = blogSource.getPage([slug]);
+  const fonts = await loadOgFonts();
+
+  return new ImageResponse(
+    renderOgImage(page?.data.title ?? "alineo blog", page?.data.description, "alineo blog"),
+    { ...ogImageSize, fonts },
+  );
+}

--- a/apps/docs/src/app/blog/[slug]/page.tsx
+++ b/apps/docs/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { DocsBody } from "fumadocs-ui/layouts/docs/page";
+import { blogSource } from "@/lib/source";
+import { mdxComponents } from "@/lib/mdx-components";
+import { createMetadata } from "@/lib/metadata";
+import { formatBlogDate } from "@/lib/blog";
+
+const SITE = "https://docs.alineo.tech";
+
+export default async function BlogPostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const page = blogSource.getPage([slug]);
+  if (!page) notFound();
+
+  const MDX = page.data.body;
+  const date = new Date(page.data.date);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: page.data.title,
+    description: page.data.description,
+    datePublished: date.toISOString(),
+    author: { "@type": "Organization", name: page.data.author },
+    publisher: { "@type": "Organization", name: "alineo", url: "https://alineo.tech" },
+    mainEntityOfPage: `${SITE}${page.url}`,
+    image: `${SITE}/blog-og/${slug}`,
+  };
+
+  return (
+    <article className="mx-auto w-full max-w-3xl flex-1 px-6 py-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Link href="/blog" className="text-sm text-fd-muted-foreground hover:text-fd-foreground">
+        ← Blog
+      </Link>
+      <h1 className="mt-6 text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">
+        {page.data.title}
+      </h1>
+      <div className="mt-3 text-sm text-fd-muted-foreground">
+        <time dateTime={date.toISOString()}>{formatBlogDate(date)}</time> · {page.data.author}
+      </div>
+      <DocsBody className="mt-10">
+        <MDX components={mdxComponents} />
+      </DocsBody>
+    </article>
+  );
+}
+
+export function generateStaticParams() {
+  return blogSource.getPages().map((page) => ({ slug: page.slugs[0] }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const page = blogSource.getPage([slug]);
+  if (!page) return createMetadata({ title: "Not Found" });
+
+  const ogImage = `/blog-og/${slug}`;
+
+  return createMetadata({
+    title: page.data.title,
+    description: page.data.description,
+    alternates: { canonical: `${SITE}${page.url}` },
+    openGraph: {
+      type: "article",
+      publishedTime: new Date(page.data.date).toISOString(),
+      images: [ogImage],
+    },
+    twitter: { images: [ogImage] },
+  });
+}

--- a/apps/docs/src/app/blog/page.tsx
+++ b/apps/docs/src/app/blog/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { createMetadata } from "@/lib/metadata";
+import { formatBlogDate, getBlogPosts } from "@/lib/blog";
+
+export const metadata: Metadata = createMetadata({
+  title: "Blog",
+  description: "Updates and notes from the alineo team.",
+  alternates: {
+    canonical: "https://docs.alineo.tech/blog",
+    types: { "application/rss+xml": "https://docs.alineo.tech/blog/rss.xml" },
+  },
+});
+
+export default function BlogIndexPage() {
+  const posts = getBlogPosts();
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-8 px-6 py-24">
+      <header className="flex flex-col gap-3">
+        <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">Blog</h1>
+        <p className="text-fd-muted-foreground">
+          Updates and notes from the alineo team.{" "}
+          <a href="/blog/rss.xml" className="underline decoration-fd-border">
+            RSS
+          </a>
+        </p>
+      </header>
+
+      <div className="flex flex-col divide-y divide-fd-border">
+        {posts.map((post) => (
+          <Link key={post.url} href={post.url} className="group flex flex-col gap-1.5 py-5">
+            <time className="text-xs text-fd-muted-foreground" dateTime={post.date.toISOString()}>
+              {formatBlogDate(post.date)}
+            </time>
+            <span className="text-lg font-medium text-fd-foreground group-hover:text-fd-primary">
+              {post.title}
+            </span>
+            <span className="text-sm text-fd-muted-foreground">{post.description}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/app/blog/rss.xml/route.ts
+++ b/apps/docs/src/app/blog/rss.xml/route.ts
@@ -1,0 +1,49 @@
+import { getBlogPosts } from "@/lib/blog";
+
+export const dynamic = "force-static";
+
+const SITE = "https://docs.alineo.tech";
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function GET() {
+  const posts = getBlogPosts();
+  const updated = posts[0]?.date ?? new Date();
+
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE}${post.url}</link>
+      <guid isPermaLink="true">${SITE}${post.url}</guid>
+      <pubDate>${post.date.toUTCString()}</pubDate>
+      <description>${escapeXml(post.description)}</description>
+    </item>`,
+    )
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>alineo blog</title>
+    <link>${SITE}/blog</link>
+    <atom:link href="${SITE}/blog/rss.xml" rel="self" type="application/rss+xml" />
+    <description>Updates and notes from the alineo team.</description>
+    <language>en</language>
+    <lastBuildDate>${updated.toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(xml, {
+    headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/brand/page.tsx
+++ b/apps/docs/src/app/brand/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Brand",
+  description: "The alineo logo, colors, and typography — and how to use them.",
+  alternates: { canonical: "https://docs.alineo.tech/brand" },
+};
+
+const BURGUNDY = "#7a1b48";
+
+const NEUTRALS: { name: string; hex: string; note: string }[] = [
+  { name: "Foreground", hex: "#111111", note: "Body text" },
+  { name: "Muted foreground", hex: "#71717a", note: "Secondary text" },
+  { name: "Border", hex: "#e4e4e7", note: "Hairlines, dividers" },
+  { name: "Card", hex: "#fafafa", note: "Raised surfaces" },
+  { name: "Background", hex: "#ffffff", note: "Page" },
+];
+
+function Swatch({ hex, name, note }: { hex: string; name: string; note: string }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-fd-border p-3">
+      <div
+        className="size-10 shrink-0 rounded-md border border-fd-border"
+        style={{ background: hex }}
+      />
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-fd-foreground">{name}</div>
+        <div className="text-xs text-fd-muted-foreground">
+          <code>{hex}</code> · {note}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function BrandPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-12 px-6 py-24">
+      <header className="flex flex-col gap-3">
+        <h1 className="text-3xl font-semibold tracking-[-0.025em] text-fd-foreground">Brand</h1>
+        <p className="text-fd-muted-foreground">
+          The alineo logo, colors, and typography. Use these when writing about or linking to alineo
+          — a talk, a blog post, an integration listing.
+        </p>
+      </header>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-lg font-semibold text-fd-foreground">Logo</h2>
+        <div className="flex flex-wrap items-center gap-6 rounded-xl border border-fd-border bg-fd-card p-8">
+          <span className="flex items-center gap-2.5 text-2xl font-semibold tracking-[-0.02em] text-fd-foreground">
+            <span className="size-5 rounded-[5px]" style={{ background: BURGUNDY }} />
+            alineo
+          </span>
+        </div>
+        <p className="text-sm text-fd-muted-foreground">
+          The wordmark is set in Inter Semibold, all lowercase, paired with the burgundy mark.
+          Don&apos;t recolor the wordmark, add effects, or set it on a busy background. Raw assets:{" "}
+          <a href="/logo.svg">logo.svg</a>,{" "}
+          <a href="/web-app-manifest-512x512.png">icon (512×512 PNG)</a>.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-lg font-semibold text-fd-foreground">Color</h2>
+        <div className="flex flex-col gap-2">
+          <div
+            className="flex items-end gap-3 rounded-xl p-6 text-white"
+            style={{ background: BURGUNDY }}
+          >
+            <span className="text-lg font-semibold">Burgundy</span>
+            <code className="text-sm opacity-90">{BURGUNDY}</code>
+          </div>
+          <p className="text-sm text-fd-muted-foreground">
+            The single brand color — the docs sidebar, links, and accents. Everything else is
+            neutral.
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {NEUTRALS.map((c) => (
+            <Swatch key={c.hex} {...c} />
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-lg font-semibold text-fd-foreground">Typography</h2>
+        <div className="flex flex-col gap-3 rounded-xl border border-fd-border p-6">
+          <div>
+            <div className="text-2xl font-semibold text-fd-foreground">Inter</div>
+            <div className="text-sm text-fd-muted-foreground">
+              Headings and body. Weights 400 and 600.
+            </div>
+          </div>
+          <div>
+            <div className="font-mono text-xl text-fd-foreground">Geist Mono</div>
+            <div className="text-sm text-fd-muted-foreground">
+              Code, identifiers, terminal output.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-fd-foreground">Principles</h2>
+        <ul className="flex flex-col gap-2 text-sm text-fd-muted-foreground">
+          <li>Light mode only. No dark-on-brand treatments outside the sidebar.</li>
+          <li>No gradients, glows, or generic &ldquo;AI product&rdquo; visual shortcuts.</li>
+          <li>Restraint over spectacle — clarity is the point.</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/docs/src/app/docs/agent/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/agent/[[...slug]]/page.tsx
@@ -1,8 +1,7 @@
 import { DocsPage, DocsBody } from "fumadocs-ui/layouts/docs/page";
 import { agentSource } from "@/lib/source";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Steps, Step } from "fumadocs-ui/components/steps";
+import { mdxComponents } from "@/lib/mdx-components";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
@@ -30,7 +29,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
         githubUrl={githubSourceUrl("agent", page.path)}
       />
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/src/app/docs/alineo/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/alineo/[[...slug]]/page.tsx
@@ -1,8 +1,7 @@
 import { DocsPage, DocsBody } from "fumadocs-ui/layouts/docs/page";
 import { alineoSource } from "@/lib/source";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Steps, Step } from "fumadocs-ui/components/steps";
+import { mdxComponents } from "@/lib/mdx-components";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
@@ -30,7 +29,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
         githubUrl={githubSourceUrl("alineo", page.path)}
       />
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/src/app/docs/cookbooks/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/cookbooks/[[...slug]]/page.tsx
@@ -1,10 +1,9 @@
 import { DocsPage, DocsBody } from "fumadocs-ui/layouts/docs/page";
 import { cookbooksSource } from "@/lib/source";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import { mdxComponents } from "@/lib/mdx-components";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
@@ -37,9 +36,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
       <DocsBody>
         <MDX
           components={{
-            ...defaultMdxComponents,
-            Steps,
-            Step,
+            ...mdxComponents,
             Tabs,
             Tab,
             Accordion,

--- a/apps/docs/src/app/docs/core/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/core/[[...slug]]/page.tsx
@@ -1,8 +1,7 @@
 import { DocsPage, DocsBody } from "fumadocs-ui/layouts/docs/page";
 import { coreSource } from "@/lib/source";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Steps, Step } from "fumadocs-ui/components/steps";
+import { mdxComponents } from "@/lib/mdx-components";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
@@ -38,7 +37,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
         githubUrl={githubSourceUrl("core", page.path)}
       />
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/src/app/docs/examples/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/examples/[[...slug]]/page.tsx
@@ -1,8 +1,7 @@
 import { DocsPage, DocsBody } from "fumadocs-ui/layouts/docs/page";
 import { examplesSource } from "@/lib/source";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Steps, Step } from "fumadocs-ui/components/steps";
+import { mdxComponents } from "@/lib/mdx-components";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
@@ -30,7 +29,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
         githubUrl={githubSourceUrl("examples", page.path)}
       />
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/src/app/docs/workflow/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/workflow/[[...slug]]/page.tsx
@@ -1,8 +1,7 @@
 import { DocsPage, DocsBody } from "fumadocs-ui/layouts/docs/page";
 import { workflowSource } from "@/lib/source";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Steps, Step } from "fumadocs-ui/components/steps";
+import { mdxComponents } from "@/lib/mdx-components";
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
 import { DocPageHeader } from "@/components/doc-page-header";
@@ -30,7 +29,7 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
         githubUrl={githubSourceUrl("workflow", page.path)}
       />
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Steps, Step }} />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -69,9 +69,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               { text: "Docs", url: "/docs/core", active: "nested-url" },
               { text: "Examples", url: "/docs/examples", active: "nested-url" },
               { text: "Cookbook", url: "/cookbook", active: "nested-url" },
+              { text: "Blog", url: "/blog", active: "nested-url" },
               { text: "FAQ", url: "/faq", active: "nested-url" },
-              { text: "Use Cases", url: "/use-cases", active: "nested-url" },
               { text: "Changelog", url: "/changelog", active: "nested-url" },
+              { text: "Brand", url: "/brand", active: "nested-url" },
             ]}
           >
             {children}

--- a/apps/docs/src/app/search-index.json/route.ts
+++ b/apps/docs/src/app/search-index.json/route.ts
@@ -1,0 +1,39 @@
+import { docCollections, docUrlToMarkdownUrl } from "@/lib/doc-markdown";
+
+export const dynamic = "force-static";
+
+const SITE = "https://docs.alineo.tech";
+
+interface StructuredData {
+  headings?: { id: string; content: string }[];
+  contents?: { heading?: string; content: string }[];
+}
+
+/**
+ * A flat, machine-readable index of every docs page — title, description, headings,
+ * and section text, plus the canonical and Markdown URLs. Cheaper for an agent to
+ * pull than crawling HTML, and a companion to `/llms.txt` (which is a link index)
+ * and `/api/search` (the Orama search bundle).
+ */
+export function GET() {
+  const pages = Object.values(docCollections).flatMap((source) => source.getPages());
+
+  const index = pages.map((page) => {
+    const structured = (page.data as { structuredData?: StructuredData }).structuredData ?? {};
+    return {
+      url: `${SITE}${page.url}`,
+      markdownUrl: `${SITE}${docUrlToMarkdownUrl(page.url)}`,
+      title: page.data.title,
+      description: page.data.description ?? "",
+      headings: (structured.headings ?? []).map((h) => h.content),
+      sections: (structured.contents ?? []).map((c) => ({
+        heading: c.heading ?? null,
+        content: c.content,
+      })),
+    };
+  });
+
+  return new Response(JSON.stringify({ site: SITE, pages: index }, null, 2), {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { docCollections } from "@/lib/doc-markdown";
 import { getChangelogEntries } from "@/lib/changelog";
+import { getBlogPosts } from "@/lib/blog";
 
 export const dynamic = "force-static";
 
@@ -22,8 +23,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const changelogEntries = await getChangelogEntries();
   const changelogUpdated = changelogEntries.find((e) => e.date)?.date;
 
+  const blogPosts = getBlogPosts();
+  const blogPages: MetadataRoute.Sitemap = blogPosts.map((post) => ({
+    url: `${BASE_URL}${post.url}`,
+    lastModified: post.date,
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
   return [
     { url: BASE_URL, changeFrequency: "monthly", priority: 1 },
+    {
+      url: `${BASE_URL}/blog`,
+      ...(blogPosts[0] ? { lastModified: blogPosts[0].date } : {}),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
     {
       url: `${BASE_URL}/changelog`,
       ...(changelogUpdated ? { lastModified: new Date(changelogUpdated) } : {}),
@@ -32,6 +47,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     { url: `${BASE_URL}/cookbook`, changeFrequency: "weekly", priority: 0.5 },
     { url: `${BASE_URL}/faq`, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${BASE_URL}/brand`, changeFrequency: "yearly", priority: 0.3 },
+    ...blogPages,
     ...docPages,
   ];
 }

--- a/apps/docs/src/components/mermaid.tsx
+++ b/apps/docs/src/components/mermaid.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+
+/**
+ * Renders a Mermaid diagram. ` ```mermaid ` code fences in MDX are rewritten to
+ * `<Mermaid chart="…" />` by `remarkMdxMermaid` (wired in `source.config.ts`).
+ *
+ * `mermaid` is a large dependency, so it's imported lazily on first render — fine
+ * for a static export, where this only runs in the browser anyway.
+ */
+export function Mermaid({ chart }: { chart: string }) {
+  const id = useId();
+  const [svg, setSvg] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const renderedChart = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (renderedChart.current === chart) return;
+    renderedChart.current = chart;
+
+    let cancelled = false;
+    void (async () => {
+      const { default: mermaid } = await import("mermaid");
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: "loose",
+        fontFamily: "var(--font-inter), ui-sans-serif, system-ui, sans-serif",
+        theme: "base",
+        themeVariables: {
+          background: "#ffffff",
+          primaryColor: "#faf0f5",
+          primaryBorderColor: "#7a1b48",
+          primaryTextColor: "#111111",
+          lineColor: "#a1a1aa",
+          secondaryColor: "#f4f4f5",
+          tertiaryColor: "#fafafa",
+        },
+      });
+
+      try {
+        const { svg } = await mermaid.render(`mermaid-${id.replace(/[^a-zA-Z0-9]/g, "")}`, chart);
+        if (!cancelled) setSvg(svg);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chart, id]);
+
+  if (error) {
+    return (
+      <pre className="text-fd-muted-foreground text-sm">
+        <code>{chart}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      className="my-6 flex justify-center [&_svg]:h-auto [&_svg]:max-w-full"
+      // eslint-disable-next-line react/no-danger -- mermaid output, rendered client-side
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/apps/docs/src/lib/blog.ts
+++ b/apps/docs/src/lib/blog.ts
@@ -1,0 +1,29 @@
+import { blogSource } from "@/lib/source";
+
+export interface BlogPost {
+  url: string;
+  slug: string;
+  title: string;
+  description: string;
+  date: Date;
+  author: string;
+}
+
+/** All blog posts, newest first. */
+export function getBlogPosts(): BlogPost[] {
+  return blogSource
+    .getPages()
+    .map((page) => ({
+      url: page.url,
+      slug: page.slugs[0],
+      title: page.data.title,
+      description: page.data.description,
+      date: new Date(page.data.date),
+      author: page.data.author,
+    }))
+    .sort((a, b) => b.date.getTime() - a.date.getTime());
+}
+
+export function formatBlogDate(date: Date): string {
+  return date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -7,7 +7,41 @@ interface LLMPage {
   };
 }
 
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, body: string) => {
+    if (body[0] === "#") {
+      const code =
+        body[1] === "x" || body[1] === "X"
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10);
+      return Number.isNaN(code) ? match : String.fromCodePoint(code);
+    }
+    return NAMED_ENTITIES[body] ?? match;
+  });
+}
+
+/**
+ * `remarkMdxMermaid` rewrites ```mermaid fences to `<Mermaid chart="…" />` for the
+ * rendered docs — but the Markdown/LLM output wants the fence back (agents and
+ * GitHub render mermaid natively).
+ */
+function restoreMermaidFences(markdown: string): string {
+  return markdown.replace(
+    /<Mermaid\s+chart="([\s\S]*?)"\s*\/>/g,
+    (_, chart: string) => `\`\`\`mermaid\n${decodeEntities(chart).trim()}\n\`\`\``,
+  );
+}
+
 export async function getLLMText(page: LLMPage) {
-  const content = await page.data.getText("processed");
+  const content = restoreMermaidFences(await page.data.getText("processed"));
   return `# ${page.data.title}\nURL: ${page.url}\n\n${page.data.description ?? ""}\n\n${content}`;
 }

--- a/apps/docs/src/lib/mdx-components.tsx
+++ b/apps/docs/src/lib/mdx-components.tsx
@@ -1,0 +1,12 @@
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import type { MDXComponents } from "mdx/types";
+import { Mermaid } from "@/components/mermaid";
+
+/** MDX components available in every docs collection. */
+export const mdxComponents: MDXComponents = {
+  ...defaultMdxComponents,
+  Steps,
+  Step,
+  Mermaid,
+};

--- a/apps/docs/src/lib/og-image.tsx
+++ b/apps/docs/src/lib/og-image.tsx
@@ -4,6 +4,14 @@ import { join } from "node:path";
 export const ogImageSize = { width: 1200, height: 630 };
 export const ogImageContentType = "image/png";
 
+// Docs light palette (src/app/globals.css)
+const BRAND = "#7a1b48";
+const BG = "#ffffff";
+const FG = "#111111";
+const MUTED = "#52525b";
+const FAINT = "#a1a1aa";
+const BORDER = "#e4e4e7";
+
 export async function loadOgFonts() {
   const [regular, semibold] = await Promise.all([
     readFile(join(process.cwd(), "assets/Inter-Regular.woff")),
@@ -16,34 +24,80 @@ export async function loadOgFonts() {
   ];
 }
 
-export function renderOgImage(title: string, description?: string) {
+export function renderOgImage(title: string, description?: string, eyebrow = "alineo docs") {
   return (
     <div
       style={{
         display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
         width: "100%",
         height: "100%",
-        padding: "80px",
-        background: "#000000",
-        color: "#ffffff",
+        background: BG,
         fontFamily: "Inter",
       }}
     >
-      <div style={{ display: "flex", fontSize: 28, color: "#8a8a8a", marginBottom: 24 }}>
-        alineo docs
-      </div>
-      <div style={{ display: "flex", fontSize: 64, fontWeight: 600, lineHeight: 1.1 }}>{title}</div>
-      {description && (
-        <div
-          style={{ display: "flex", fontSize: 28, color: "#a3a3a3", marginTop: 24, maxWidth: 900 }}
-        >
-          {description}
+      {/* Burgundy edge band — echoes the docs sidebar */}
+      <div style={{ display: "flex", width: 14, height: "100%", background: BRAND }} />
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          padding: "72px 80px",
+          borderTop: `1px solid ${BORDER}`,
+          borderBottom: `1px solid ${BORDER}`,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <div
+            style={{ display: "flex", width: 20, height: 20, borderRadius: 5, background: BRAND }}
+          />
+          <div
+            style={{
+              display: "flex",
+              fontSize: 24,
+              fontWeight: 600,
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+              color: BRAND,
+            }}
+          >
+            {eyebrow}
+          </div>
         </div>
-      )}
-      <div style={{ display: "flex", fontSize: 24, color: "#6a6a6a", marginTop: "auto" }}>
-        docs.alineo.tech
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 66,
+            fontWeight: 600,
+            lineHeight: 1.1,
+            color: FG,
+            marginTop: 36,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          {title}
+        </div>
+
+        {description && (
+          <div
+            style={{
+              display: "flex",
+              fontSize: 28,
+              lineHeight: 1.4,
+              color: MUTED,
+              marginTop: 24,
+              maxWidth: 920,
+            }}
+          >
+            {description}
+          </div>
+        )}
+
+        <div style={{ display: "flex", fontSize: 22, color: FAINT, marginTop: "auto" }}>
+          docs.alineo.tech
+        </div>
       </div>
     </div>
   );

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -5,8 +5,10 @@ import {
   agentDocs,
   examplesDocs,
   cookbooksDocs,
+  blogPosts,
 } from "collections/server";
 import { loader } from "fumadocs-core/source";
+import { toFumadocsSource } from "fumadocs-mdx/runtime/server";
 
 export const coreSource = loader({ baseUrl: "/docs/core", source: coreDocs.toFumadocsSource() });
 
@@ -33,4 +35,9 @@ export const examplesSource = loader({
 export const cookbooksSource = loader({
   baseUrl: "/docs/cookbooks",
   source: cookbooksDocs.toFumadocsSource(),
+});
+
+export const blogSource = loader({
+  baseUrl: "/blog",
+  source: toFumadocsSource(blogPosts, []),
 });

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,11 @@
         "fumadocs-mdx": "^15.0.12",
         "fumadocs-ui": "^16.10.5",
         "lucide-react": "^1.22.0",
+        "mermaid": "^11.17.2",
         "next": "16.3.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
+        "zod": "^4",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -83,7 +85,7 @@
     },
     "cookbooks/ai-agent-bugfix": {
       "name": "alineo-cookbook-ai-agent-bugfix",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@alineo-labs/opensandbox": "workspace:*",
         "@alineo-labs/sandbox": "workspace:*",
@@ -93,7 +95,7 @@
     },
     "cookbooks/ci-test-runner": {
       "name": "alineo-cookbook-ci-test-runner",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -101,7 +103,7 @@
     },
     "cookbooks/credential-scoped-agent": {
       "name": "alineo-cookbook-credential-scoped-agent",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -110,7 +112,7 @@
     },
     "cookbooks/parallel-test-shards": {
       "name": "alineo-cookbook-parallel-test-shards",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -118,7 +120,7 @@
     },
     "cookbooks/persistent-agent-memory": {
       "name": "alineo-cookbook-persistent-agent-memory",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/memory": "workspace:*",
@@ -130,7 +132,7 @@
     },
     "cookbooks/resumable-etl-pipeline": {
       "name": "alineo-cookbook-resumable-etl-pipeline",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -138,7 +140,7 @@
     },
     "cookbooks/untrusted-code-execution": {
       "name": "alineo-cookbook-untrusted-code-execution",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -146,7 +148,7 @@
     },
     "examples/agent-egress-approval": {
       "name": "alineo-example-agent-egress-approval",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/sqlite": "workspace:*",
         "alineo": "workspace:*",
@@ -154,7 +156,7 @@
     },
     "examples/benchmark": {
       "name": "alineo-example-benchmark",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -162,7 +164,7 @@
     },
     "examples/cancellation": {
       "name": "alineo-example-cancellation",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -170,7 +172,7 @@
     },
     "examples/capture": {
       "name": "alineo-example-capture",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -178,7 +180,7 @@
     },
     "examples/control-flow": {
       "name": "alineo-example-control-flow",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -187,7 +189,7 @@
     },
     "examples/credential-injection": {
       "name": "alineo-example-credential-injection",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -195,7 +197,7 @@
     },
     "examples/environments": {
       "name": "alineo-example-environments",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -203,7 +205,7 @@
     },
     "examples/error-handling": {
       "name": "alineo-example-error-handling",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -211,7 +213,7 @@
     },
     "examples/exec-code": {
       "name": "alineo-example-exec-code",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -219,7 +221,7 @@
     },
     "examples/file-ops": {
       "name": "alineo-example-file-ops",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -227,7 +229,7 @@
     },
     "examples/hello-world": {
       "name": "alineo-example-hello-world",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -235,7 +237,7 @@
     },
     "examples/human-in-the-loop": {
       "name": "alineo-example-human-in-the-loop",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/sqlite": "workspace:*",
         "alineo": "workspace:*",
@@ -243,7 +245,7 @@
     },
     "examples/interactive-exec": {
       "name": "alineo-example-interactive-exec",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -251,7 +253,7 @@
     },
     "examples/memory-basics": {
       "name": "alineo-example-memory-basics",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/memory": "workspace:*",
@@ -260,7 +262,7 @@
     },
     "examples/network-egress": {
       "name": "alineo-example-network-egress",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -268,7 +270,7 @@
     },
     "examples/pi-agent": {
       "name": "alineo-example-pi-agent",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/opensandbox": "workspace:*",
         "@alineo-labs/sandbox": "workspace:*",
@@ -278,7 +280,7 @@
     },
     "examples/ports": {
       "name": "alineo-example-ports",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -286,7 +288,7 @@
     },
     "examples/read-file": {
       "name": "alineo-example-read-file",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -294,7 +296,7 @@
     },
     "examples/rlm-repo-fanout": {
       "name": "alineo-example-rlm-repo-fanout",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -303,7 +305,7 @@
     },
     "examples/run-bash-script": {
       "name": "alineo-example-run-bash-script",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -311,7 +313,7 @@
     },
     "examples/sandbox-extensions": {
       "name": "alineo-example-sandbox-extensions",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -320,7 +322,7 @@
     },
     "examples/sandbox-fork": {
       "name": "alineo-example-sandbox-fork",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -328,7 +330,7 @@
     },
     "examples/snapshot-replay": {
       "name": "alineo-example-snapshot-replay",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -351,7 +353,7 @@
     },
     "packages/adapters/otel": {
       "name": "@alineo-labs/otel",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -367,7 +369,7 @@
     },
     "packages/adapters/postgres": {
       "name": "@alineo-labs/postgres",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "postgres": "3.4.9",
@@ -380,7 +382,7 @@
     },
     "packages/adapters/postgres-memory": {
       "name": "@alineo-labs/postgres-memory",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@alineo-labs/memory": "workspace:*",
         "postgres": "3.4.9",
@@ -393,7 +395,7 @@
     },
     "packages/adapters/sqlite": {
       "name": "@alineo-labs/sqlite",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -405,7 +407,7 @@
     },
     "packages/adapters/sqlite-memory": {
       "name": "@alineo-labs/sqlite-memory",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@alineo-labs/memory": "workspace:*",
         "sqlite-vec": "^0.1.9",
@@ -418,7 +420,7 @@
     },
     "packages/adapters/vault": {
       "name": "@alineo-labs/vault",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/opensandbox": "workspace:*",
@@ -431,7 +433,7 @@
     },
     "packages/agent": {
       "name": "alineo",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/memory": "workspace:*",
@@ -446,7 +448,7 @@
     },
     "packages/agent-browser": {
       "name": "@alineo-labs/agent-browser",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -459,7 +461,7 @@
     },
     "packages/cli": {
       "name": "alineo-cli",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bin": {
         "alineo": "./dist/index.mjs",
       },
@@ -479,7 +481,7 @@
     },
     "packages/core": {
       "name": "@alineo-labs/core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@alineo-labs/opensandbox": "workspace:*",
       },
@@ -500,7 +502,7 @@
     },
     "packages/memory": {
       "name": "@alineo-labs/memory",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
       },
@@ -527,7 +529,7 @@
     },
     "packages/opensandbox": {
       "name": "@alineo-labs/opensandbox",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "bun-types": "1.3.14",
         "tsdown": "0.22.3",
@@ -537,7 +539,7 @@
     },
     "packages/sdks/typescript": {
       "name": "@alineo-labs/sandbox",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@alineo-labs/core": "workspace:*",
         "@alineo-labs/opensandbox": "workspace:*",
@@ -552,7 +554,7 @@
     },
     "packages/workflow": {
       "name": "@alineo-labs/workflow",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
       },
@@ -565,7 +567,7 @@
     },
     "tests/integration": {
       "name": "@alineo-labs/integration-tests",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@alineo-labs/sandbox": "workspace:*",
         "@alineo-labs/sqlite": "workspace:*",
@@ -634,6 +636,8 @@
     "@alineo-labs/workflow": ["@alineo-labs/workflow@workspace:packages/workflow"],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@antfu/install-pkg": ["@antfu/install-pkg@2.0.1", "", { "dependencies": { "package-manager-detector": "^1.7.0", "tinyexec": "^1.2.4" } }, "sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
@@ -763,6 +767,8 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
     "@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow=="],
 
     "@bruits/satteri-darwin-x64": ["@bruits/satteri-darwin-x64@0.9.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q=="],
@@ -816,6 +822,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@clack/core": ["@clack/core@1.4.2", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ=="],
 
@@ -953,6 +961,10 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.7", "", { "dependencies": { "@antfu/install-pkg": "^2.0.1", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-JZHlwdID+dy+lTgbYC8NEC4zeugqeYsc6jewvzb4c58kHauJn+X7rNwQjxz5p2qSjqaEeQoLkCIQ9v/H4PK0/w=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -1056,6 +1068,8 @@
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.1", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
@@ -1423,6 +1437,68 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.1", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.2.0", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -1432,6 +1508,8 @@
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -1528,6 +1606,8 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.12.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.12.2", "", { "os": "win32", "cpu": "x64" }, "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@valibot/to-json-schema": ["@valibot/to-json-schema@1.7.1", "", { "peerDependencies": { "valibot": "^1.4.0" } }, "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A=="],
 
@@ -1821,6 +1901,8 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
@@ -1837,6 +1919,78 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.3", "", {}, "sha512-yfYGhRcGAntq6YBD583j4n0Eg3jIxvWmZtz/5uz9UYkeIStSlMxuUja+ec5j3iBD8nv1rwaOAYMW09tBdkSeaQ=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
@@ -1846,6 +2000,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "dayjs": ["dayjs@1.11.23", "", {}, "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1862,6 +2018,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1944,6 +2102,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.1", "", { "dependencies": { "es-abstract-get": "^1.0.0", "es-errors": "^1.3.0", "is-callable": "^1.2.7", "is-date-object": "^1.1.0", "is-symbol": "^1.1.1" } }, "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g=="],
+
+    "es-toolkit": ["es-toolkit@1.52.0", "", {}, "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -2047,6 +2207,8 @@
 
     "fast-xml-parser": ["fast-xml-parser@5.9.3", "", { "dependencies": { "@nodable/entities": "^2.2.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^1.0.1", "path-expression-matcher": "^1.5.0", "strnum": "^2.4.1", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g=="],
 
+    "fastdom": ["fastdom@1.0.12", "", { "dependencies": { "strictdom": "^1.0.1" } }, "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -2149,6 +2311,8 @@
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -2219,6 +2383,8 @@
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "import-without-cache": ["import-without-cache@0.4.0", "", {}, "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -2230,6 +2396,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
@@ -2357,7 +2525,11 @@
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -2366,6 +2538,8 @@
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
     "layerr": ["layerr@3.0.0", "", {}, "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -2394,6 +2568,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -2462,6 +2638,8 @@
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.17.2", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.34.0", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.21", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "fastdom": "1.0.12", "katex": "^0.16.47", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -2685,6 +2863,8 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.6.1", "", {}, "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ=="],
@@ -2710,6 +2890,10 @@
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2833,13 +3017,19 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rolldown": ["rolldown@1.1.2", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.2", "@rolldown/binding-darwin-arm64": "1.1.2", "@rolldown/binding-darwin-x64": "1.1.2", "@rolldown/binding-freebsd-x64": "1.1.2", "@rolldown/binding-linux-arm-gnueabihf": "1.1.2", "@rolldown/binding-linux-arm64-gnu": "1.1.2", "@rolldown/binding-linux-arm64-musl": "1.1.2", "@rolldown/binding-linux-ppc64-gnu": "1.1.2", "@rolldown/binding-linux-s390x-gnu": "1.1.2", "@rolldown/binding-linux-x64-gnu": "1.1.2", "@rolldown/binding-linux-x64-musl": "1.1.2", "@rolldown/binding-openharmony-arm64": "1.1.2", "@rolldown/binding-wasm32-wasi": "1.1.2", "@rolldown/binding-win32-arm64-msvc": "1.1.2", "@rolldown/binding-win32-x64-msvc": "1.1.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.26.0", "", { "dependencies": { "@babel/generator": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0", "@babel/parser": "^8.0.0", "ast-kit": "^3.0.0", "birpc": "^4.0.0", "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q=="],
 
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
@@ -2943,6 +3133,8 @@
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
+    "strictdom": ["strictdom@1.0.1", "", {}, "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg=="],
+
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
@@ -2976,6 +3168,8 @@
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -3024,6 +3218,8 @@
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
@@ -3110,6 +3306,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@14.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ=="],
 
     "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
@@ -3216,6 +3414,8 @@
     "@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@alineo-labs/sandbox-app/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@antfu/install-pkg/package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
 
     "@astrojs/compiler-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
 
@@ -3357,6 +3557,16 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "docs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
@@ -3409,9 +3619,13 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "magicast/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -3554,6 +3768,12 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 


### PR DESCRIPTION
Items **3, 5, 6, 7** from the better-auth feature-set comparison, plus the OG-image restyle. All `apps/docs`-only; empty changeset included.

> **Item 4 (`<ApiMethod>` MDX components)** is deliberately not here — it touches the structure of the API-reference content and the `remark-llms` placeholder pipeline, and deserves its own pass. Fast-follow.

## 3 — Blog + RSS

- `content/blog` collection (`defineCollections`, `title`/`description`/`date`/`author` schema).
- `/blog` index, `/blog/<slug>` post (`BlogPosting` JSON-LD, `og:type: article`, per-post OG image), `/blog/rss.xml`.
- Seeded with one post — *"The docs are now built for agents"* — covering the llms.txt / llms.mdx / skills work from #244/#245. **Please sanity-check the voice.**
- Nav: **Blog** added, **Use Cases** removed (it's a `noindex` "coming soon" stub).

## 5 — Mermaid diagrams

- `remarkMdxMermaid` (wired in `source.config.ts`) rewrites ` ```mermaid ` fences → `<Mermaid>`, a lazy-loaded client component themed to the docs light palette (white fill, burgundy borders).
- `get-llm-text.ts` restores the raw ` ```mermaid ` fence in the Markdown/LLM output — agents and GitHub render mermaid natively, so the fence is better there than the component tag.
- First diagram added to `core/getting-started/how-it-works` (replacing an ASCII-art box).
- `mermaid` added as a dependency (~lazy-loaded, not in the initial bundle).

## 6 — `/brand`

The logo lockup, the single brand color (`#7a1b48`), the neutral palette, typography (Inter / Geist Mono), and usage principles pulled from the design guidance.

## 7 — `/search-index.json`

A flat, machine-readable index of every docs page — title, description, headings, per-section text, and both the canonical and `.md` URLs. Companion to `/llms.txt` (link index) and `/api/search` (Orama bundle). Linked from `/docs/core/ai-resources`.

## OG images → docs light theme

`renderOgImage` was a black card with white text. Redesigned to match the docs: white field, a burgundy edge band + eyebrow (echoing the sidebar), dark title, grey description. Applies to `opengraph-image`, `twitter-image`, `docs-og/*`, and the new `blog-og/*` (all also added to `_headers` for `image/png`).

<table><tr>
<td><b>before</b><br><sub>black</sub></td>
<td><b>after</b><br><sub>light, on-brand</sub></td>
</tr></table>

## Also

- `src/lib/mdx-components.tsx` — the six per-collection MDX component maps collapsed into one shared object (needed for `<Mermaid>` everywhere anyway).

## Verified

`bunx tsc --noEmit`, `bun run build`, `oxfmt --check`, `oxlint`, `apps/docs` tests (6/6) all pass. Screenshotted the blog index, a post (with the mermaid diagram), `/brand`, and the new light OG image. Built output checked: `rss.xml` valid, `search-index.json` well-formed, `BlogPosting` JSON-LD present, `_headers` covers `blog-og/*` + `blog/rss.xml`, mermaid fence restored in `llms.mdx` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)