### PR TITLE
docs: fix deploy — drop unresolvable mdx/types import

### DIFF
--- a/.changeset/fix-docs-mdx-types-import.md
+++ b/.changeset/fix-docs-mdx-types-import.md
@@ -1,0 +1,7 @@
+---
+---
+
+Docs site only: drop the `import type { MDXComponents } from "mdx/types"` in
+`src/lib/mdx-components.tsx` (added in #246). `@types/mdx` isn't in `apps/docs`'s
+dependency tree, so `next build`'s type check couldn't resolve it on a clean
+install and the docs deploy failed. The inferred type is fine.

--- a/apps/docs/src/lib/mdx-components.tsx
+++ b/apps/docs/src/lib/mdx-components.tsx
@@ -1,10 +1,9 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { Step, Steps } from "fumadocs-ui/components/steps";
-import type { MDXComponents } from "mdx/types";
 import { Mermaid } from "@/components/mermaid";
 
 /** MDX components available in every docs collection. */
-export const mdxComponents: MDXComponents = {
+export const mdxComponents = {
   ...defaultMdxComponents,
   Steps,
   Step,


### PR DESCRIPTION
The docs deploy for #246 failed:

```
src/lib/mdx-components.tsx(3,36): error TS2307: Cannot find module 'mdx/types' or its corresponding type declarations.
```

`#246` added `import type { MDXComponents } from "mdx/types"`. `@types/mdx` is present in the workspace but isn't a declared `apps/docs` dependency, so `next build`'s TypeScript check can't resolve it on a clean install (`deploy-docs.yml` runs `next build` with `working-directory: apps/docs`). CI's `ci.yml` Build passed because the root install hoists it into view; the isolated deploy build doesn't.

Fix: drop the annotation — the inferred type of the components object is fine. Returns to the pre-#246 pattern.

Verified: `bunx tsc --noEmit` and `bun run build` (incl. the "Running TypeScript" step) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)