### PR TITLE
docs: remove Brand from the navbar

### DIFF
--- a/.changeset/docs-brand-out-of-nav.md
+++ b/.changeset/docs-brand-out-of-nav.md
@@ -1,0 +1,5 @@
+---
+---
+
+Docs site only: drop "Brand" from the top navbar. The `/brand` page stays (linked
+from the sitemap and reachable directly) — it just doesn't need a nav slot.

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -72,7 +72,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               { text: "Blog", url: "/blog", active: "nested-url" },
               { text: "FAQ", url: "/faq", active: "nested-url" },
               { text: "Changelog", url: "/changelog", active: "nested-url" },
-              { text: "Brand", url: "/brand", active: "nested-url" },
             ]}
           >
             {children}


### PR DESCRIPTION
Drops "Brand" from the top navbar (added in #246). The `/brand` page itself stays — it's in the sitemap and linked directly — it just doesn't need a nav slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)