### PR TITLE
chore(lint): add a trimmed anti-slop oxlint rule set and fix its findings

### DIFF
--- a/.changeset/anti-slop-lint-rules.md
+++ b/.changeset/anti-slop-lint-rules.md
@@ -1,0 +1,14 @@
+---
+"@alineo-labs/core": patch
+"@alineo-labs/workflow": patch
+"@alineo-labs/flue": patch
+"alineo": patch
+"alineo-cli": patch
+---
+
+Narrow a few parameter types to the `SandboxHandle` / `Alineo` members they actually use, so
+callers (and tests) can pass a structural stand-in instead of a cast: `PiAdapter`'s
+`install`/`configure`/`startBridge` take `PiSandbox`, `EgressApprovalGate.bind()` takes
+`EgressApprovalSandbox`, the Flue `alineo()` factory takes `AlineoSandbox`, `flushOps()` takes
+`SandboxLike`, and `collectReply()` takes `Pick<Alineo, "prompt">`. Every existing call site still
+type-checks; there is no runtime change.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,9 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript"],
+  "jsPlugins": [
+    { "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }
+  ],
   "env": {
     "node": true
   },
@@ -8,6 +11,15 @@
     "typeAware": true
   },
   "rules": {
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/no-unsafe-dictionary-type": "warn",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-reduce-accumulator-copy": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-module-mocking": "error",
+
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "warn",
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,9 @@
       "name": "drej",
       "devDependencies": {
         "@changesets/cli": "2.31.0",
+        "@oxlint/plugins": "^1.82.0",
         "oxfmt": "^0.57.0",
-        "oxlint": "^1.71.0",
+        "oxlint": "^1.82.0",
         "oxlint-tsgolint": "^7.0.2001",
       },
     },
@@ -1226,43 +1227,45 @@
 
     "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.71.0", "", { "os": "android", "cpu": "arm" }, "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.82.0", "", { "os": "android", "cpu": "arm" }, "sha512-a3LB+C5Dsj5b/qtmG/mv5WrzuiXEpg1KF5nXWcEvaoN5TYAqkIvxPOwTPp3Jy/FoGpRo8zsTFhMElMXfeoOEzA=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.71.0", "", { "os": "android", "cpu": "arm64" }, "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.82.0", "", { "os": "android", "cpu": "arm64" }, "sha512-OBlhRgNqFblGpGenno/aqOfJLOkQ2B8Ig3iDAalfn0H8hJGZKXPeexCRTDm6uwv6YUjSA9Xnwt1y/Bgj5ZH8uw=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.71.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.82.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dsopxqtY5ZdyT9uLHyGt1SyiLop6hi7hWI3PKpePodkRQOkLaCm+OE4fR9CAz9qdfjiFO8531tX/QDyP/psjFg=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.71.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.82.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-94Lu0SgTClKColU66g1VDuigV3HkcbkJBnTtZjGYfE8UPugaWDgKrm2icjC6HJVUYler2OXaHP/X0TBy8+CowQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.71.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.82.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hne/V06ewhh1i0w8+l7GDNROAGCGPmyFuOwiP7YTRu0JycyStJ4785dmF8xU5p0uUwt2emvIF9vc7Xjis+cJ0g=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.82.0", "", { "os": "linux", "cpu": "arm" }, "sha512-aWY2xtbZf1LneW9Qsv/n2Sp8gOu74JrlQzEtj4coHX2SHFrCfhmAumaU+sI/A5nr+yoTRTSmI/pL2s6ADlNSkw=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.82.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Fe+TtXCXMh/5f7kWlZ2VAwsMumZWtraFlKVk1NJlL52/beGwfDE7ov+/8gVirHzWokzGu7X65hSPq0ucPDskWQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.82.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-6azCZ6OJudlvipNttXCCQcyeFfcJ/NvUZdSN1z8elo73kCHtyQC7WTiUcSjWYvJ1jaq9KDUyMAoAS/vNzhBomA=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.82.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PLEaSD8IAIIlwW4dwOd9YaxuxeOpwiXL4J24rcnE4iNtyM5j9Q9/3+gti08oXpx0u2ygNjRDx9xjWWpQonuJEw=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.71.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.82.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-D94em/BwknNTn4vqxjHh5wb2oL566eFhArabqKIr0cNZMHOJuiraFp1A8tXpH05bbE5tqwEfLXTI0MWEGtn3Dw=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.82.0", "", { "os": "linux", "cpu": "none" }, "sha512-MOprxBaoYU2D4VgxXCl3ghydThWtx7Um1lL51kGYNeQ5Al7WzsH7/tqGdNtbLrIWnjq3bsm13+nz/gRIxjrOXw=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.82.0", "", { "os": "linux", "cpu": "none" }, "sha512-5h55QsfJ/luDXZzC20k6SNOY1Az+dCP9WvntKtcUWh2JhckAdwApY2ZusaBTwLENnReXU+A2fJtSrYvZJNKNPg=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.71.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.82.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-IE8NJNLlHr0CaXyGJPGVn0eTkUyoj1I2UfA8x7I4PSOYKsQ/6btVC7Pywrj5onk0cMH25r6Z38SoN3AvE5Zuog=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.82.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XUUUxaBo9XKl+J1B9EmP1cTGQPddzeURvoGkfwh/94PGnbW+hBprDljneoI2M1jzC1bzrIV3ihc7iM9UXl8+tg=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.82.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SWLSFulX9TDuH6yvbPYp4+VNn6jkkIvvI+KiujDM5rWBRHEfkesCC/pCneIIUr6ovkxZ5fRtpi2v5Cz5FrMJZg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.71.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.82.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BQy35f6ZUdNr9a6c7B7orxQTcLjByGT2z3WAgmRovpRwmPYAaJ+NTplmMzhdjdJ4qSchfMNZy/Ukg+qRg6zseQ=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.71.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.82.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V4QhSTg5gctZue8RJjsGi7NpQPThr/p1/HfmiMC5kfe1KFEup9SQRVub4A6kijQjdHfxj7bLL1KO3QO7/5bwMQ=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.71.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.82.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-TUSCLaKB2yktpFAJ/r3HAUYsaV/3DT7JS4iNKyoh3a9YNwD0UG7Ezh4D8m23654vQcU6P/RQrCAjRPKe4peP/A=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.71.0", "", { "os": "win32", "cpu": "x64" }, "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.82.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTVoRIWJTb+wvUX8EYoPArfFH02whuR10goFXE/LHRRX33ajRrFgqbcONXZMiF4C5rnattfkm87HqYn8jb8hmQ=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.82.0", "", {}, "sha512-IDF4UXBNOaCeLoEpVxf5Bg85KOWdeuBEkbo1rGzS2vXcbD+GT1asBSeeTC+5BgW6NFTHVByd6N5giHsFPGtwAA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -2880,7 +2883,7 @@
 
     "oxfmt": ["oxfmt@0.57.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.57.0", "@oxfmt/binding-android-arm64": "0.57.0", "@oxfmt/binding-darwin-arm64": "0.57.0", "@oxfmt/binding-darwin-x64": "0.57.0", "@oxfmt/binding-freebsd-x64": "0.57.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0", "@oxfmt/binding-linux-arm-musleabihf": "0.57.0", "@oxfmt/binding-linux-arm64-gnu": "0.57.0", "@oxfmt/binding-linux-arm64-musl": "0.57.0", "@oxfmt/binding-linux-ppc64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-musl": "0.57.0", "@oxfmt/binding-linux-s390x-gnu": "0.57.0", "@oxfmt/binding-linux-x64-gnu": "0.57.0", "@oxfmt/binding-linux-x64-musl": "0.57.0", "@oxfmt/binding-openharmony-arm64": "0.57.0", "@oxfmt/binding-win32-arm64-msvc": "0.57.0", "@oxfmt/binding-win32-ia32-msvc": "0.57.0", "@oxfmt/binding-win32-x64-msvc": "0.57.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA=="],
 
-    "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+    "oxlint": ["oxlint@1.82.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.82.0", "@oxlint/binding-android-arm64": "1.82.0", "@oxlint/binding-darwin-arm64": "1.82.0", "@oxlint/binding-darwin-x64": "1.82.0", "@oxlint/binding-freebsd-x64": "1.82.0", "@oxlint/binding-linux-arm-gnueabihf": "1.82.0", "@oxlint/binding-linux-arm-musleabihf": "1.82.0", "@oxlint/binding-linux-arm64-gnu": "1.82.0", "@oxlint/binding-linux-arm64-musl": "1.82.0", "@oxlint/binding-linux-ppc64-gnu": "1.82.0", "@oxlint/binding-linux-riscv64-gnu": "1.82.0", "@oxlint/binding-linux-riscv64-musl": "1.82.0", "@oxlint/binding-linux-s390x-gnu": "1.82.0", "@oxlint/binding-linux-x64-gnu": "1.82.0", "@oxlint/binding-linux-x64-musl": "1.82.0", "@oxlint/binding-openharmony-arm64": "1.82.0", "@oxlint/binding-win32-arm64-msvc": "1.82.0", "@oxlint/binding-win32-ia32-msvc": "1.82.0", "@oxlint/binding-win32-x64-msvc": "1.82.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-+iFM1BGw1ntYJt3QngbJmjbrGxPaKMUADOXOijpWGnYcBPq8YZnQftSS1C+pVcDYy9YxqDVJKQqQkTazTQMboQ=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0",
+    "@oxlint/plugins": "^1.82.0",
     "oxfmt": "^0.57.0",
-    "oxlint": "^1.71.0",
+    "oxlint": "^1.82.0",
     "oxlint-tsgolint": "^7.0.2001"
   }
 }

--- a/packages/adapters/flue/src/index.ts
+++ b/packages/adapters/flue/src/index.ts
@@ -2,6 +2,12 @@ import type { SandboxApi, SandboxFactory, FileStat } from "@flue/runtime";
 import { createSandboxSessionEnv } from "@flue/runtime";
 import type { SandboxHandle } from "@alineo-labs/sandbox";
 
