### PR TITLE
docs(mcp): deploy with a minimal Cloudflare token (Workers Scripts: Edit only)

### DIFF
--- a/.changeset/mcp-pin-account.md
+++ b/.changeset/mcp-pin-account.md
@@ -2,10 +2,8 @@
 ---
 
 Docs MCP Worker config only, so the deploy works with a minimal Cloudflare token
-(just **Workers Scripts: Edit**):
-
-- Pin `account_id` in `apps/docs-mcp/wrangler.toml` (no "Account Settings: Read"
-  needed).
-- Move the `docs.alineo.tech/mcp` route out of `wrangler.toml` — it's added once in
-  the Cloudflare dashboard, so the token doesn't also need "Workers Routes: Edit".
-  Until then the Worker is on its `*.workers.dev` URL.
+(just **Workers Scripts: Edit**): drop the `routes` from `apps/docs-mcp/wrangler.toml`
+— the `docs.alineo.tech/mcp` route is added once in the Cloudflare dashboard, so the
+token doesn't also need "Workers Routes: Edit". Until then the Worker is on its
+`*.workers.dev` URL. `account_id` stays out of the file (it comes from the
+`CLOUDFLARE_ACCOUNT_ID` secret).

--- a/.changeset/mcp-pin-account.md
+++ b/.changeset/mcp-pin-account.md
@@ -1,0 +1,6 @@
+---
+---
+
+Docs MCP Worker config only: pin `account_id` in `apps/docs-mcp/wrangler.toml` so
+the deploy token doesn't need "Account Settings: Read" (and the deploy fails with a
+clearer error if the real problem is missing Workers permissions).

--- a/.changeset/mcp-pin-account.md
+++ b/.changeset/mcp-pin-account.md
@@ -1,6 +1,11 @@
 ---
 ---
 
-Docs MCP Worker config only: pin `account_id` in `apps/docs-mcp/wrangler.toml` so
-the deploy token doesn't need "Account Settings: Read" (and the deploy fails with a
-clearer error if the real problem is missing Workers permissions).
+Docs MCP Worker config only, so the deploy works with a minimal Cloudflare token
+(just **Workers Scripts: Edit**):
+
+- Pin `account_id` in `apps/docs-mcp/wrangler.toml` (no "Account Settings: Read"
+  needed).
+- Move the `docs.alineo.tech/mcp` route out of `wrangler.toml` — it's added once in
+  the Cloudflare dashboard, so the token doesn't also need "Workers Routes: Edit".
+  Until then the Worker is on its `*.workers.dev` URL.

--- a/apps/docs-mcp/README.md
+++ b/apps/docs-mcp/README.md
@@ -26,19 +26,9 @@ sandboxes.
 
 ```bash
 bun install
-bun run dev        # wrangler dev on :8787
+bun run dev        # wrangler dev
 bun run typecheck
 ```
 
-## Deploy
-
-Automatic on push to `main` touching `apps/docs-mcp/**`
-(`.github/workflows/deploy-docs-mcp.yml`, via `wrangler deploy`). The deploy token
-(`CLOUDFLARE_API_TOKEN`) needs **Account · Workers Scripts · Edit**.
-
-The public endpoint `docs.alineo.tech/mcp` is a Worker **route**, added once in the
-dashboard — **Workers & Pages → alineo-docs-mcp → Settings → Domains & Routes → Add
-route** → `docs.alineo.tech/mcp*` (zone `alineo.tech`). Workers routes take
-precedence over the Pages site on the same hostname. It's kept out of
-`wrangler.toml` so the deploy token doesn't also need **Workers Routes · Edit**.
-Until the route exists, the Worker is reachable at its `*.workers.dev` URL.
+Deploys automatically on push to `main` touching `apps/docs-mcp/**`
+(`.github/workflows/deploy-docs-mcp.yml`).

--- a/apps/docs-mcp/README.md
+++ b/apps/docs-mcp/README.md
@@ -33,10 +33,12 @@ bun run typecheck
 ## Deploy
 
 Automatic on push to `main` touching `apps/docs-mcp/**`
-(`.github/workflows/deploy-docs-mcp.yml`, via `wrangler deploy`).
+(`.github/workflows/deploy-docs-mcp.yml`, via `wrangler deploy`). The deploy token
+(`CLOUDFLARE_API_TOKEN`) needs **Account · Workers Scripts · Edit**.
 
-The `routes` in `wrangler.toml` bind the Worker to `docs.alineo.tech/mcp*` (Workers
-routes take precedence over the Pages site on the same hostname). If the deploy
-token lacks **Workers Routes: Edit** on the `alineo.tech` zone, add the two routes
-once in the Cloudflare dashboard — the Worker is also published to its
-`*.workers.dev` URL as a fallback.
+The public endpoint `docs.alineo.tech/mcp` is a Worker **route**, added once in the
+dashboard — **Workers & Pages → alineo-docs-mcp → Settings → Domains & Routes → Add
+route** → `docs.alineo.tech/mcp*` (zone `alineo.tech`). Workers routes take
+precedence over the Pages site on the same hostname. It's kept out of
+`wrangler.toml` so the deploy token doesn't also need **Workers Routes · Edit**.
+Until the route exists, the Worker is reachable at its `*.workers.dev` URL.

