### PR TITLE
fix(sandbox): restrict POST /:id/exec to an exact-match command allowlist

### DIFF
--- a/.changeset/sandbox-exec-allowlist.md
+++ b/.changeset/sandbox-exec-allowlist.md
@@ -1,0 +1,12 @@
+---
+---
+
+`apps/sandbox` only, no publishable package changes: `POST /api/sandboxes/:id/exec` is
+public and unauthenticated, so restrict it to an exact-match allowlist of the fixed
+commands the docs playground's guided workflows actually send
+(`apps/sandbox/server/config.ts`'s new `ALLOWED_EXEC_COMMANDS`) — anything else now gets a
+403 instead of running. Every playground step already runs a hardcoded command (the
+editable snippet/fix/task fields go through `writeFile`/the agent prompt, not this route),
+so this closes the arbitrary-shell surface with no change to playground behavior. Verified
+the 15-entry allowlist matches every command in `apps/docs/src/lib/playground/workflows.ts`
+1:1, programmatically diffed against the source.

--- a/apps/sandbox/server/config.ts
+++ b/apps/sandbox/server/config.ts
@@ -19,6 +19,39 @@ export const SANDBOX_TIMEOUT_SECONDS = 60 * 60 * 4;
 /** Wall-clock cap on a single `POST /api/sandboxes/:id/exec` command. */
 export const EXEC_TIMEOUT_MS = 120_000;
 
+/**
+ * `POST /api/sandboxes/:id/exec` is public and unauthenticated — it exists only to back
+ * the docs playground's guided workflows, every one of which runs a fixed, hardcoded
+ * command (never anything built from reader input; the editable snippet/fix/task fields
+ * go through `writeFile`/the agent prompt, not this route). So rather than trust whatever
+ * `command` a caller sends, only ever run one of these exact strings.
+ *
+ * Sourced verbatim from apps/docs/src/lib/playground/workflows.ts — keep the two in sync:
+ * a new playground step needs its exact command added here too, or its exec calls 403.
+ */
+export const ALLOWED_EXEC_COMMANDS: ReadonlySet<string> = new Set([
+  // run-untrusted-code
+  "mkdir -p /work",
+  "cd /work && timeout 20 python3 snippet.py",
+  "echo hostname=$(cat /etc/hostname); echo user=$(whoami); echo '--- / ---'; ls -1 /",
+  // ci-test-runner
+  "mkdir -p /proj",
+  "cd /proj && node --test sum.test.js 2>&1 || true",
+  // checkpoint-and-resume
+  "mkdir -p /data && echo ready",
+  `node -e "const fs=require('fs');const w=fs.createWriteStream('/data/raw.jsonl');for(let i=0;i<5000;i++)w.write(JSON.stringify({id:i,v:Math.floor(Math.random()*1000)})+'\\n');w.end();" && wc -l /data/raw.jsonl`,
+  `node -e "const fs=require('fs');const rows=fs.readFileSync('/data/raw.jsonl','utf8').trim().split('\\n').map(JSON.parse);const b={};for(const r of rows){const k=Math.floor(r.v/100);b[k]=(b[k]||0)+1;}fs.writeFileSync('/data/agg.json',JSON.stringify(b,null,2));" && cat /data/agg.json`,
+  "cp /data/agg.json /data/loaded.json && echo 'loaded at' $(date -u +%FT%TZ) | tee /data/DONE",
+  // fork-a-sandbox
+  "mkdir -p /work && echo 'shared baseline built once' > /work/base.txt && sleep 1 && cat /work/base.txt",
+  "echo 'A was here' >> /work/base.txt && cat /work/base.txt",
+  "echo 'B was here' >> /work/base.txt && cat /work/base.txt",
+  "cat /work/base.txt",
+  // agent-bugfix (verify step — the seed step uses writeFile, not exec)
+  "cd /work && python3 test_fib.py 2>&1 || true",
+  `cd /work && python3 -c "from fib import fib; print('fib(15) =', fib(15))"`,
+]);
+
 export const MAX_AGENTS = 2;
 export const AGENTS_DIR = "./agents";
 /** The only spec names `POST /api/agents` will accept — never an arbitrary URL or spec body. */

--- a/apps/sandbox/server/routes/sandboxes.ts
+++ b/apps/sandbox/server/routes/sandboxes.ts
@@ -130,6 +130,9 @@ export async function execCommand(id: string, command: string): Promise<Response
   if (typeof command !== "string" || !command.trim()) {
     return Response.json({ error: "missing command" }, { status: 400 });
   }
+  if (!config.ALLOWED_EXEC_COMMANDS.has(command)) {
+    return Response.json({ error: "command not allowed" }, { status: 403 });
+  }
 
   const handle = sb.exec(command, { timeoutMs: config.EXEC_TIMEOUT_MS });
   const encoder = new TextEncoder();


### PR DESCRIPTION
## What

`POST /api/sandboxes/:id/exec` is public and unauthenticated. This restricts it to an
exact-match allowlist of the fixed commands the docs playground actually sends —
anything else now gets `403 { "error": "command not allowed" }` instead of running.

## Why

Every playground step already runs a hardcoded command string; the reader-editable
fields (snippet / fix / agent task) go through `writeFile` or the agent prompt, never
into the exec command itself. So the allowlist costs the playground nothing and closes
the arbitrary-shell-on-a-public-endpoint surface flagged after #255 shipped.

`ALLOWED_EXEC_COMMANDS` in `apps/sandbox/server/config.ts` is sourced verbatim from
`apps/docs/src/lib/playground/workflows.ts` — verified 1:1 by programmatically
extracting every `run()`/`runQuiet()` call argument from workflows.ts and diffing
against the new set (15/15 match, zero drift). A comment on the allowlist flags that a
new playground step needs its exact command added there too.

## Checklist

- [x] Changeset added (docs/sandbox-only, no publishable package changes)
- [x] `bun run typecheck` passes (apps/sandbox)
- [x] `bun run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne3qCsHqepxPhwGeggWPr8