+/** The `SandboxHandle` methods the Flue adapter calls. */
+export type AlineoSandbox = Pick<
+  SandboxHandle,
+  "exec" | "readFile" | "writeFile" | "listDirectory"
+>;
+
 // POSIX single-quote escaping for shell arguments.
 function esc(p: string): string {
   return `'${p.replace(/'/g, "'\\''")}'`;
@@ -31,7 +37,7 @@ function base64ToUint8(b64: string): Uint8Array {
 }
 
 class AlineoSandboxApi implements SandboxApi {
-  constructor(private readonly sb: SandboxHandle) {}
+  constructor(private readonly sb: AlineoSandbox) {}
 
   async exec(
     command: string,
@@ -138,7 +144,7 @@ class AlineoSandboxApi implements SandboxApi {
  * );
  * ```
  */
-export function alineo(sandbox: SandboxHandle, opts?: { cwd?: string }): SandboxFactory {
+export function alineo(sandbox: AlineoSandbox, opts?: { cwd?: string }): SandboxFactory {
   return {
     createSessionEnv(_: { id: string }) {
       return Promise.resolve(

--- a/packages/adapters/flue/test/adapter.test.ts
+++ b/packages/adapters/flue/test/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import type { SandboxHandle } from "@alineo-labs/sandbox";
+import type { AlineoSandbox } from "../src/index.ts";
 import type { SandboxApi } from "@flue/runtime";
 
 // ── Module mock ──────────────────────────────────────────────────────────────
@@ -8,9 +8,11 @@ import type { SandboxApi } from "@flue/runtime";
 type MockSessionEnv = { _cwd: string };
 
 let capturedApi: SandboxApi | null = null;
+let capturedCwd: string | null = null;
 void mock.module("@flue/runtime", () => ({
   createSandboxSessionEnv: (api: SandboxApi, cwd: string): MockSessionEnv => {
     capturedApi = api;
+    capturedCwd = cwd;
     return { _cwd: cwd };
   },
 }));
@@ -48,17 +50,17 @@ type SandboxStub = {
   listDirectory: (path: string, opts?: ListDirectoryOpts) => Promise<FileInfoStub[]>;
 };
 
-function makeStub(overrides: Partial<SandboxStub> = {}): SandboxHandle {
+function makeStub(overrides: Partial<SandboxStub> = {}): AlineoSandbox {
   return {
     exec:
       overrides.exec ?? ((_cmd, _opts) => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 })),
     readFile: overrides.readFile ?? ((_path) => Promise.resolve("")),
     writeFile: overrides.writeFile ?? ((_path, _content) => Promise.resolve()),
     listDirectory: overrides.listDirectory ?? ((_path, _opts) => Promise.resolve([])),
-  } as unknown as SandboxHandle;
+  } as AlineoSandbox;
 }
 
-async function getApi(sb: SandboxHandle): Promise<SandboxApi> {
+async function getApi(sb: AlineoSandbox): Promise<SandboxApi> {
   capturedApi = null;
   const factory = alineo(sb);
   await factory.createSessionEnv({ id: "test-ctx" });
@@ -441,14 +443,14 @@ describe("alineo factory", () => {
   it("passes cwd '/' by default to createSandboxSessionEnv", async () => {
     const sb = makeStub();
     const factory = alineo(sb);
-    const env = (await factory.createSessionEnv({ id: "x" })) as unknown as MockSessionEnv;
-    expect(env._cwd).toBe("/");
+    await factory.createSessionEnv({ id: "x" });
+    expect(capturedCwd).toBe("/");
   });
 
   it("forwards custom cwd option", async () => {
     const sb = makeStub();
     const factory = alineo(sb, { cwd: "/workspace" });
-    const env = (await factory.createSessionEnv({ id: "x" })) as unknown as MockSessionEnv;
-    expect(env._cwd).toBe("/workspace");
+    await factory.createSessionEnv({ id: "x" });
+    expect(capturedCwd).toBe("/workspace");
   });
 });

--- a/packages/adapters/sqlite/test/adapter.test.ts
+++ b/packages/adapters/sqlite/test/adapter.test.ts
@@ -166,7 +166,7 @@ describe("SQLiteAdapter", () => {
       expect(d?.sandboxId).toBe("abc-123");
       expect(d?.name).toBe("my-sb");
       expect(d?.runId).toBe("abc-123");
-      expect((d as unknown as { workflowName?: unknown } | null)?.workflowName).toBeUndefined();
+      expect((d as { workflowName?: unknown } | null)?.workflowName).toBeUndefined();
     });
   });
 

--- a/packages/agent/src/adapters/pi.ts
+++ b/packages/agent/src/adapters/pi.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import type { SandboxHandle, CredentialBinding, CredentialSource } from "@alineo-labs/core";
+import type {
+  SandboxHandle,
+  CredentialBinding,
+  CredentialSource,
+  ExecOptions,
+  ExecResult,
+} from "@alineo-labs/core";
 import { PromptTimeoutError } from "../errors";
 import { normalizePermissions } from "../permissions";
 import type { AgentSpec, CredentialEnvBinding } from "../schema";
@@ -16,6 +22,14 @@ import type {
   SessionStats,
   ThinkingLevel,
 } from "../types";
+
+/** The subset of `SandboxHandle` that `PiAdapter` calls. `exec` only needs to be awaitable, so
+ * callers (and tests) don't have to supply a full `ExecHandle`. */
+export interface PiSandbox {
+  exec(cmd: string, opts?: ExecOptions): PromiseLike<ExecResult>;
+  proxy: SandboxHandle["proxy"];
+  writeFile: SandboxHandle["writeFile"];
+}
 
 // Node.js CJS bridge script — written into the sandbox at /alineo-bridge.js and run with `node`.
 // Wraps `pi --mode rpc` in an HTTP server so the host can communicate bidirectionally
@@ -169,7 +183,7 @@ export class PiAdapter {
   }
 
   /** Install Pi CLI and any spec packages. Slow — result is captured by checkpoint(). */
-  async install(sb: SandboxHandle, spec: AgentSpec): Promise<void> {
+  async install(sb: PiSandbox, spec: AgentSpec): Promise<void> {
     const pkgs = [...new Set(spec.packages ?? [])].filter(
       (p) => p !== "nodejs_22" && p !== "nodejs",
     );
@@ -190,7 +204,7 @@ export class PiAdapter {
    * and snapshot resume alike) so env values, model/provider, and bridge code stay current.
    */
   async configure(
-    sb: SandboxHandle,
+    sb: PiSandbox,
     spec: AgentSpec,
     resolvedEnv: Record<string, string>,
     opts?: { resume?: boolean },
@@ -218,7 +232,7 @@ export class PiAdapter {
    * be part of the exact command that spawns the bridge process so the bridge (and
    * everything it in turn spawns, including Pi itself) inherits the already-clean env.
    */
-  async startBridge(sb: SandboxHandle, unsetVars?: string[]): Promise<void> {
+  async startBridge(sb: PiSandbox, unsetVars?: string[]): Promise<void> {
     const prefix = unsetVars && unsetVars.length > 0 ? `unset ${unsetVars.join(" ")}; ` : "";
     await sb.exec(`${prefix}node /alineo-bridge.js &`);
     const { url } = await sb.proxy(3001);

--- a/packages/agent/src/agent/egress-approval.ts
+++ b/packages/agent/src/agent/egress-approval.ts
@@ -6,6 +6,9 @@ import {
   type SandboxHandle,
 } from "@alineo-labs/core";
 
+/** The subset of `SandboxHandle` the gate calls. */
+export type EgressApprovalSandbox = Pick<SandboxHandle, "egress" | "credentials" | "emit">;
+
 /**
  * Human-in-the-loop gate for a sandboxed agent's outbound network access.
  *
@@ -74,7 +77,7 @@ export interface EgressApprovalGateOptions {
 export class EgressApprovalGate {
   private server: Server | undefined;
   private port = 0;
-  private sandbox: SandboxHandle | undefined;
+  private sandbox: EgressApprovalSandbox | undefined;
   private readonly handler: EgressRequestHandler;
   private readonly webhookHost: string;
   /** host → the held credentials bound to it. */
@@ -101,11 +104,11 @@ export class EgressApprovalGate {
   }
 
   /** Attach the sandbox whose egress this gate manages. Called once its handle exists. */
-  bind(sandbox: SandboxHandle): void {
+  bind(sandbox: EgressApprovalSandbox): void {
     this.sandbox = sandbox;
   }
 
-  private sb(): SandboxHandle {
+  private sb(): EgressApprovalSandbox {
     if (!this.sandbox) throw new Error("EgressApprovalGate.bind() has not been called");
     return this.sandbox;
   }

--- a/packages/agent/test/egress-approval.test.ts
+++ b/packages/agent/test/egress-approval.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import type { CredentialBinding, SandboxHandle } from "@alineo-labs/core";
+import type { CredentialBinding } from "@alineo-labs/core";
 import {
   EgressApprovalGate,
+  type EgressApprovalSandbox,
   type EgressDecision,
   type HeldCredential,
 } from "../src/agent/egress-approval";
 
 interface FakeSandbox {
-  handle: SandboxHandle;
+  handle: EgressApprovalSandbox;
   patches: Array<Array<{ action: string; target: string }>>;
   credsSet: string[];
   credsRemoved: string[];
@@ -19,24 +20,28 @@ function fakeSandbox(): FakeSandbox {
   const credsSet: string[] = [];
   const credsRemoved: string[] = [];
   const emits: FakeSandbox["emits"] = [];
-  const handle = {
+  const handle: EgressApprovalSandbox = {
     egress: {
       patch: async (rules: Array<{ action: string; target: string }>) => {
         patches.push(rules);
       },
+      delete: async () => {},
+      get: async () => ({}),
     },
     credentials: {
       set: async (name: string) => {
         credsSet.push(name);
       },
+      patch: async () => {},
       remove: async (name: string) => {
         credsRemoved.push(name);
       },
+      listBindings: async () => [],
     },
     emit: async (event: string, _step: number, payload: unknown) => {
       emits.push({ event, payload });
     },
-  } as unknown as SandboxHandle;
+  };
   return { handle, patches, credsSet, credsRemoved, emits };
 }
 

--- a/packages/agent/test/pi-install.test.ts
+++ b/packages/agent/test/pi-install.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from "bun:test";
-import type { SandboxHandle } from "@alineo-labs/core";
-import { PiAdapter } from "../src/adapters/pi";
+import { PiAdapter, type PiSandbox } from "../src/adapters/pi";
 import type { AgentSpec } from "../src/schema";
 
 function fakeSandbox() {
   const commands: string[] = [];
-  const sb = {
+  const sb: PiSandbox = {
     exec: (cmd: string) => {
       commands.push(cmd);
       return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
     },
     proxy: (_port: number) => Promise.resolve({ url: "http://fake-proxy", headers: {} }),
-  } as unknown as SandboxHandle;
+    writeFile: () => Promise.resolve(),
+  };
   return { sb, commands };
 }
 

--- a/packages/agent/test/pi-prompt-timeout.test.ts
+++ b/packages/agent/test/pi-prompt-timeout.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach } from "bun:test";
-import type { SandboxHandle } from "@alineo-labs/core";
-import { PiAdapter } from "../src/adapters/pi";
+import { PiAdapter, type PiSandbox } from "../src/adapters/pi";
 import { PromptTimeoutError } from "../src/errors";
+
+function stubFetch(impl: () => Promise<Response>): typeof fetch {
+  return Object.assign(impl, { preconnect: () => {} });
+}
 
 // The bridge's own `: ping\n\n` heartbeat (every 3s in production, see pi-bridge.js) keeps the
 // SSE connection's raw `reader.read()` resolving regardless of whether Pi itself is making any
@@ -9,11 +12,12 @@ import { PromptTimeoutError } from "../src/errors";
 // comment lines, or a mix of heartbeats and real events -- to verify the inactivity timeout is
 // keyed off real `AgentEvent`s, not raw stream activity.
 
-function fakeSandbox(): SandboxHandle {
+function fakeSandbox(): PiSandbox {
   return {
     exec: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
     proxy: (_port: number) => Promise.resolve({ url: "http://fake-bridge", headers: {} }),
-  } as unknown as SandboxHandle;
+    writeFile: () => Promise.resolve(),
+  };
 }
 
 async function adapterWithBridge(): Promise<PiAdapter> {
@@ -59,10 +63,11 @@ afterEach(() => {
 
 describe("PiAdapter.prompt inactivity timeout", () => {
   it("times out when only heartbeat pings arrive, never a real event", async () => {
-    globalThis.fetch = (() =>
+    globalThis.fetch = stubFetch(() =>
       Promise.resolve(
         sseResponse(Array<string>(50).fill(": ping\n\n"), { intervalMs: 10, keepOpenAfter: true }),
-      )) as unknown as typeof fetch;
+      ),
+    );
 
     const adapter = await adapterWithBridge();
     const stream = adapter.prompt("hi", { inactivityTimeoutMs: 80 });
@@ -87,8 +92,7 @@ describe("PiAdapter.prompt inactivity timeout", () => {
       'data: {"type":"text","text":"b"}\n\n',
       "data: [DONE]\n\n",
     ];
-    globalThis.fetch = (() =>
-      Promise.resolve(sseResponse(chunks, { intervalMs: 20 }))) as unknown as typeof fetch;
+    globalThis.fetch = stubFetch(() => Promise.resolve(sseResponse(chunks, { intervalMs: 20 })));
 
     const adapter = await adapterWithBridge();
     const stream = adapter.prompt("hi", { inactivityTimeoutMs: 200 });

--- a/packages/agent/test/session-control-endturn.test.ts
+++ b/packages/agent/test/session-control-endturn.test.ts
@@ -6,6 +6,7 @@ import type { AgentInternal } from "../src/agent/internal";
 /** An `AgentInternal` just complete enough for `bash()` → `instrument()`. */
 function fakeAgent(events: AgentEvent[]) {
   let endTurnCalls = 0;
+  // eslint-disable-next-line anti-slop/no-chained-type-assertions -- deliberately partial: bash() only reads these fields of AgentInternal
   const a = {
     adapter: {
       // eslint-disable-next-line require-yield

--- a/packages/cli/src/agent-prompt.ts
+++ b/packages/cli/src/agent-prompt.ts
@@ -12,7 +12,7 @@ export interface CollectedReply {
 
 /** Sends one prompt and collects the text chunks plus a record of any tool calls made. */
 export async function collectReply(
-  agent: Alineo,
+  agent: Pick<Alineo, "prompt">,
   message: string,
   opts?: { inactivityTimeoutMs?: number },
 ): Promise<CollectedReply> {

--- a/packages/cli/test/agent-prompt.test.ts
+++ b/packages/cli/test/agent-prompt.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "bun:test";
 import type { Alineo, AgentEvent } from "alineo";
 import { collectReply } from "../src/agent-prompt";
 
-function fakeAgent(events: AgentEvent[]): Alineo {
+function fakeAgent(events: AgentEvent[]): Pick<Alineo, "prompt"> {
   return {
     // eslint-disable-next-line typescript/require-await -- must be async to match Alineo.prompt's real signature; nothing here needs to await
     prompt: async function* () {
       for (const ev of events) yield ev;
     },
-  } as unknown as Alineo;
+  };
 }
 
 describe("collectReply", () => {

--- a/packages/cli/test/docker.test.ts
+++ b/packages/cli/test/docker.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { pollHealth } from "../src/docker.js";
+import { stubFetch } from "./fetch-stub.ts";
 
 describe("pollHealth", () => {
   let originalFetch: typeof globalThis.fetch;
@@ -13,17 +14,17 @@ describe("pollHealth", () => {
   });
 
   it("resolves when server returns { status: 'healthy' }", async () => {
-    globalThis.fetch = mock(async (_url: string | URL | Request) => {
+    globalThis.fetch = stubFetch(async () => {
       return new Response(JSON.stringify({ status: "healthy" }), { status: 200 });
-    }) as unknown as typeof globalThis.fetch;
+    });
 
     await expect(pollHealth("http://localhost:8080/health", 5_000)).resolves.toBeUndefined();
   });
 
   it("throws after timeout if server never becomes healthy", async () => {
-    globalThis.fetch = mock(async (_url: string | URL | Request) => {
+    globalThis.fetch = stubFetch(async () => {
       return new Response(JSON.stringify({ status: "starting" }), { status: 200 });
-    }) as unknown as typeof globalThis.fetch;
+    });
 
     await expect(pollHealth("http://localhost:8080/health", 100)).rejects.toThrow(
       /did not become healthy/,
@@ -31,9 +32,9 @@ describe("pollHealth", () => {
   });
 
   it("throws after timeout if server is unreachable", async () => {
-    globalThis.fetch = mock(async (_url: string | URL | Request) => {
+    globalThis.fetch = stubFetch(async () => {
       throw new Error("ECONNREFUSED");
-    }) as unknown as typeof globalThis.fetch;
+    });
 
     await expect(pollHealth("http://localhost:8080/health", 100)).rejects.toThrow(
       /did not become healthy/,

--- a/packages/cli/test/fetch-stub.ts
+++ b/packages/cli/test/fetch-stub.ts
@@ -1,0 +1,8 @@
+import { mock } from "bun:test";
+
+/** A `mock()` that is also assignable to `typeof fetch`, which requires Bun's `preconnect` static. */
+export function stubFetch(
+  impl: (url: string | URL | Request, init?: RequestInit) => Promise<Response>,
+) {
+  return Object.assign(mock(impl), { preconnect: () => {} });
+}

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -11,6 +11,7 @@ import {
   writeTelemetryConfig,
   type CliTelemetryEvent,
 } from "../src/telemetry.js";
+import { stubFetch } from "./fetch-stub.ts";
 
 let originalConfigPath: string | undefined;
 let originalDisabled: string | undefined;
@@ -104,9 +105,7 @@ describe("sendTelemetryEvent", () => {
   };
 
   it("never throws when fetch rejects", async () => {
-    globalThis.fetch = mock(() =>
-      Promise.reject(new Error("network down")),
-    ) as unknown as typeof fetch;
+    globalThis.fetch = stubFetch(() => Promise.reject(new Error("network down")));
     // bun-types types `.resolves`/`.rejects` as Matchers<unknown>, whose assertion methods
     // return void — the actual async runtime behavior isn't reflected in the type.
     // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression
@@ -120,14 +119,14 @@ describe("sendTelemetryEvent", () => {
     // honor that same contract to actually exercise sendTelemetryEvent's own timeout bound
     // (a mock that ignores `init.signal` entirely would hang regardless of what the
     // implementation does, proving nothing about its timeout logic).
-    globalThis.fetch = mock(
-      (_url: string, init?: RequestInit) =>
+    globalThis.fetch = stubFetch(
+      (_url, init) =>
         new Promise<Response>((_resolve, reject) => {
           init?.signal?.addEventListener("abort", () => {
             reject(new Error("aborted"));
           });
         }),
-    ) as unknown as typeof fetch;
+    );
     const start = performance.now();
     await sendTelemetryEvent(event, "http://example.invalid/v1/events");
     expect(performance.now() - start).toBeLessThan(2000);
@@ -136,11 +135,11 @@ describe("sendTelemetryEvent", () => {
   it("POSTs the event as JSON to the given endpoint", async () => {
     let capturedBody: string | undefined;
     let capturedUrl: string | undefined;
-    globalThis.fetch = mock((url: string, init?: RequestInit) => {
+    globalThis.fetch = stubFetch((url, init) => {
       capturedUrl = String(url);
       capturedBody = init?.body as string;
       return Promise.resolve(new Response(null, { status: 204 }));
-    }) as unknown as typeof fetch;
+    });
     await sendTelemetryEvent(event, "http://example.invalid/v1/events");
     expect(capturedUrl).toBe("http://example.invalid/v1/events");
     expect(JSON.parse(capturedBody ?? "{}")).toEqual(event);
@@ -150,10 +149,10 @@ describe("sendTelemetryEvent", () => {
 describe("withTelemetry", () => {
   it("calls run() directly when telemetry is disabled, without ever touching fetch", async () => {
     await writeTelemetryConfig({ enabled: false, anonymousId: "x", notifiedAt: Date.now() });
-    const fetchSpy = mock(() => {
+    const fetchSpy = stubFetch(() => {
       throw new Error("should not be called");
     });
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     let ran = false;
     // eslint-disable-next-line typescript/require-await -- run must return a Promise per withTelemetry's signature; nothing here needs to await
     await withTelemetry("spawn", [], async () => {
@@ -166,10 +165,10 @@ describe("withTelemetry", () => {
   it("re-throws the original error after recording outcome: error", async () => {
     await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: Date.now() });
     let capturedBody: string | undefined;
-    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    globalThis.fetch = stubFetch((_url, init) => {
       capturedBody = init?.body as string;
       return Promise.resolve(new Response(null, { status: 204 }));
-    }) as unknown as typeof fetch;
+    });
 
     const boom = new Error("boom");
     // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression -- see comment on the earlier .resolves. usage above
@@ -188,10 +187,10 @@ describe("withTelemetry", () => {
   it("only reports allowlisted flags for the given command, dropping everything else", async () => {
     await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: Date.now() });
     let capturedBody: string | undefined;
-    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    globalThis.fetch = stubFetch((_url, init) => {
       capturedBody = init?.body as string;
       return Promise.resolve(new Response(null, { status: 204 }));
-    }) as unknown as typeof fetch;
+    });
 
     // "agents" only allowlists --json; --not-a-real-flag must never appear in the sent event.
     await withTelemetry("agents", ["--json", "--not-a-real-flag"], async () => {});
@@ -202,9 +201,7 @@ describe("withTelemetry", () => {
 
   it("prints the first-run notice exactly once, on the first send", async () => {
     await writeTelemetryConfig({ enabled: true, anonymousId: "x", notifiedAt: null });
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response(null, { status: 204 })),
-    ) as unknown as typeof fetch;
+    globalThis.fetch = stubFetch(() => Promise.resolve(new Response(null, { status: 204 })));
 
     const originalError = console.error;
     const messages: unknown[] = [];

--- a/packages/core/src/sandbox/observability.ts
+++ b/packages/core/src/sandbox/observability.ts
@@ -17,9 +17,15 @@ export async function metrics(sb: SandboxInternal): Promise<Metrics> {
 export async function* watchMetrics(sb: SandboxInternal): AsyncGenerator<Metrics> {
   const ec = await sb.getExecClient();
   for await (const ev of ec.watchMetrics()) {
-    const m = ev as unknown as Metrics;
-    if (typeof m.cpu === "number" && typeof m.memory === "number") yield m;
+    if (isMetrics(ev)) yield ev;
   }
+}
+
+/** `ExecClient.watchMetrics()` types every SSE payload as `SSEEvent`; this checks it's actually metrics. */
+function isMetrics(ev: object): ev is Metrics {
+  return (
+    "cpu" in ev && typeof ev.cpu === "number" && "memory" in ev && typeof ev.memory === "number"
+  );
 }
 
 /** Return sandbox diagnostic logs (names, sizes, and optional inline content). */

--- a/packages/core/test/control-stub.ts
+++ b/packages/core/test/control-stub.ts
@@ -1,0 +1,9 @@
+import { ControlClient } from "@alineo-labs/opensandbox";
+
+/** A real (never-connected) `ControlClient` with the methods a test exercises replaced by mocks. */
+export function stubControl<T extends Partial<ControlClient>>(methods: T): ControlClient & T {
+  return Object.assign(
+    new ControlClient({ baseUrl: "http://control.invalid", apiKey: "" }),
+    methods,
+  );
+}

--- a/packages/core/test/resolve-exec-client.test.ts
+++ b/packages/core/test/resolve-exec-client.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { resolveExecClient } from "../src/sandbox/resolve.ts";
 import { ExecConnectionError } from "../src/errors.ts";
 import type { ControlClient } from "@alineo-labs/opensandbox";
+import { stubControl } from "./control-stub.ts";
 
 function makeControl(): ControlClient {
-  return {
+  return stubControl({
     getEndpoint: vi.fn().mockResolvedValue({ endpoint: "http://localhost:44772", headers: {} }),
-  } as unknown as ControlClient;
+  });
 }
 
 describe("resolveExecClient", () => {

--- a/packages/core/test/sandbox-close.test.ts
+++ b/packages/core/test/sandbox-close.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { SandboxHandle } from "../src/sandbox/index.ts";
 import type { SandboxDeps } from "../src/sandbox/index.ts";
 import type { IStorageAdapter } from "../src/ledger.ts";
+import { stubControl } from "./control-stub.ts";
 
 function makeAdapter(): IStorageAdapter {
   return {
@@ -21,27 +22,19 @@ function makeAdapter(): IStorageAdapter {
 }
 
 function makeControl() {
-  return { deleteSandbox: vi.fn().mockResolvedValue(undefined) };
-}
-
-function asControl(control: ReturnType<typeof makeControl>): SandboxDeps["control"] {
-  return control as unknown as SandboxDeps["control"];
+  return stubControl({ deleteSandbox: vi.fn().mockResolvedValue(undefined) });
 }
 
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
   return {
-    control: asControl(makeControl()),
+    control: makeControl(),
     adapter,
   };
 }
 
-interface SandboxTestInternals {
-  _execClient: unknown;
-}
-
 /** SandboxCore._execClient is private; this reaches it for tests that need to inject a fake. */
 function setExecClient(sb: SandboxHandle, client: unknown): void {
-  (sb as unknown as SandboxTestInternals)._execClient = client;
+  Object.assign(sb, { _execClient: client });
 }
 
 describe("SandboxHandle.close()", () => {
@@ -61,7 +54,7 @@ describe("SandboxHandle.close()", () => {
   it("does not resolve a new exec client just to dispose it when none was ever created", async () => {
     const adapter = makeAdapter();
     const control = makeControl();
-    const sb = new SandboxHandle("sb-1", "test", { control: asControl(control), adapter });
+    const sb = new SandboxHandle("sb-1", "test", { control, adapter });
 
     await expect(sb.close()).resolves.toBeUndefined();
     // No fetch/control call was ever made to resolve an exec client — deleteSandbox is

--- a/packages/core/test/sandbox-fork.test.ts
+++ b/packages/core/test/sandbox-fork.test.ts
@@ -5,6 +5,7 @@ import { SnapshotState } from "@alineo-labs/opensandbox";
 import type { SandboxDeps } from "../src/sandbox/index.ts";
 import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
 import { LedgerEvent } from "../src/ledger.ts";
+import { stubControl } from "./control-stub.ts";
 
 function makeAdapter(): IStorageAdapter {
   return {
@@ -24,20 +25,16 @@ function makeAdapter(): IStorageAdapter {
 }
 
 function makeControl(snapshotId = "snap-abc") {
-  return {
+  return stubControl({
     createSnapshot: vi.fn().mockResolvedValue({ id: snapshotId }),
     getSnapshot: vi.fn().mockResolvedValue({ state: SnapshotState.Ready }),
     deleteSandbox: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function asControl(control: ReturnType<typeof makeControl>): SandboxDeps["control"] {
-  return control as unknown as SandboxDeps["control"];
+  });
 }
 
 function makeDeps(adapter: IStorageAdapter, overrides: Partial<SandboxDeps> = {}): SandboxDeps {
   return {
-    control: asControl(makeControl()),
+    control: makeControl(),
     adapter,
     ...overrides,
   };
@@ -55,7 +52,7 @@ describe("SandboxHandle.fork()", () => {
     const control = makeControl("snap-xyz");
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: asControl(control),
+      control,
       adapter,
       fork: forkFn,
     });
@@ -84,7 +81,7 @@ describe("SandboxHandle.fork()", () => {
     const control = makeControl("snap-tagged");
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: asControl(control),
+      control,
       adapter,
       fork: forkFn,
     });
@@ -106,7 +103,7 @@ describe("SandboxHandle.fork()", () => {
     const forkFn = vi.fn().mockResolvedValue(forkedSandbox);
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: asControl(makeControl()),
+      control: makeControl(),
       adapter,
       fork: forkFn,
     });
@@ -132,7 +129,7 @@ describe("SandboxHandle.fork()", () => {
     const forkFn = vi.fn().mockResolvedValue(forkedSandbox);
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: asControl(makeControl()),
+      control: makeControl(),
       adapter,
       fork: forkFn,
     });
@@ -153,7 +150,7 @@ describe("SandboxHandle.fork()", () => {
     const forkFn = vi.fn().mockResolvedValue(forkedSandbox);
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: asControl(makeControl()),
+      control: makeControl(),
       adapter,
       fork: forkFn,
     });
@@ -172,7 +169,7 @@ describe("SandboxHandle.fork()", () => {
     const onCheckpoint = vi.fn();
 
     const sb = new SandboxHandle("sb-1", "test", {
-      control: asControl(makeControl("snap-hook")),
+      control: makeControl("snap-hook"),
       adapter,
       hooks: { onCheckpoint },
       fork: forkFn,

--- a/packages/core/test/sandbox-interactive.test.ts
+++ b/packages/core/test/sandbox-interactive.test.ts
@@ -5,6 +5,7 @@ import { LedgerEvent } from "../src/ledger.ts";
 import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
 import type { ExecResult } from "../src/exec-handle.ts";
 import type { PtyOutputListener, PtyExitListener } from "@alineo-labs/opensandbox";
+import { stubControl } from "./control-stub.ts";
 
 function makeAdapter(): IStorageAdapter {
   return {
@@ -24,9 +25,8 @@ function makeAdapter(): IStorageAdapter {
 }
 
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
-  const control = { deleteSandbox: vi.fn().mockResolvedValue(undefined) };
   return {
-    control: control as unknown as SandboxDeps["control"],
+    control: stubControl({ deleteSandbox: vi.fn().mockResolvedValue(undefined) }),
     adapter,
   };
 }

--- a/packages/core/test/sandbox-ledger-queue.test.ts
+++ b/packages/core/test/sandbox-ledger-queue.test.ts
@@ -3,6 +3,7 @@ import { SandboxHandle } from "../src/sandbox/index.ts";
 import { LedgerEvent } from "../src/ledger.ts";
 import type { SandboxDeps } from "../src/sandbox/index.ts";
 import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
+import { stubControl } from "./control-stub.ts";
 
 function makeAdapter(): IStorageAdapter {
   return {
@@ -22,7 +23,7 @@ function makeAdapter(): IStorageAdapter {
 }
 
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
-  return { control: {} as unknown as SandboxDeps["control"], adapter };
+  return { control: stubControl({}), adapter };
 }
 
 describe("SandboxHandle — ledger write ordering (emit queue)", () => {

--- a/packages/core/test/sandbox-replay.test.ts
+++ b/packages/core/test/sandbox-replay.test.ts
@@ -6,6 +6,7 @@ import type { SandboxDeps } from "../src/sandbox/index.ts";
 import type { IStorageAdapter, LedgerEntry } from "../src/ledger.ts";
 import { LedgerEvent } from "../src/ledger.ts";
 import type { ExecResult } from "../src/exec-handle.ts";
+import { stubControl } from "./control-stub.ts";
 
 function makeAdapter(): IStorageAdapter {
   return {
@@ -36,18 +37,14 @@ function makeExecClient(events: SSEEvent[] = []) {
   };
 }
 
-interface SandboxTestInternals {
-  _execClient: unknown;
-}
-
 /** SandboxCore._execClient is private; this reaches it for tests that need to inject a fake. */
 function setExecClient(sb: SandboxHandle, client: ReturnType<typeof makeExecClient>): void {
-  (sb as unknown as SandboxTestInternals)._execClient = client;
+  Object.assign(sb, { _execClient: client });
 }
 
 function makeDeps(adapter: IStorageAdapter): SandboxDeps {
   return {
-    control: {} as unknown as SandboxDeps["control"],
+    control: stubControl({}),
     adapter,
   };
 }
@@ -173,7 +170,7 @@ describe("SandboxHandle live mode", () => {
 
     for (const entry of appendedEntries(adapter)) {
       expect(entry.sandboxId).toBe("session-abc");
-      expect((entry as unknown as { runId?: unknown }).runId).toBeUndefined();
+      expect((entry as { runId?: unknown }).runId).toBeUndefined();
     }
   });
 

--- a/packages/memory/test/schema-working-memory.test.ts
+++ b/packages/memory/test/schema-working-memory.test.ts
@@ -69,9 +69,10 @@ describe("SchemaWorkingMemory", () => {
     );
     await profile.update(ref, { name: "Ada" });
 
-    await expect(profile.update(ref, { age: "not a number" as unknown as number })).rejects.toThrow(
-      "age must be a number",
-    );
+    await expect(
+      // @ts-expect-error -- deliberately the wrong type: the validator must reject it at runtime
+      profile.update(ref, { age: "not a number" }),
+    ).rejects.toThrow("age must be a number");
     expect(await profile.get(ref)).toEqual({ name: "Ada" });
   });
 

--- a/packages/model-providers/test/fetch-stub.ts
+++ b/packages/model-providers/test/fetch-stub.ts
@@ -1,0 +1,8 @@
+import { mock } from "bun:test";
+
+/** A `mock()` that is also assignable to `typeof fetch`, which requires Bun's `preconnect` static. */
+export function stubFetch(
+  impl: (url: string | URL | Request, init?: RequestInit) => Promise<Response>,
+) {
+  return Object.assign(mock(impl), { preconnect: () => {} });
+}

--- a/packages/model-providers/test/google.test.ts
+++ b/packages/model-providers/test/google.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { stubFetch } from "./fetch-stub";
 import type * as GoogleModule from "../src/google";
 
 let originalFetch: typeof fetch;
@@ -44,10 +45,10 @@ describe("googleProvider", () => {
 
   it("listModels returns [] without fetching when GEMINI_API_KEY is unset", async () => {
     delete process.env.GEMINI_API_KEY;
-    const fetchSpy = mock(() => {
+    const fetchSpy = stubFetch(() => {
       throw new Error("should not be called");
     });
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { googleProvider } = await freshModule();
     expect(await googleProvider.listModels()).toEqual([]);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -55,21 +56,19 @@ describe("googleProvider", () => {
 
   it("listModels returns [] on a non-OK response", async () => {
     process.env.GEMINI_API_KEY = "test-key";
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("nope", { status: 500 })),
-    ) as unknown as typeof fetch;
+    globalThis.fetch = stubFetch(() => Promise.resolve(new Response("nope", { status: 500 })));
     const { googleProvider } = await freshModule();
     expect(await googleProvider.listModels()).toEqual([]);
   });
 
   it("listModels returns the provider's model list on success, and caches it", async () => {
     process.env.GEMINI_API_KEY = "test-key";
-    const fetchSpy = mock(() =>
+    const fetchSpy = stubFetch(() =>
       Promise.resolve(
         new Response(JSON.stringify({ data: [{ id: "gemini-flash-latest" }] }), { status: 200 }),
       ),
     );
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { googleProvider } = await freshModule();
     expect(await googleProvider.listModels()).toEqual([{ id: "gemini-flash-latest" }]);
     await googleProvider.listModels();

--- a/packages/model-providers/test/groq.test.ts
+++ b/packages/model-providers/test/groq.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { stubFetch } from "./fetch-stub";
 import type * as GroqModule from "../src/groq";
 
 let originalFetch: typeof fetch;
@@ -44,10 +45,10 @@ describe("groqProvider", () => {
 
   it("listModels returns [] without fetching when GROQ_API_KEY is unset", async () => {
     delete process.env.GROQ_API_KEY;
-    const fetchSpy = mock(() => {
+    const fetchSpy = stubFetch(() => {
       throw new Error("should not be called");
     });
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { groqProvider } = await freshModule();
     expect(await groqProvider.listModels()).toEqual([]);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -55,23 +56,21 @@ describe("groqProvider", () => {
 
   it("listModels returns [] on a non-OK response", async () => {
     process.env.GROQ_API_KEY = "test-key";
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("nope", { status: 500 })),
-    ) as unknown as typeof fetch;
+    globalThis.fetch = stubFetch(() => Promise.resolve(new Response("nope", { status: 500 })));
     const { groqProvider } = await freshModule();
     expect(await groqProvider.listModels()).toEqual([]);
   });
 
   it("listModels returns the provider's model list on success, and caches it", async () => {
     process.env.GROQ_API_KEY = "test-key";
-    const fetchSpy = mock(() =>
+    const fetchSpy = stubFetch(() =>
       Promise.resolve(
         new Response(JSON.stringify({ data: [{ id: "llama-3.3-70b-versatile" }] }), {
           status: 200,
         }),
       ),
     );
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { groqProvider } = await freshModule();
     expect(await groqProvider.listModels()).toEqual([{ id: "llama-3.3-70b-versatile" }]);
     await groqProvider.listModels();

--- a/packages/model-providers/test/nvidia-embeddings.test.ts
+++ b/packages/model-providers/test/nvidia-embeddings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { stubFetch } from "./fetch-stub";
 import type * as NvidiaEmbeddingsModule from "../src/nvidia-embeddings";
 
 let originalFetch: typeof fetch;
@@ -36,10 +37,10 @@ describe("createNvidiaEmbeddingProvider", () => {
   });
 
   it("embed([]) returns [] without fetching", async () => {
-    const fetchSpy = mock(() => {
+    const fetchSpy = stubFetch(() => {
       throw new Error("should not be called");
     });
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { createNvidiaEmbeddingProvider } = await freshModule();
 
     expect(await createNvidiaEmbeddingProvider().embed([])).toEqual([]);
@@ -60,9 +61,9 @@ describe("createNvidiaEmbeddingProvider", () => {
 
   it("throws with status and body on a non-OK response", async () => {
     process.env.NVIDIA_API_KEY = "test-key";
-    globalThis.fetch = mock(() =>
+    globalThis.fetch = stubFetch(() =>
       Promise.resolve(new Response("bad request", { status: 400 })),
-    ) as unknown as typeof fetch;
+    );
     const { createNvidiaEmbeddingProvider } = await freshModule();
 
     // eslint-disable-next-line typescript/await-thenable, typescript/no-confusing-void-expression -- see comment on the earlier .rejects. usage above
@@ -72,8 +73,8 @@ describe("createNvidiaEmbeddingProvider", () => {
   it("returns embeddings re-sorted by the response's index field", async () => {
     process.env.NVIDIA_API_KEY = "test-key";
     let capturedBody: { input: string[]; model: string; input_type: string } | undefined;
-    globalThis.fetch = mock((_url: string, init: RequestInit) => {
-      capturedBody = JSON.parse(init.body as string) as {
+    globalThis.fetch = stubFetch((_url, init) => {
+      capturedBody = JSON.parse(init?.body as string) as {
         input: string[];
         model: string;
         input_type: string;
@@ -89,7 +90,7 @@ describe("createNvidiaEmbeddingProvider", () => {
           { status: 200 },
         ),
       );
-    }) as unknown as typeof fetch;
+    });
     const { createNvidiaEmbeddingProvider } = await freshModule();
 
     const result = await createNvidiaEmbeddingProvider({ inputType: "passage" }).embed([
@@ -111,16 +112,16 @@ describe("createNvidiaEmbeddingProvider", () => {
   it("a per-call opts.type overrides the constructor-time default", async () => {
     process.env.NVIDIA_API_KEY = "test-key";
     const capturedInputTypes: string[] = [];
-    globalThis.fetch = mock((_url: string, init: RequestInit) => {
+    globalThis.fetch = stubFetch((_url, init) => {
       capturedInputTypes.push(
-        (JSON.parse(init.body as string) as { input_type: string }).input_type,
+        (JSON.parse(init?.body as string) as { input_type: string }).input_type,
       );
       return Promise.resolve(
         new Response(JSON.stringify({ data: [{ index: 0, embedding: [1, 0] }] }), {
           status: 200,
         }),
       );
-    }) as unknown as typeof fetch;
+    });
     const { createNvidiaEmbeddingProvider } = await freshModule();
     // Constructed with the "query" default (the module's own fallback).
     const provider = createNvidiaEmbeddingProvider();

--- a/packages/model-providers/test/nvidia.test.ts
+++ b/packages/model-providers/test/nvidia.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { stubFetch } from "./fetch-stub";
 import type * as NvidiaModule from "../src/nvidia";
 
 let originalFetch: typeof fetch;
@@ -44,10 +45,10 @@ describe("nvidiaProvider", () => {
 
   it("listModels returns [] without fetching when NVIDIA_API_KEY is unset", async () => {
     delete process.env.NVIDIA_API_KEY;
-    const fetchSpy = mock(() => {
+    const fetchSpy = stubFetch(() => {
       throw new Error("should not be called");
     });
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { nvidiaProvider } = await freshModule();
     expect(await nvidiaProvider.listModels()).toEqual([]);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -55,23 +56,21 @@ describe("nvidiaProvider", () => {
 
   it("listModels returns [] on a non-OK response", async () => {
     process.env.NVIDIA_API_KEY = "test-key";
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("nope", { status: 500 })),
-    ) as unknown as typeof fetch;
+    globalThis.fetch = stubFetch(() => Promise.resolve(new Response("nope", { status: 500 })));
     const { nvidiaProvider } = await freshModule();
     expect(await nvidiaProvider.listModels()).toEqual([]);
   });
 
   it("listModels returns the provider's model list on success, and caches it", async () => {
     process.env.NVIDIA_API_KEY = "test-key";
-    const fetchSpy = mock(() =>
+    const fetchSpy = stubFetch(() =>
       Promise.resolve(
         new Response(JSON.stringify({ data: [{ id: "nvidia/nemotron-3.5-lightning-30b-a3b" }] }), {
           status: 200,
         }),
       ),
     );
-    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    globalThis.fetch = fetchSpy;
     const { nvidiaProvider } = await freshModule();
     expect(await nvidiaProvider.listModels()).toEqual([
       { id: "nvidia/nemotron-3.5-lightning-30b-a3b" },

--- a/packages/opensandbox/test/egress.test.ts
+++ b/packages/opensandbox/test/egress.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { EgressClient, EgressClientError } from "../src/egress.ts";
-import type { ControlClient } from "../src/control.ts";
+import { ControlClient } from "../src/control.ts";
 
 function fakeControl(
   endpoint = "http://10.1.2.3:18080",
   headers: Record<string, string> = { "X-EXECD-ACCESS-TOKEN": "t" },
 ): ControlClient {
-  return {
+  return Object.assign(new ControlClient({ baseUrl: "http://control.invalid", apiKey: "" }), {
     getEndpoint: vi.fn().mockResolvedValue({ endpoint, headers }),
-  } as unknown as ControlClient;
+  });
 }
 
 function jsonResponse(body: unknown, ok = true, status = 200) {
@@ -17,7 +17,7 @@ function jsonResponse(body: unknown, ok = true, status = 200) {
 
 /** The `[url, init]` pair of the first fetch call, typed. */
 function firstCall(fetchMock: ReturnType<typeof vi.fn>): [string, RequestInit] {
-  return fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+  return fetchMock.mock.calls[0] as [string, RequestInit];
 }
 
 describe("EgressClient", () => {

--- a/packages/sdks/typescript/test/client.test.ts
+++ b/packages/sdks/typescript/test/client.test.ts
@@ -52,6 +52,7 @@ interface SandboxInternals {
 }
 
 function internals(client: Sandbox): SandboxInternals {
+  // eslint-disable-next-line anti-slop/no-chained-type-assertions -- reaches private members, which no public type can describe
   return client as unknown as SandboxInternals;
 }
 

--- a/packages/workflow/src/sandbox-builder.ts
+++ b/packages/workflow/src/sandbox-builder.ts
@@ -1,5 +1,11 @@
 import type { SandboxHandle, ExecOptions, ExecCodeOptions } from "@alineo-labs/sandbox";
 
+/** The `SandboxHandle` methods a flushed op queue calls. */
+export type SandboxLike = Pick<
+  SandboxHandle,
+  "exec" | "execCode" | "writeFile" | "readFile" | "deleteFile" | "moveFile" | "checkpoint"
+>;
+
 /** An operation queued on a SandboxBuilder and executed later. */
 export type SandboxOp =
   | { kind: "exec"; cmd: string; opts: ExecOptions }
@@ -178,7 +184,7 @@ export interface FlushContext {
 
 /** Flush a SandboxBuilder's op queue against a live SandboxHandle. */
 export async function flushOps(
-  sandbox: SandboxHandle,
+  sandbox: SandboxLike,
   ops: SandboxOp[],
   ctx: FlushContext,
 ): Promise<void> {
@@ -262,7 +268,7 @@ export async function flushOps(
 }
 
 async function flushRetry(
-  sandbox: SandboxHandle,
+  sandbox: SandboxLike,
   fn: (sb: SandboxBuilder) => void,
   maxAttempts: number,
   opts: RetryOptions,
@@ -288,7 +294,7 @@ async function flushRetry(
 }
 
 async function flushForEach(
-  sandbox: SandboxHandle,
+  sandbox: SandboxLike,
   items: unknown[],
   fn: (sb: SandboxBuilder, item: unknown, index: number) => void,
   opts: ForEachOptions,

--- a/packages/workflow/test/sandbox-builder.test.ts
+++ b/packages/workflow/test/sandbox-builder.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import type { SandboxHandle } from "@alineo-labs/sandbox";
 import { SandboxBuilder, flushOps, type FlushContext } from "../src/sandbox-builder.ts";
 
 function makeCtx(overrides: Partial<FlushContext> = {}): FlushContext {
@@ -79,7 +78,7 @@ describe("flushOps — execution", () => {
 
     const sandbox = makeSandbox();
     const ctx = makeCtx();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, ctx);
+    await flushOps(sandbox, sb._ops, ctx);
 
     expect(sandbox.exec).toHaveBeenCalledWith("cmd1", {});
     expect(sandbox.exec).toHaveBeenCalledWith("cmd2", {});
@@ -90,7 +89,7 @@ describe("flushOps — execution", () => {
     sb.writeFile("/tmp/f", "hello");
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
+    await flushOps(sandbox, sb._ops, makeCtx());
 
     expect(sandbox.writeFile).toHaveBeenCalledWith("/tmp/f", "hello");
   });
@@ -101,7 +100,7 @@ describe("flushOps — execution", () => {
 
     const sandbox = makeSandbox();
     const ctx = makeCtx();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, ctx);
+    await flushOps(sandbox, sb._ops, ctx);
 
     expect(sandbox.readFile).toHaveBeenCalledWith("/tmp/f");
     expect(ctx.vars["content"]).toBe("file content");
@@ -112,7 +111,7 @@ describe("flushOps — execution", () => {
     sb.checkpoint("after-install");
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
+    await flushOps(sandbox, sb._ops, makeCtx());
 
     expect(sandbox.checkpoint).toHaveBeenCalledWith("after-install");
   });
@@ -132,7 +131,7 @@ describe("flushOps — when primitive", () => {
     );
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx({ exitCode: 0 }));
+    await flushOps(sandbox, sb._ops, makeCtx({ exitCode: 0 }));
 
     const calls = (sandbox.exec as ReturnType<typeof vi.fn>).mock.calls.map((c: string[]) => c[0]);
     expect(calls).toContain("echo pass");
@@ -152,7 +151,7 @@ describe("flushOps — when primitive", () => {
     );
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx({ exitCode: 1 }));
+    await flushOps(sandbox, sb._ops, makeCtx({ exitCode: 1 }));
 
     const calls = (sandbox.exec as ReturnType<typeof vi.fn>).mock.calls.map((c: string[]) => c[0]);
     expect(calls).toContain("echo fail");
@@ -168,7 +167,7 @@ describe("flushOps — forEach primitive", () => {
     });
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
+    await flushOps(sandbox, sb._ops, makeCtx());
 
     const calls = (sandbox.exec as ReturnType<typeof vi.fn>).mock.calls.map((c: string[]) => c[0]);
     expect(calls).toEqual(["echo a", "echo b", "echo c"]);
@@ -183,7 +182,7 @@ describe("flushOps — retry primitive", () => {
     });
 
     const sandbox = makeSandbox();
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
+    await flushOps(sandbox, sb._ops, makeCtx());
 
     expect(sandbox.exec).toHaveBeenCalledTimes(1);
   });
@@ -191,6 +190,7 @@ describe("flushOps — retry primitive", () => {
   it("retries on failure and succeeds", async () => {
     let attempts = 0;
     const sandbox = {
+      ...makeSandbox(),
       exec: vi.fn().mockImplementation(() => {
         attempts++;
         if (attempts < 3) {
@@ -227,12 +227,13 @@ describe("flushOps — retry primitive", () => {
       { delayMs: 0 },
     );
 
-    await flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx());
+    await flushOps(sandbox, sb._ops, makeCtx());
     expect(attempts).toBe(3);
   });
 
   it("throws after exhausting all attempts", async () => {
     const sandbox = {
+      ...makeSandbox(),
       exec: vi.fn().mockImplementation(() => ({
         stdout: async function* () {},
         result: async () => {
@@ -255,9 +256,7 @@ describe("flushOps — retry primitive", () => {
       { delayMs: 0 },
     );
 
-    await expect(flushOps(sandbox as unknown as SandboxHandle, sb._ops, makeCtx())).rejects.toThrow(
-      "always fails",
-    );
+    await expect(flushOps(sandbox, sb._ops, makeCtx())).rejects.toThrow("always fails");
     expect(sandbox.exec).toHaveBeenCalledTimes(3);
   });
 });

--- a/tools/oxlint/anti-slop/LICENSE
+++ b/tools/oxlint/anti-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dillon Mulroy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,27 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noReduceAccumulatorCopyRule } from "./rules/no-reduce-accumulator-copy.ts";
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-reduce-accumulator-copy": noReduceAccumulatorCopyRule,
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.test.ts
@@ -1,0 +1,32 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noChainedTypeAssertionsRule } from "./no-chained-type-assertions.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "chained" };
+
+tester.run("anti-slop/no-chained-type-assertions", noChainedTypeAssertionsRule, {
+  valid: [
+    "const value = input as User;",
+    "const value = (input as User);",
+    "const value = ({ id: 1 } as const) as const;",
+  ],
+  invalid: [
+    { name: "as chain", code: "const value = input as unknown as User;", errors: [error] },
+    {
+      name: "parenthesized chain",
+      code: "const value = (input as unknown) as User;",
+      errors: [error],
+    },
+    {
+      name: "angle-bracket chain",
+      code: "const value = <User>(<unknown>input);",
+      errors: [error],
+    },
+    {
+      name: "mixed const chain",
+      code: "const value = ({ id: 1 } as const) as User;",
+      errors: [error],
+    },
+  ],
+});

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.test.ts
@@ -1,0 +1,28 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noModuleMockingRule } from "./no-module-mocking.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "moduleMock" };
+
+tester.run("anti-slop/no-module-mocking", noModuleMockingRule, {
+  valid: [
+    "const store = new InMemoryUserStore();",
+    "vi.spyOn(store, 'save');",
+    "const vi = { mock() {} }; vi.mock();",
+    "function test(jest: { mock(): void }) { jest.mock(); }",
+    "import { vi as localVi } from './helpers'; localVi.mock('./module');",
+  ],
+  invalid: [
+    { code: "vi.mock('./user-store');", errors: [error] },
+    { code: "jest.mock('./user-store');", errors: [error] },
+    { code: "vi['doMock']('./user-store');", errors: [error] },
+    { code: "jest.unstable_mockModule('./user-store');", errors: [error] },
+    { code: "import { vi } from 'vitest'; vi.mock('./user-store');", errors: [error] },
+    { code: "import { vi as testApi } from 'vitest'; testApi.mock('./user-store');", errors: [error] },
+    {
+      code: "import { jest } from '@jest/globals'; jest.mock('./user-store');",
+      errors: [error],
+    },
+  ],
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,80 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { resolveVariable } from "../shared/scope.ts";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.test.ts
@@ -1,0 +1,52 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noReduceAccumulatorCopyRule } from "./no-reduce-accumulator-copy.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "accumulatorCopy" };
+
+tester.run("anti-slop/no-reduce-accumulator-copy", noReduceAccumulatorCopyRule, {
+  valid: [
+    "items.reduce((acc, item) => { acc.push(item); return acc; }, []);",
+    "items.reduce((acc, item) => Object.assign(acc, item), {});",
+    "items.reduce((acc, item) => Object.assign(acc, acc, item), {});",
+    "items.reduce((acc, item) => { acc[item.id] = { ...item }; return acc; }, {});",
+    "items.reduce((acc, item) => { acc.push(Object.assign({}, item)); return acc; }, []);",
+    "items.reduce((acc, item) => { acc.push(item.slice()); return acc; }, []);",
+    "items.reduce((acc, item) => acc.concat(item), '');",
+    "items.reduce((acc, item) => acc.concat(item), customCollection);",
+    "function copy(acc) { return Object.assign({}, acc); }",
+    "items.map((acc, item) => Object.assign({}, acc));",
+    "items.reduce((acc, item) => { function copy(acc) { return Object.assign({}, acc); } return acc; }, {});",
+    "items.reduce((acc, item) => { const snapshot = () => Object.assign({}, acc); return acc; }, {});",
+    "items.reduce((acc, item) => { { const acc = {}; Object.assign({}, acc); } return acc; }, {});",
+    "const Object = custom; items.reduce((acc, item) => Object.assign({}, acc), {});",
+    "function run(Object) { return items.reduce((acc, item) => Object.assign({}, acc), {}); }",
+    "const Array = custom; items.reduce((acc, item) => Array.from(acc), []);",
+    "items.reduce((acc, item) => { let alias = acc; alias = item; return Object.assign({}, alias); }, {});",
+    "items.reduce((acc, item) => [...acc, item], []);", // Owned by the native rule.
+    "items.reduce((acc, item) => ({ ...acc, [item.id]: item }), {});",
+  ],
+  invalid: [
+    { code: "items.reduce((acc, item) => Object.assign({}, acc, { [item.id]: item }), {});", errors: [error] },
+    { code: "items.reduceRight((acc, item) => Object.assign({}, acc, item), {});", errors: [error] },
+    { code: "items.reduce((acc, item, index, array) => Object.assign({}, acc, item), {});", errors: [error] },
+    { code: "items.reduce(acc => Object.assign({}, acc), {});", errors: [error] },
+    { code: "items.reduce(function (acc, item) { return Object.assign({}, item, acc); }, {});", errors: [error] },
+    { code: "items['reduce'](((acc, item) => Object['assign']({}, acc, item)), {});", errors: [error] },
+    { code: "items.reduce((acc = {}, item) => Object.assign({}, acc, item), {});", errors: [error] },
+    { code: "items.reduce((acc, item) => { const alias = acc; return Object.assign({}, alias, item); }, {});", errors: [error] },
+    { code: "items.reduce((acc, item) => Object.assign({}, acc as State, item), {});", errors: [error] },
+    { code: "items.reduce((acc, item) => { const next = Object.assign({}, acc); next[item.id] = item; return next; }, {});", errors: [error] },
+    { code: "items.reduce((acc, item) => acc.concat([item]), []);", errors: [error] },
+    { code: "items.reduceRight((acc, item, index) => acc['concat']([item]), [] as Item[]);", errors: [error] },
+    { code: "items.reduce((acc, item) => { const next = acc.slice(); next.push(item); return next; }, []);", errors: [error] },
+    { code: "items.reduce((acc, item) => { const alias = acc; return alias.concat(item); }, []);", errors: [error] },
+    { code: "const initial = []; items.reduce((acc, item) => acc.concat(item), initial);", errors: [error] },
+    { code: "items.reduce((acc, item) => { const next = Array.from(acc); next.push(item); return next; }, []);", errors: [error] },
+    { code: "items.reduce((acc, item) => acc.toSpliced(acc.length, 0, item), []);", errors: [error] },
+    { code: "items.reduce((acc, item) => acc.toSorted(), []);", errors: [error] },
+    { code: "items.reduce((acc, item) => acc.toReversed(), []);", errors: [error] },
+    { code: "items.reduce((acc, item) => acc.with(0, item), []);", errors: [error] },
+  ],
+});

--- a/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
+++ b/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
@@ -1,0 +1,109 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, SourceCode, Variable } from "@oxlint/plugins";
+
+import {
+  arrayMethodTarget,
+  isKnownArrayExpression,
+  resolveArrayBinding,
+  unwrapArrayExpression,
+} from "../shared/array-method.ts";
+
+function enclosingReducer(node: ESTree.Node) {
+  let parent = node.parent;
+  while (parent !== null) {
+    if (parent.type === "FunctionDeclaration") return null;
+    if (parent.type === "ArrowFunctionExpression" || parent.type === "FunctionExpression") {
+      const callback = parent;
+      let owner: ESTree.Node | null = callback.parent;
+      while (owner !== null && unwrapArrayExpression(owner) === callback) owner = owner.parent;
+      if (owner?.type !== "CallExpression") return null;
+      const method = arrayMethodTarget(owner.callee);
+      const firstArgument = owner.arguments[0];
+      if (
+        method === null || (method.name !== "reduce" && method.name !== "reduceRight") ||
+        owner.arguments.length > 2 || firstArgument === undefined ||
+        unwrapArrayExpression(firstArgument) !== callback
+      ) return null;
+      const firstParameter = callback.params[0];
+      const accumulator = firstParameter?.type === "AssignmentPattern" ? firstParameter.left : firstParameter;
+      if (accumulator?.type !== "Identifier") return null;
+      return { callback, accumulator, initialValue: owner.arguments[1] };
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+function referencesAccumulator(
+  sourceCode: SourceCode,
+  node: ESTree.Node,
+  accumulator: Variable,
+  visited = new Set<Variable>(),
+): boolean {
+  const variable = resolveArrayBinding(sourceCode, node);
+  if (variable === null || visited.has(variable)) return false;
+  if (variable === accumulator) return true;
+  visited.add(variable);
+  if (variable.references.some(reference => reference.isWrite() && !reference.init)) return false;
+  for (const definition of variable.defs) {
+    if (
+      definition.type === "Variable" && definition.node.type === "VariableDeclarator" &&
+      definition.node.id.type === "Identifier" && definition.node.init !== null &&
+      definition.node.parent.type === "VariableDeclaration" && definition.node.parent.kind === "const"
+    ) {
+      return referencesAccumulator(sourceCode, definition.node.init, accumulator, visited);
+    }
+  }
+  return false;
+}
+
+function isGlobalCopyOwner(sourceCode: SourceCode, node: ESTree.Node, name: string): boolean {
+  node = unwrapArrayExpression(node);
+  if (node.type !== "Identifier" || node.name !== name) return false;
+  const variable = resolveArrayBinding(sourceCode, node);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reject non-spread copies of reducer accumulators; pair with oxc/no-accumulating-spread. */
+export const noReduceAccumulatorCopyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: { description: "Disallow copying growing reducer accumulators with Object.assign, Array.from, or array copy methods." },
+    messages: {
+      accumulatorCopy: "Do not copy the reducer accumulator on every iteration; growing copies can cause quadratic work. Mutate a fresh, locally owned accumulator and return it, or use an iterator pipeline/flatMap.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        const method = arrayMethodTarget(node.callee);
+        if (method === null) return;
+        const reducer = enclosingReducer(node);
+        if (reducer === null) return;
+        const accumulator = context.sourceCode.getDeclaredVariables(reducer.callback).find(variable =>
+          variable.identifiers.some(identifier => identifier.start === reducer.accumulator.start),
+        );
+        if (accumulator === undefined) return;
+        const isAccumulator = (expression: ESTree.Node) =>
+          referencesAccumulator(context.sourceCode, expression, accumulator);
+        let copiesAccumulator = false;
+        if (method.name === "assign" && isGlobalCopyOwner(context.sourceCode, method.object, "Object")) {
+          const target = node.arguments[0];
+          copiesAccumulator = (
+            target !== undefined && unwrapArrayExpression(target).type === "ObjectExpression" &&
+            node.arguments.slice(1).some(isAccumulator)
+          );
+        } else if (method.name === "from" && isGlobalCopyOwner(context.sourceCode, method.object, "Array")) {
+          const source = node.arguments[0];
+          copiesAccumulator = source !== undefined && isAccumulator(source);
+        } else if (["concat", "slice", "toSpliced", "toSorted", "toReversed", "with"].includes(method.name)) {
+          const initialValue = reducer.initialValue;
+          const arrayAccumulator = initialValue !== undefined &&
+            isKnownArrayExpression(context.sourceCode, initialValue);
+          copiesAccumulator = arrayAccumulator && isAccumulator(method.object);
+        }
+        if (copiesAccumulator) context.report({ node, messageId: "accumulatorCopy" });
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.test.ts
@@ -1,0 +1,19 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noReflectApplyRule } from "./no-reflect-apply.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "reflectApply" };
+
+tester.run("anti-slop/no-reflect-apply", noReflectApplyRule, {
+  valid: [
+    "const value = operation.apply(owner, args);",
+    "Reflect.get(owner, key);",
+    "const Reflect = { apply() { return 1; } }; Reflect.apply();",
+    "function invoke(Reflect: { apply(): number }) { return Reflect.apply(); }",
+  ],
+  invalid: [
+    { code: "const value = Reflect.apply(operation, owner, args);", errors: [error] },
+    { code: "const value = Reflect['apply'](operation, owner, args);", errors: [error] },
+  ],
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.test.ts
@@ -1,0 +1,20 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noReflectGetRule } from "./no-reflect-get.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "reflectGet" };
+
+tester.run("anti-slop/no-reflect-get", noReflectGetRule, {
+  valid: [
+    "const value = owner.property;",
+    "const value = owner[key];",
+    "Reflect.set(owner, key, value);",
+    "const Reflect = { get() { return 1; } }; Reflect.get();",
+    "function read(Reflect: { get(): number }) { return Reflect.get(); }",
+  ],
+  invalid: [
+    { name: "static access", code: "const value = Reflect.get(owner, key);", errors: [error] },
+    { name: "computed access", code: "const value = Reflect['get'](owner, key);", errors: [error] },
+  ],
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.test.ts
@@ -1,0 +1,37 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noUnknownTypeAliasesRule } from "./no-unknown-type-aliases.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "unknownAlias" };
+
+tester.run("anti-slop/no-unknown-type-aliases", noUnknownTypeAliasesRule, {
+	valid: [
+		"type User = { readonly id: string };",
+		"type Alias = string; type UserId = Alias;",
+		"type Payload = string | number;",
+		"type Box<T> = { readonly value: T }; type Payload = Box<unknown>;",
+	],
+	invalid: [
+		{ code: "type Alias = unknown;", errors: [error] },
+		{ code: "type Current = unknown;", errors: [error] },
+		{ code: "type UnknownValue = unknown; type Alias = UnknownValue;", errors: [error, error] },
+		{ code: "type Payload = string | unknown;", errors: [error] },
+		{
+			code: "type Payload = string | unknown; type NestedPayload = number | Payload;",
+			errors: [error, error],
+		},
+		{
+			code: "type Identity<T> = T; type Payload = Identity<unknown>;",
+			errors: [error],
+		},
+		{
+			code: "type Identity<T> = T; type Wrapped<T> = Identity<T>; type Payload = Wrapped<unknown>;",
+			errors: [error],
+		},
+		{
+			code: "function outer() { type Payload = unknown; }",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,54 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSUnknownKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return resolved.type === "TSUnionType" && resolved.types.some(matches);
+			});
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeAliasDeclaration(node) {
+				if (!resolvesToUnknown(node.typeAnnotation)) return;
+				context.report({
+					node: node.id,
+					messageId: "unknownAlias",
+					data: { alias: node.id.name },
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.test.ts
@@ -1,0 +1,115 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noUnsafeDictionaryTypeRule } from "./no-unsafe-dictionary-type.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+
+const error = { messageId: "unsafeDictionary" };
+
+tester.run("anti-slop/no-unsafe-dictionary-type", noUnsafeDictionaryTypeRule, {
+	valid: [
+		"type Commands = Record<string, Command>;",
+		"type Metadata = Record<PropertyKey, JsonValue>;",
+		"type PermissionLevels = Record<Permission, number>;",
+		"type Indexed = { [key: string]: Command };",
+		"type CompatibleIndexes = { [index: number]: Command; [key: string]: Command | OtherCommand };",
+		"type Exhaustive = { [K in Permission]: number };",
+		"type Allowed = Record<string, { payload: unknown }>;",
+		"type AlsoAllowed = Record<string, Result<Data, unknown>>;",
+		"type Index<T> = Record<string, T>; type EntityIndex<T extends Entity> = Record<string, T>;",
+		"type Safe = Index<Command>; type Index<T> = Record<string, T>;",
+		"type A = Map<string, unknown>; type B = ReadonlyMap<string, unknown>; type C = WeakMap<object, unknown>;",
+		"import { Record } from './local'; type A = Record<string, unknown>;",
+		"type Record<K, V> = { key: K; value: V }; type A = Record<string, unknown>;",
+		"type Readonly<T> = { value: T }; type A = Record<string, Readonly<unknown>>;",
+		"type NonNullable<T> = { value: T }; type A = Record<string, NonNullable<unknown>>;",
+		"type Value<T> = T; type Index<T = Command, U = Value<T>> = Record<string, U>; type A = Index;",
+		"interface Owner { readonly id: string } type A = Record<string, unknown & Owner>;",
+		"interface Owner { readonly id: string } interface Child extends Owner {} type A = Record<string, Child>;",
+		"interface Owner { readonly id: string } interface Child extends Owner { readonly __brand?: never } type A = Record<string, Child>;",
+		"interface Escape {} interface Escape { readonly id: string } type A = Record<string, Escape>;",
+		"interface Escape { readonly id: string } interface Escape {} type A = Record<string, Escape>;",
+		"interface Owner { readonly id: string } type A = Record<string, object & Owner>;",
+		"type Wrap<T> = { readonly wrapped: T }; type Inner<T, U> = { readonly value: T } & Wrap<U>; type Outer<T, U> = Record<string, Inner<T, U>>; declare function f<T, U>(): Outer<T, U>;",
+		"type WithSchema<T extends Record<string, unknown>> = (schema: T) => void;",
+		"function run<T extends Record<string, unknown>>(input: T): T { return input; }",
+		"declare class Store<T extends Record<string, unknown>> { read(): T }",
+		"type Deep<T extends Readonly<Record<string, unknown>>> = T;",
+	],
+	invalid: [
+		{ code: "type A = Record<string, unknown>;", errors: [error] },
+		{ code: "type A = { [key: string]: any };", errors: [error] },
+		{ code: "type A = { [index: number]: Command; [key: string]: unknown | Command };", errors: 1 },
+		{ code: "type A = { [K in PropertyKey]: object };", errors: [error] },
+		{ code: "type A = { [K in PropertyKey]: NonNullable<unknown> };", errors: [error] },
+		{ code: "type A = { [key: string]: NonNullable<unknown> };", errors: [error] },
+		{ code: "type A = Record<string, {}>;", errors: [error] },
+		{ code: "interface Escape {} type A = Record<string, Escape>;", errors: [error] },
+		{
+			code: "interface Escape { readonly __brand?: never } type A = Record<string, Escape>;",
+			errors: [error],
+		},
+		{
+			code: "type Escape = { readonly __brand?: never }; type A = Record<string, Escape>;",
+			errors: [error],
+		},
+		{ code: "type A = Record<string, { readonly __brand?: never }>;", errors: [error] },
+		{ code: "type A = Record<string, string | unknown>;", errors: [error] },
+		{ code: "interface Escape {} type A = Record<string, string | Escape>;", errors: [error] },
+		{ code: "type A = Record<string, unknown & {}>;", errors: [error] },
+		{
+			code: "interface Owner { readonly id: string } type A = Record<string, any & Owner>;",
+			errors: [error],
+		},
+		{ code: "type Escape = unknown; type A = Record<string, Escape>;", errors: [error] },
+		{ code: "type Dict = Record<string, unknown>;", errors: [error] },
+		{ code: "type A = Readonly<Partial<Required<(Record<string, unknown>)>>>;", errors: [error] },
+		{ code: "type A = { readonly [key: string]: unknown };", errors: [error] },
+		{ code: "type A = { readonly [K in string]: unknown };", errors: [error] },
+		{ code: "type Source = Record<string, unknown>; type A = Pick<Source, string>;", errors: 2 },
+		{ code: "type Source = Record<string, unknown>; type A = Omit<Source, never>;", errors: 2 },
+		{ code: "type Index<T> = Record<string, T>; type A = Index<unknown>;", errors: 1 },
+		{ code: "interface A { [key: string]: unknown }", errors: [error] },
+		{ code: "type A = Readonly<Record<string, unknown>>;", errors: 1 },
+		{ code: "type A = Record<string, Readonly<unknown>>;", errors: [error] },
+		{ code: "type A = Record<string, Partial<unknown>>;", errors: [error] },
+		{ code: "type A = Record<string, Required<unknown>>;", errors: [error] },
+		{ code: "type Escape = Readonly<unknown>; type A = Record<string, Escape>;", errors: 1 },
+		{
+			code: "type Wrapped<T> = Readonly<T>; type A = Record<string, Wrapped<unknown>>;",
+			errors: 1,
+		},
+		{ code: "type A = Record<string, NonNullable<unknown>>;", errors: [error] },
+		{ code: "type Escape = NonNullable<unknown>; type A = Record<string, Escape>;", errors: 1 },
+		{
+			code: "type Unsafe = Record<string, unknown>; const x: Unsafe = {}; const y: Unsafe = {};",
+			errors: 1,
+		},
+		{
+			code: "type Unsafe = Record<string, unknown>; type AlsoUnsafe = Unsafe; const x: Unsafe = {};",
+			errors: 2,
+		},
+		{ code: "type Index<T = unknown> = Record<string, T>; type A = Index;", errors: 1 },
+		{
+			code: "type Index<T, U = T> = Record<string, U>; type A = Index<string, unknown>;",
+			errors: 1,
+		},
+		{ code: "type Index<T, U = T> = Record<string, U>; type A = Index<unknown>;", errors: 1 },
+		{
+			code: "type Value<T> = T; type Index<T, U = Value<T>> = Record<string, U>; type A = Index<unknown>;",
+			errors: 1,
+		},
+		{
+			code: "type Marker<T> = { readonly __brand?: never }; type Index<T, U = Marker<T>> = Record<string, U>; type A = Index<Item>;",
+			errors: 1,
+		},
+		{
+			code: "function outer() { type Identity<T> = T; type A = Record<string, Identity<unknown>>; }",
+			errors: 1,
+		},
+		{
+			code: "function local() { type Record<K, V> = { key: K; value: V }; type A = Record<string, unknown>; } function global() { type A = Record<string, unknown>; }",
+			errors: 1,
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,154 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+import { visibleTypeAlias } from "../shared/type-alias-resolution.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return (
+		name !== null &&
+		visibleTypeAlias(name, node, environment.typeAliases) !== null &&
+		!isInsideTypeAliasDeclaration(node)
+	);
+}
+
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
@@ -1,0 +1,19 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noWidenThenAssertRule } from "./no-widen-then-assert.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "widenThenAssert" };
+
+tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
+	valid: [
+		"const source = { id: 'first' }; const widened: unknown = source;",
+		"declare const input: unknown; const parsed = input as { readonly id: string };",
+	],
+	invalid: [
+		{
+			code: "const source = { id: 'second' }; const widened: unknown = source; const parsed = widened as { readonly id: string };",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/array-method.ts
+++ b/tools/oxlint/anti-slop/shared/array-method.ts
@@ -1,0 +1,94 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+/** Unwrap syntax-only wrappers when inspecting array methods and accumulator references. */
+export function unwrapArrayExpression(node: ESTree.Node): ESTree.Node {
+  while (
+    node.type === "ParenthesizedExpression" ||
+    node.type === "ChainExpression" ||
+    node.type === "TSAsExpression" ||
+    node.type === "TSTypeAssertion" ||
+    node.type === "TSNonNullExpression" ||
+    node.type === "TSSatisfiesExpression"
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/** Resolve a local binding by scope, not by identifier spelling. */
+export function resolveArrayBinding(sourceCode: SourceCode, node: ESTree.Node): Variable | null {
+  node = unwrapArrayExpression(node);
+  if (node.type !== "Identifier") return null;
+  let scope: Scope | null = sourceCode.getScope(node);
+  while (scope !== null) {
+    const variable = scope.set.get(node.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+/** Read static method names, including computed string literals, without evaluating expressions. */
+export function arrayMethodTarget(
+  node: ESTree.Node,
+): { readonly name: string; readonly object: ESTree.Node } | null {
+  node = unwrapArrayExpression(node);
+  if (node.type !== "MemberExpression") return null;
+  const property = node.property;
+  if (!node.computed && property.type === "Identifier") {
+    return { name: property.name, object: node.object };
+  }
+  if (node.computed && property.type === "Literal" && typeof property.value === "string") {
+    return { name: property.value, object: node.object };
+  }
+  return null;
+}
+
+function isArrayAnnotation(type: ESTree.TSType): boolean {
+  if (type.type === "TSArrayType" || type.type === "TSTupleType") return true;
+  if (type.type === "TSParenthesizedType") return isArrayAnnotation(type.typeAnnotation);
+  if (type.type === "TSTypeOperator" && type.operator === "readonly") {
+    return isArrayAnnotation(type.typeAnnotation);
+  }
+  return (
+    type.type === "TSTypeReference" && type.typeName.type === "Identifier" &&
+    (type.typeName.name === "Array" || type.typeName.name === "ReadonlyArray")
+  );
+}
+
+/** Recognize local array evidence; unknown receivers and iterator pipelines are deliberately excluded. */
+export function isKnownArrayExpression(
+  sourceCode: SourceCode,
+  node: ESTree.Node,
+  visited = new Set<Variable>(),
+): boolean {
+  node = unwrapArrayExpression(node);
+  if (node.type === "ArrayExpression") return true;
+  if (node.type === "CallExpression") {
+    const method = arrayMethodTarget(node.callee);
+    return (
+      method !== null &&
+      ["map", "filter", "flatMap", "slice", "concat", "toSorted", "toReversed", "toSpliced"].includes(method.name) &&
+      isKnownArrayExpression(sourceCode, method.object, visited)
+    );
+  }
+  if (node.type !== "Identifier") return false;
+  const variable = resolveArrayBinding(sourceCode, node);
+  if (variable === null || visited.has(variable)) return false;
+  visited.add(variable);
+  if (variable.references.some(reference => reference.isWrite() && !reference.init)) return false;
+  for (const identifier of variable.identifiers) {
+    const annotation = identifier.typeAnnotation?.typeAnnotation;
+    if (annotation !== undefined) return isArrayAnnotation(annotation);
+  }
+  for (const definition of variable.defs) {
+    if (
+      definition.type === "Variable" && definition.node.type === "VariableDeclarator" &&
+      definition.node.id.type === "Identifier" && definition.node.init !== null &&
+      definition.node.parent.type === "VariableDeclaration" && definition.node.parent.kind === "const"
+    ) {
+      return isKnownArrayExpression(sourceCode, definition.node.init, visited);
+    }
+  }
+  return false;
+}

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,515 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	hasVisibleTypeBinding,
+	visibleTypeAlias,
+	type TypeAliasEnvironment as LexicalTypeAliasEnvironment,
+} from "./type-alias-resolution.ts";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly typeAliases: LexicalTypeAliasEnvironment;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(
+	program: ESTree.Program,
+	visitorKeys: Readonly<Record<string, readonly string[]>>,
+): TypeEnvironment {
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type !== "TSInterfaceDeclaration") continue;
+		const declarations = interfaces.get(declaration.id.name) ?? [];
+		declarations.push(declaration);
+		interfaces.set(declaration.id.name, declarations);
+	}
+
+	return {
+		interfaces,
+		typeAliases: createTypeAliasEnvironment(program, visitorKeys),
+	};
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeEnvironment,
+): boolean {
+	return (
+		BUILT_INS.has(name) &&
+		!hasVisibleTypeBinding(name, use, environment.typeAliases)
+	);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? unsafeMembers[0]
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if (
+		(name === "Pick" || name === "Omit") &&
+		isBuiltIn(name, unwrapped, environment)
+	) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
+	}
+	if (name === "PropertyKey" && isBuiltIn(name, unwrapped, environment)) return true;
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (
+		alias === null ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,61 @@
+import type { ESTree } from "@oxlint/plugins";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function collectInferTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	names: Set<string>,
+): void {
+	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
+	const record = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = record[key];
+		if (isNode(value)) {
+			collectInferTypeParameterNames(value, visitorKeys, names);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+		}
+	}
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	let descendant: ESTree.Node = node;
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(descendant === current.nameType || descendant === current.typeAnnotation)
+		) {
+			names.add(current.key.name);
+		}
+		if (current.type === "TSConditionalType" && descendant === current.trueType) {
+			collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,24 @@
+import { resolveVariable } from "./scope.ts";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/tools/oxlint/anti-slop/shared/scope.ts
+++ b/tools/oxlint/anti-slop/shared/scope.ts
@@ -1,0 +1,15 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+/** Resolve an identifier to its binding by walking lexical scopes upward. */
+export function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}

--- a/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
+++ b/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
@@ -1,0 +1,250 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "./lexical-type-parameters.ts";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+type TypeScope = ESTree.Node;
+
+type TypeBinding = {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+	readonly scope: TypeScope;
+};
+
+type Substitution = {
+	readonly substitutions: Substitutions;
+	readonly type: ESTree.TSType;
+};
+
+type Substitutions = ReadonlyMap<string, Substitution>;
+
+export type TypeAliasEnvironment = {
+	readonly aliases: readonly ESTree.TSTypeAliasDeclaration[];
+	readonly bindingsByName: ReadonlyMap<string, readonly TypeBinding[]>;
+	readonly visitorKeys: VisitorKeys;
+};
+
+export type ResolvedTypeMatcher = (
+	type: ESTree.TSType,
+	matches: (child: ESTree.TSType) => boolean,
+) => boolean;
+
+const environmentsByProgram = new WeakMap<ESTree.Program, TypeAliasEnvironment>();
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function enclosingTypeScope(node: ESTree.Node): TypeScope {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null) {
+		if (
+			current.type === "Program" ||
+			current.type === "BlockStatement" ||
+			current.type === "TSModuleBlock" ||
+			current.type === "StaticBlock" ||
+			current.type === "SwitchStatement"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return node;
+}
+
+function declaredTypeBinding(node: ESTree.Node): {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+} | null {
+	if (node.type === "TSTypeAliasDeclaration") {
+		return { alias: node, name: node.id.name };
+	}
+	if (
+		node.type === "TSInterfaceDeclaration" ||
+		node.type === "TSEnumDeclaration" ||
+		node.type === "ClassDeclaration" ||
+		node.type === "ClassExpression"
+	) {
+		return node.id === null ? null : { alias: null, name: node.id.name };
+	}
+	if (
+		node.type === "ImportSpecifier" ||
+		node.type === "ImportDefaultSpecifier" ||
+		node.type === "ImportNamespaceSpecifier"
+	) {
+		return { alias: null, name: node.local.name };
+	}
+	return null;
+}
+
+function collectTypeBindings(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	bindingsByName: Map<string, TypeBinding[]>,
+	aliases: ESTree.TSTypeAliasDeclaration[],
+): void {
+	const declared = declaredTypeBinding(node);
+	if (declared !== null) {
+		const bindings = bindingsByName.get(declared.name) ?? [];
+		bindings.push({ ...declared, scope: enclosingTypeScope(node) });
+		bindingsByName.set(declared.name, bindings);
+		if (declared.alias !== null) aliases.push(declared.alias);
+	}
+
+	// SAFETY: Oxlint's visitor keys identify only ESTree child-node properties.
+	const fields = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = fields[key];
+		if (isNode(value)) {
+			collectTypeBindings(value, visitorKeys, bindingsByName, aliases);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) {
+				collectTypeBindings(child, visitorKeys, bindingsByName, aliases);
+			}
+		}
+	}
+}
+
+/** Collect every lexical type alias and competing type binding in a program. */
+export function createTypeAliasEnvironment(
+	program: ESTree.Program,
+	visitorKeys: VisitorKeys,
+): TypeAliasEnvironment {
+	const cached = environmentsByProgram.get(program);
+	if (cached !== undefined) return cached;
+	const bindingsByName = new Map<string, TypeBinding[]>();
+	const aliases: ESTree.TSTypeAliasDeclaration[] = [];
+	collectTypeBindings(program, visitorKeys, bindingsByName, aliases);
+	const environment = { aliases, bindingsByName, visitorKeys };
+	environmentsByProgram.set(program, environment);
+	return environment;
+}
+
+function ancestorDistance(ancestor: ESTree.Node, node: ESTree.Node): number | null {
+	let current: ESTree.Node | null = node;
+	let distance = 0;
+	while (current !== null) {
+		if (current === ancestor) return distance;
+		current = current.parent;
+		distance += 1;
+	}
+	return null;
+}
+
+function nearestTypeBindings(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): readonly TypeBinding[] {
+	const candidates = environment.bindingsByName.get(name) ?? [];
+	let nearestDistance = Number.POSITIVE_INFINITY;
+	let nearest: TypeBinding[] = [];
+	for (const candidate of candidates) {
+		const distance = ancestorDistance(candidate.scope, use);
+		if (distance === null || distance > nearestDistance) continue;
+		if (distance === nearestDistance) {
+			nearest.push(candidate);
+			continue;
+		}
+		nearestDistance = distance;
+		nearest = [candidate];
+	}
+	return nearest;
+}
+
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export function visibleTypeAlias(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): ESTree.TSTypeAliasDeclaration | null {
+	if (lexicalTypeParameterNames(use, environment.visitorKeys).has(name)) return null;
+	const bindings = nearestTypeBindings(name, use, environment);
+	return bindings.length === 1 ? (bindings[0]?.alias ?? null) : null;
+}
+
+/** Return whether a local declaration shadows a built-in type at this use. */
+export function hasVisibleTypeBinding(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): boolean {
+	return (
+		lexicalTypeParameterNames(use, environment.visitorKeys).has(name) ||
+		nearestTypeBindings(name, use, environment).length > 0
+	);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function aliasSubstitutions(
+	alias: ESTree.TSTypeAliasDeclaration,
+	reference: ESTree.TSTypeReference,
+	base: Substitutions,
+): Substitutions | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = reference.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const explicitArgument = arguments_[index];
+		const argument = explicitArgument ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		const argumentSubstitutions = explicitArgument === undefined ? next : base;
+		next.set(parameter.name.name, {
+			type: argument,
+			substitutions: new Map(argumentSubstitutions),
+		});
+	}
+	return next;
+}
+
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export function resolvedTypeMatches(
+	type: ESTree.TSType,
+	environment: TypeAliasEnvironment,
+	matcher: ResolvedTypeMatcher,
+): boolean {
+	const evaluate = (
+		current: ESTree.TSType,
+		substitutions: Substitutions,
+		resolvingAliases: ReadonlySet<ESTree.TSTypeAliasDeclaration>,
+	): boolean => {
+		if (current.type === "TSTypeReference") {
+			const name = typeReferenceName(current);
+			if (name !== null) {
+				const substitution = substitutions.get(name);
+				if (substitution !== undefined && !current.typeArguments?.params.length) {
+					return evaluate(
+						substitution.type,
+						substitution.substitutions,
+						resolvingAliases,
+					);
+				}
+				const alias = visibleTypeAlias(name, current, environment);
+				if (alias !== null && !resolvingAliases.has(alias)) {
+					const nextSubstitutions = aliasSubstitutions(alias, current, substitutions);
+					if (nextSubstitutions !== null) {
+						const nextResolving = new Set(resolvingAliases);
+						nextResolving.add(alias);
+						return evaluate(alias.typeAnnotation, nextSubstitutions, nextResolving);
+					}
+				}
+			}
+		}
+		return matcher(current, (child) =>
+			evaluate(child, substitutions, resolvingAliases),
+		);
+	};
+
+	return evaluate(type, new Map(), new Set());
+}


### PR DESCRIPTION
## Summary

Adds 8 of [dmmulroy/anti-slop](https://github.com/dmmulroy/anti-slop)'s generic oxlint rules as a vendored jsPlugin (`tools/oxlint/anti-slop`, MIT) and fixes everything they flag. This replaces the full 18-rule trial on `experiment/anti-slop-trial`, which produced ~2,100 findings, 14 per-file overrides, 162 boilerplate SAFETY comments, and several runtime regressions.

**Enabled**
- `no-chained-type-assertions` (error) — 58 findings on main, all fixed here
- `no-unsafe-dictionary-type` (**warning**) — 34 findings, left as warnings for follow-up
- `no-widen-then-assert`, `no-reflect-apply`, `no-reflect-get`, `no-reduce-accumulator-copy`, `no-unknown-type-aliases`, `no-module-mocking` (error) — 0 findings today; guardrails only

**Dropped** (from the trial): `require-readable-spacing` (formatter's job; 1,687 blank-line findings), `require-safety-comment-for-type-assertion` (283 findings, mostly tests, produced boilerplate), `no-unknown-parameters` / `no-unknown-returns` / `no-runtime-typeof` (conflict with legitimate boundary parsing; needed 18–20 file overrides each), `no-known-value-widening` (strips explicit return types off exported functions), `no-conditional-empty-object-spread`, `no-array-filter-map`, `no-object-parameters`, `no-shape-in-symbol-names`.

Also bumps `oxlint` 1.71 → 1.82 and adds `@oxlint/plugins` (jsPlugins support is still alpha upstream).

## How the 58 errors were fixed (no runtime behavior changes)

- **Fetch mocks** — `stubFetch()` test helper (model-providers, cli, agent): a `mock()` that is also assignable to `typeof fetch`.
- **ControlClient mocks** — `stubControl()` in core tests / inline in opensandbox: a real, never-connected `ControlClient` with only the exercised methods mocked.
- **Narrower parameter types** (type-only, every existing call site still compiles): `PiSandbox` (`PiAdapter.install/configure/startBridge`), `EgressApprovalSandbox` (`EgressApprovalGate`), `AlineoSandbox` (flue `alineo()`), `SandboxLike` (workflow `flushOps`), `Pick<Alineo, "prompt">` (`collectReply`).
- **Private field injection** — `Object.assign(sb, { _execClient })` instead of a cast.
- **`watchMetrics()`** — replaced the cast with a runtime type guard; yields the same raw event as before.
- Two documented `eslint-disable-next-line` comments where tests reach private members / a deliberately partial `AgentInternal`.

## Pre-existing bug found (not fixed here)

OpenSandbox's execd spec says `/metrics/watch` streams `{ cpu_count, cpu_used_pct, mem_total_mib, mem_used_mib, timestamp: number }`, but alineo's `Metrics` type is `{ cpu, memory, timestamp: string }`. `watchMetrics()` filters on `cpu`/`memory`, so it very likely yields nothing, and `metrics()` returns data that doesn't match its type. Worth a separate fix.

## Test plan

- [x] `bun run lint` — 0 errors (34 `no-unsafe-dictionary-type` warnings + existing typescript warnings)
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bun run test` — all packages pass
- [x] Changeset added (patch: core, workflow, flue, alineo, alineo-cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2k5SgszHvY4ZKAcPa75r2