--- a/apps/docs-mcp/wrangler.toml
+++ b/apps/docs-mcp/wrangler.toml
@@ -10,10 +10,14 @@ compatibility_date = "2025-09-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
+# The alineo Cloudflare account (also in every dashboard URL — not a secret).
+# Pinning it means the deploy token doesn't also need "Account Settings: Read".
+account_id = "68eaf5a2fb30025e59d1c4b9ab8d2bc7"
+
 # Serve at docs.alineo.tech/mcp. Workers routes take precedence over the Pages
-# site on the same hostname. If the deploy token can't create the route, add it
-# once in the Cloudflare dashboard (Workers Routes → alineo.tech) or set
-# workers_dev and use the *.workers.dev URL.
+# site on the same hostname. Needs "Workers Routes: Edit" on the alineo.tech zone;
+# without it, add the route once in the dashboard (the Worker still publishes to
+# its *.workers.dev URL).
 routes = [
   { pattern = "docs.alineo.tech/mcp", zone_name = "alineo.tech" },
   { pattern = "docs.alineo.tech/mcp/*", zone_name = "alineo.tech" },

--- a/apps/docs-mcp/wrangler.toml
+++ b/apps/docs-mcp/wrangler.toml
@@ -10,12 +10,6 @@ compatibility_date = "2025-09-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
-# The alineo Cloudflare account (also in every dashboard URL — not a secret).
-# Pinning it means the deploy token doesn't also need "Account Settings: Read".
 account_id = "68eaf5a2fb30025e59d1c4b9ab8d2bc7"
 
-# The public endpoint is docs.alineo.tech/mcp. That route is added to this Worker
-# in the Cloudflare dashboard (Workers & Pages → alineo-docs-mcp → Settings →
-# Domains & Routes → Add route: docs.alineo.tech/mcp*), not here — managing it from
-# wrangler.toml would make the deploy token also need "Workers Routes: Edit" on the
-# zone. Until the route is added, the Worker is reachable at its *.workers.dev URL.
+# The docs.alineo.tech/mcp route is attached in the Cloudflare dashboard, not here.

--- a/apps/docs-mcp/wrangler.toml
+++ b/apps/docs-mcp/wrangler.toml
@@ -14,11 +14,8 @@ workers_dev = true
 # Pinning it means the deploy token doesn't also need "Account Settings: Read".
 account_id = "68eaf5a2fb30025e59d1c4b9ab8d2bc7"
 
-# Serve at docs.alineo.tech/mcp. Workers routes take precedence over the Pages
-# site on the same hostname. Needs "Workers Routes: Edit" on the alineo.tech zone;
-# without it, add the route once in the dashboard (the Worker still publishes to
-# its *.workers.dev URL).
-routes = [
-  { pattern = "docs.alineo.tech/mcp", zone_name = "alineo.tech" },
-  { pattern = "docs.alineo.tech/mcp/*", zone_name = "alineo.tech" },
-]
+# The public endpoint is docs.alineo.tech/mcp. That route is added to this Worker
+# in the Cloudflare dashboard (Workers & Pages → alineo-docs-mcp → Settings →
+# Domains & Routes → Add route: docs.alineo.tech/mcp*), not here — managing it from
+# wrangler.toml would make the deploy token also need "Workers Routes: Edit" on the
+# zone. Until the route is added, the Worker is reachable at its *.workers.dev URL.

--- a/apps/docs-mcp/wrangler.toml
+++ b/apps/docs-mcp/wrangler.toml
@@ -10,6 +10,5 @@ compatibility_date = "2025-09-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
-account_id = "68eaf5a2fb30025e59d1c4b9ab8d2bc7"
-
+# account_id comes from the CLOUDFLARE_ACCOUNT_ID secret (wrangler-action env).
 # The docs.alineo.tech/mcp route is attached in the Cloudflare dashboard, not here.


### PR DESCRIPTION
The MCP Worker deploy (#249) is red because `CLOUDFLARE_API_TOKEN` is a Pages-scoped token with no Workers permissions.

This makes the deploy need **only** `Account · Workers Scripts · Edit`:

- **`routes` removed from `wrangler.toml`** — no "Workers Routes: Edit" on the zone needed. The `docs.alineo.tech/mcp` route is attached to the Worker once in the dashboard (Workers & Pages → alineo-docs-mcp → Settings → Domains & Routes). Worker is on `*.workers.dev` until then.
- `account_id` stays out of the file — it's already the `CLOUDFLARE_ACCOUNT_ID` secret, passed by wrangler-action.
- README/wrangler.toml deploy notes trimmed.

## After merging

1. Add `Account · Workers Scripts · Edit` to the Pages token → deploy green, Worker on `*.workers.dev`.
2. Add route `docs.alineo.tech/mcp*` in the dashboard → `docs.alineo.tech/mcp` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)