### PR TITLE
docs(mcp): drop [observability] from wrangler.toml

### DIFF
--- a/.changeset/mcp-wrangler-trim.md
+++ b/.changeset/mcp-wrangler-trim.md
@@ -1,0 +1,5 @@
+---
+---
+
+Docs MCP Worker config only: remove `[observability]` from `apps/docs-mcp/wrangler.toml`
+so the deploy needs fewer Cloudflare token permissions.

--- a/apps/docs-mcp/wrangler.toml
+++ b/apps/docs-mcp/wrangler.toml
@@ -18,6 +18,3 @@ routes = [
   { pattern = "docs.alineo.tech/mcp", zone_name = "alineo.tech" },
   { pattern = "docs.alineo.tech/mcp/*", zone_name = "alineo.tech" },
 ]
-
-[observability]
-enabled = true


### PR DESCRIPTION
Trims the docs MCP Worker config so the deploy needs fewer Cloudflare API token permissions (no Workers Observability). Follows #249, whose deploy is blocked on token perms (Workers Scripts: Edit + Workers Routes: Edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)